### PR TITLE
Refactor Buffer API to be object-oriented

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -9,41 +9,43 @@ import (
 // Buffer represents actual data (a tensor) stored in the accelerator that is actually going to execute the graph.
 // It's used as input/output of computation execution. A Buffer is always associated to a DeviceNum, even if there is
 // only one.
-//
-// It is opaque from the compute user perspective, but it cannot be mixed -- a Buffer returned by one backend can't
-// be used with another backend.
-type Buffer any
+type Buffer interface {
+	// Backend returns the compute Backend that owns and manages this buffer.
+	Backend() Backend
+
+	// Finalize allows the client to inform the backend that the buffer is no longer needed and associated
+	// resources can be freed immediately, as opposed to waiting for a garbage collection.
+	//
+	// A finalized buffer should never be used again.
+	Finalize() error
+
+	// Shape returns the shape for the buffer.
+	Shape() (shapes.Shape, error)
+
+	// DeviceNum returns the deviceNum for the buffer.
+	DeviceNum() (DeviceNum, error)
+
+	// ToFlatData transfers the flat values of a buffer to a Go flat slice.
+	// The slice flat must have the exact number of elements required to store the Buffer shape,
+	// and be a slice of the corresponding DType -- see DType.GoType().
+	ToFlatData(flat any) error
+
+	// Data returns a slice pointing to the buffer storage memory directly.
+	// This only works if the backend's HasSharedBuffer is true.
+	Data() (flat any, err error)
+
+	// CopyToDevice copies the buffer to the deviceNum.
+	//
+	// Accelerators often have a much faster bus on which to transfer data, so this is expected to be potentially
+	// much faster than copying to the host and to the new device.
+	CopyToDevice(deviceNum DeviceNum) (bufferOnDevice Buffer, err error)
+}
 
 // DataInterface is the Backend's subinterface that defines the API to transfer Buffer to/from accelerators for the
 // backend.
 type DataInterface interface {
-	// BufferFinalize allows the client to inform the backend that the buffer is no longer needed and associated
-	// resources can be freed immediately, as opposed to waiting for a garbage collection.
-	//
-	// A finalized buffer should never be used again. Preferably, the caller should set its references to it to nil.
-	//
-	// It's good practice not to rely on the GC for backends' buffers, because the backend memory may not be managed by
-	// Go (or not even run on CPU) and the GC won't know about the memory it uses, and won't be pressured to release
-	// those buffers (since on the Go side, they may just be tiny references).
-	BufferFinalize(buffer Buffer) error
-
-	// BufferShape returns the shape for the buffer.
-	BufferShape(buffer Buffer) (shapes.Shape, error)
-
-	// BufferDeviceNum returns the deviceNum for the buffer.
-	BufferDeviceNum(buffer Buffer) (DeviceNum, error)
-
-	// BufferToFlatData transfers the flat values of a buffer to a Go flat slice.
-	// The slice flat must have the exact number of elements required to store the Buffer shape,
-	// and be a slice of the corresponding DType -- see DType.GoType().
-	//
-	// See also FlatDataToBuffer, BufferShape, and shapes.Shape.Size.
-	BufferToFlatData(buffer Buffer, flat any) error
-
 	// BufferFromFlatData transfers data from Go given as a flat slice (of the type corresponding to the shape DType)
 	// to the deviceNum, and returns the corresponding Buffer.
-	//
-	// If the shape is zero-sized, 'flat' is ignored and can be nil.
 	BufferFromFlatData(deviceNum DeviceNum, flat any, shape shapes.Shape) (Buffer, error)
 
 	// HasSharedBuffers returns whether the backend supports "shared buffers": these are buffers
@@ -54,33 +56,6 @@ type DataInterface interface {
 	// NewSharedBuffer returns a "shared buffer" that can be both used as input for execution of
 	// computations and directly read or mutated by the clients.
 	//
-	// It panics if the backend doesn't support shared buffers -- see HasSharedBuffer.
-	//
-	// The shared buffer should not be mutated while it is used by an execution.
-	// Also, the shared buffer cannot be "donated" during execution.
-	//
-	// When done, to release the memory, call BufferFinalized on the returned buffer.
-	//
-	// It returns a handle to the buffer and a slice of the corresponding data type pointing
-	// to the shared data.
-	//
-	// The buffer cannot be assumed to be zero-initialized.
+	// It panics if the backend doesn't support shared buffers -- see HasSharedBuffers.
 	NewSharedBuffer(deviceNum DeviceNum, shape shapes.Shape) (buffer Buffer, flat any, err error)
-
-	// BufferData returns a slice pointing to the buffer storage memory directly.
-	//
-	// This only works if HasSharedBuffer is true, that is, if the backend engine runs on CPU, or
-	// shares CPU memory.
-	//
-	// The returned slice becomes invalid after the buffer is destroyed.
-	BufferData(buffer Buffer) (flat any, err error)
-
-	// BufferCopyToDevice copies the buffer to the deviceNum.
-	//
-	// Accelerators often have a much faster bus on which to transfer data, so this is expected to be potentially
-	// much faster than copying to the host and to the new device.
-	//
-	// It cannot be used to copy within the same device: it returns an error if the deviceNum is the same as the
-	// source deviceNum.
-	BufferCopyToDevice(source Buffer, deviceNum DeviceNum) (bufferOnDevice Buffer, err error)
 }

--- a/internal/gobackend/buffers.go
+++ b/internal/gobackend/buffers.go
@@ -26,6 +26,8 @@ var _ compute.DataInterface = (*Backend)(nil)
 // The flat data may be shared -- for temporary buffers from compiled graphs they are
 // taken from larger blobs of bytes allocated in one Go -- or owned by the buffer.
 type Buffer struct {
+	backend *Backend
+
 	shape shapes.Shape
 
 	// inUse is set to false when the buffer is finalized and moved back to the pool.
@@ -104,6 +106,7 @@ func (b *Backend) getBuffer(dtype dtypes.DType, length int) (*Buffer, error) {
 	}
 	pool := b.getBufferPool(dtype, length)
 	buf := pool.Get().(*Buffer) //nolint:errcheck
+	buf.backend = b
 	buf.inUse = true
 	// buf.randomize() // Useful to help finding where zero-initialized is needed but missing.
 	return buf, nil
@@ -286,14 +289,15 @@ func (b *Backend) NewBuffer(shape shapes.Shape) *Buffer {
 // can be freed immediately.
 //
 // A isFinalized buffer should never be used again. Preferably, the caller should set its references to it to nil.
-func (b *Backend) BufferFinalize(backendBuffer compute.Buffer) error {
-	buffer := backendBuffer.(*Buffer) //nolint:errcheck
-	if b.isFinalized {
-		buffer.flat = nil // Accelerates GC.
-		return errors.Errorf("BufferFinalize(%p): backend is already finalized", backendBuffer)
-	}
+// Finalize allows the client to inform the backend that the buffer is no longer needed and associated resources
+// can be freed immediately.
+func (buffer *Buffer) Finalize() error {
 	if buffer == nil {
-		return errors.Errorf("BufferFinalize(%p): buffer was nil", backendBuffer)
+		return errors.Errorf("Finalize(%p): buffer was nil", buffer)
+	}
+	if buffer.backend.isFinalized {
+		buffer.flat = nil // Accelerates GC.
+		return errors.Errorf("Finalize(%p): backend is already finalized", buffer)
 	}
 	var issues []string
 	if buffer.flat == nil {
@@ -306,30 +310,22 @@ func (b *Backend) BufferFinalize(backendBuffer compute.Buffer) error {
 		issues = append(issues, "buffer was marked as not in use (already back in the pool)")
 	}
 	if len(issues) > 0 {
-		return errors.Errorf("BufferFinalize(%p): %s -- buffer was already finalized or back in the pool",
+		return errors.Errorf("Finalize(%p): %s -- buffer was already finalized or back in the pool",
 			buffer, strings.Join(issues, ", "))
 	}
-	// fmt.Printf("> BufferFinalize(%p): shape=%s\n", buffer, buffer.shape)
-	// fmt.Printf("\tStack trace:\n%s\n", debug.Stack())
-	b.putBuffer(buffer)
+	buffer.backend.putBuffer(buffer)
 	return nil
 }
 
 // BufferShape returns the shape for the buffer.
-func (b *Backend) BufferShape(buffer compute.Buffer) (shapes.Shape, error) {
-	buf, ok := buffer.(*Buffer)
-	if !ok {
-		return shapes.Invalid(), errors.Errorf("buffer is not a %q backend buffer", BackendName)
-	}
-	return buf.shape, nil
+// Shape returns the shape for the buffer.
+func (buffer *Buffer) Shape() (shapes.Shape, error) {
+	return buffer.shape, nil
 }
 
 // BufferDeviceNum returns the deviceNum for the buffer.
-func (b *Backend) BufferDeviceNum(buffer compute.Buffer) (compute.DeviceNum, error) {
-	_, ok := buffer.(*Buffer)
-	if !ok {
-		return 0, errors.Errorf("buffer is not a %q backend buffer", BackendName)
-	}
+// DeviceNum returns the deviceNum for the buffer.
+func (buffer *Buffer) DeviceNum() (compute.DeviceNum, error) {
 	return 0, nil
 }
 
@@ -337,12 +333,9 @@ func (b *Backend) BufferDeviceNum(buffer compute.Buffer) (compute.DeviceNum, err
 // The slice flat must have the exact number of elements required to store the compute.Buffer shape.
 //
 // See also FlatDataToBuffer, BufferShape, and shapes.Shape.Size.
-func (b *Backend) BufferToFlatData(backendBuffer compute.Buffer, flat any) error {
-	buf, ok := backendBuffer.(*Buffer)
-	if !ok {
-		return errors.Errorf("buffer is not a %q backend buffer", BackendName)
-	}
-	copyFlat(flat, buf.flat)
+// ToFlatData transfers the flat values of the buffer to the Go flat array.
+func (buffer *Buffer) ToFlatData(flat any) error {
+	copyFlat(flat, buffer.flat)
 	return nil
 }
 
@@ -421,20 +414,21 @@ func (b *Backend) NewSharedBuffer(deviceNum compute.DeviceNum, shape shapes.Shap
 // shares CPU memory.
 //
 // The returned slice becomes invalid after the buffer is destroyed.
-func (b *Backend) BufferData(buffer compute.Buffer) (flat any, err error) {
-	if b.isFinalized {
+// Data returns a slice pointing to the buffer storage memory directly.
+func (buffer *Buffer) Data() (flat any, err error) {
+	if buffer.backend.isFinalized {
 		return nil, errors.Errorf("backend is already finalized")
 	}
-	buf, ok := buffer.(*Buffer)
-	if !ok {
-		return nil, errors.Errorf("buffer is not a %q backend buffer", BackendName)
-	}
-	return buf.flat, nil
+	return buffer.flat, nil
 }
 
 // BufferCopyToDevice implements the compute.Backend interface.
-func (b *Backend) BufferCopyToDevice(_ compute.Buffer, _ compute.DeviceNum) (
-	bufferOnDevice compute.Buffer, err error) {
-	return nil, errors.Errorf("backend %q: multi-device not supported on this backend",
-		BackendName)
+// CopyToDevice implements the compute.Buffer interface.
+func (buffer *Buffer) CopyToDevice(deviceNum compute.DeviceNum) (compute.Buffer, error) {
+	return nil, errors.Errorf("backend %q: multi-device not supported on this backend", BackendName)
+}
+
+// Backend returns the backend that owns this buffer.
+func (buffer *Buffer) Backend() compute.Backend {
+	return buffer.backend
 }

--- a/internal/gobackend/builder_test.go
+++ b/internal/gobackend/builder_test.go
@@ -68,7 +68,7 @@ func TestDuplicatedOutputNodes(t *testing.T) {
 	}
 
 	// Verify shapes are correct
-	shape0, err := backend.BufferShape(outputs[0])
+	shape0, err := outputs[0].Shape()
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -76,7 +76,7 @@ func TestDuplicatedOutputNodes(t *testing.T) {
 		t.Errorf("Expected shape %s, got %s", shapes.Make(dtypes.Float32, 3), shape0)
 	}
 
-	shape1, err := backend.BufferShape(outputs[1])
+	shape1, err := outputs[1].Shape()
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}

--- a/notimplemented/notimplemented.go
+++ b/notimplemented/notimplemented.go
@@ -64,26 +64,6 @@ func (b *Backend) Builder(name string) compute.Builder {
 	return Builder{}
 }
 
-// BufferFinalize returns NotImplementedError.
-func (b *Backend) BufferFinalize(buffer compute.Buffer) error {
-	return errors.Wrapf(NotImplementedError, "in BufferFinalize()")
-}
-
-// BufferShape returns NotImplementedError.
-func (b *Backend) BufferShape(buffer compute.Buffer) (shapes.Shape, error) {
-	return shapes.Invalid(), errors.Wrapf(NotImplementedError, "in BufferShape()")
-}
-
-// BufferDeviceNum returns NotImplementedError.
-func (b *Backend) BufferDeviceNum(buffer compute.Buffer) (compute.DeviceNum, error) {
-	return 0, errors.Wrapf(NotImplementedError, "in BufferDeviceNum()")
-}
-
-// BufferToFlatData returns NotImplementedError.
-func (b *Backend) BufferToFlatData(buffer compute.Buffer, flat any) error {
-	return errors.Wrapf(NotImplementedError, "in BufferToFlatData()")
-}
-
 // BufferFromFlatData returns NotImplementedError.
 func (b *Backend) BufferFromFlatData(
 	deviceNum compute.DeviceNum,
@@ -104,19 +84,6 @@ func (b *Backend) NewSharedBuffer(
 	shape shapes.Shape,
 ) (buffer compute.Buffer, flat any, err error) {
 	return nil, nil, errors.Wrapf(NotImplementedError, "in NewSharedBuffer()")
-}
-
-// BufferData returns NotImplementedError.
-func (b *Backend) BufferData(buffer compute.Buffer) (flat any, err error) {
-	return nil, errors.Wrapf(NotImplementedError, "in BufferData()")
-}
-
-// BufferCopyToDevice returns NotImplementedError.
-func (b *Backend) BufferCopyToDevice(
-	source compute.Buffer,
-	deviceNum compute.DeviceNum,
-) (bufferOnDevice compute.Buffer, err error) {
-	return nil, errors.Wrapf(NotImplementedError, "in BufferCopyToDevice()")
 }
 
 // Finalize does nothing for this dummy backend.

--- a/support/backendtest/dotgeneral.go
+++ b/support/backendtest/dotgeneral.go
@@ -54,7 +54,7 @@ func TestDotGeneral(t *testing.T, b compute.Backend) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %+v", err)
 		}
-		outputShape, err := b.BufferShape(outputs[0])
+		outputShape, err := outputs[0].Shape()
 		if err != nil {
 			t.Fatalf("Unexpected error: %+v", err)
 		}

--- a/support/backendtest/exec.go
+++ b/support/backendtest/exec.go
@@ -142,13 +142,13 @@ func TestExec(t *testing.T, b compute.Backend) {
 		}
 
 		// i0 should already have been finalized/donated, so this shoudl be a no-op.
-		err = b.BufferFinalize(i0)
+		err = i0.Finalize()
 		if err != nil {
 			t.Fatalf("BufferFinalize failed: %+v", err)
 		}
 
 		// Verify reuse via pointer comparison of underlying shared data.
-		out0Flat, err := b.BufferData(outputs[0])
+		out0Flat, err := outputs[0].Data()
 		if err != nil {
 			t.Fatalf("BufferData failed: %+v", err)
 		}
@@ -163,7 +163,7 @@ func TestExec(t *testing.T, b compute.Backend) {
 			}
 		}
 
-		outputShape, err := b.BufferShape(outputs[1])
+		outputShape, err := outputs[1].Shape()
 		if err != nil {
 			t.Fatalf("BufferShape failed: %+v", err)
 		}
@@ -178,7 +178,7 @@ func TestExec(t *testing.T, b compute.Backend) {
 		if err != nil {
 			t.Fatalf("Execute failed: %+v", err)
 		}
-		out0FlatNoDonate, _ := b.BufferData(outputs[0])
+		out0FlatNoDonate, _ := outputs[0].Data()
 		out0PointerNoDonate := reflect.ValueOf(out0FlatNoDonate).Pointer()
 		if i1Pointer == out0PointerNoDonate {
 			t.Errorf("Expected output data buffer to be different from input data buffer when input buffer not donated")

--- a/support/testutil/buffers.go
+++ b/support/testutil/buffers.go
@@ -61,19 +61,19 @@ func ToBuffer(backend compute.Backend, v any) (compute.Buffer, error) {
 
 // FromBuffer converts a [compute.Buffer] into a nested slice of the corresponding Go type.
 func FromBuffer(backend compute.Backend, buf compute.Buffer) (any, error) {
-	shape, err := backend.BufferShape(buf)
+	shape, err := buf.Shape()
 	if err != nil {
 		return nil, err
 	}
 	var flat any
 	if backend.HasSharedBuffers() {
-		flat, err = backend.BufferData(buf)
+		flat, err = buf.Data()
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		flat = dtypes.MakeAnySlice(shape.DType, shape.Size())
-		if err := backend.BufferToFlatData(buf, flat); err != nil {
+		if err := buf.ToFlatData(flat); err != nil {
 			return nil, err
 		}
 	}

--- a/support/testutil/exec.go
+++ b/support/testutil/exec.go
@@ -25,7 +25,7 @@ func Exec(backend compute.Backend, inputs []any,
 		if err != nil {
 			return nil, errors.WithMessagef(err, "while transferring input #%d to a backend buffer", i)
 		}
-		inputShapes[i], err = backend.BufferShape(inputBuffers[i])
+		inputShapes[i], err = inputBuffers[i].Shape()
 		if err != nil {
 			return nil, errors.WithMessagef(err, "while getting shape of input #%d", i)
 		}


### PR DESCRIPTION
Refactored the Buffer API from an opaque type to an object-oriented interface, shifting responsibilities out of DataInterface directly into the Buffer type. Tested with `go test ./...`.

---
*PR created automatically by Jules for task [12748791454856298948](https://jules.google.com/task/12748791454856298948) started by @janpfeifer*