### PR TITLE
Dynamic Shapes 

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -92,7 +92,8 @@ Whenever printing an error, use `"%+v"` format so the full stack is printed.
 
 - For backend tests that could be used for any backend, write them in `support/backendtest` so other
   backends can benefit.
-
+- We DONT depend on testify or other test libraries: we are trying to minimize external dependencies.
+- Use the locally defined `support/testutil` for test utilities for equality (or InDelta or InRelativeDelta comparisons of buffers, etc.).
 
 ### Follow Existing Patterns
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -66,6 +66,15 @@ includes a comment stating which tool was used to generate them.
 All errors should include a stack-trace, using the `github.com/pkg/errors` package.
 Whenever printing an error, use `"%+v"` format so the full stack is printed.
 
+### Shapes
+
+- The Shape object should be immutable semantic after creation: function that need to mutate shapes
+  should clone first (see Shape.Clone), mutate, and return the updated (and henceforward immutable) shape.
+- It's ok to simply copy shapes (shallow copy) if they are not meant to be mutated.
+- Shape can have named axes (see `shapes.MakeDynamic`).
+- Shape can be dynamic -- dynamic axes are represented by the sentinel value `shapes.DynamicDim` (-1).
+  If they are dynamic, the must be name (see `shapes.MakeDynamic`). Non-dynamic axes can also be named.
+
 ### Modern Go Style
 
 - Use generics where possible.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -73,7 +73,8 @@ Whenever printing an error, use `"%+v"` format so the full stack is printed.
 - It's ok to simply copy shapes (shallow copy) if they are not meant to be mutated.
 - Shape can have named axes (see `shapes.MakeDynamic`).
 - Shape can be dynamic -- dynamic axes are represented by the sentinel value `shapes.DynamicDim` (-1).
-  If they are dynamic, the must be name (see `shapes.MakeDynamic`). Non-dynamic axes can also be named.
+  If they are dynamic, they must be named (see `shapes.MakeDynamic`), and the dynamic axes must have a name != "".
+  Non-dynamic axes can also be named, but it's not required (the shape.AxisNames can be nil, or their name == "").
 
 ### Modern Go Style
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,19 @@ It powers [GoMLX](https://github.com/gomlx/gomlx), the machine learning framewor
 
 The `compute.Backend` API is currently implemented by:
 
-- Package `native`: provides a native Go implementation, hence very portable (including it runs in WASM). It covers 80% of the API (some ops are still missing). EXPERIMENTAL: we are working on SIMD versions, for architectures that support it (with runtime dispatching for instance on _amd64_, so one binary will take advantage of AVX2 / AVX512, whichever is available), it offers huge gains.
-- Package `xla`: provides an [XLA (PJRT)](https://openxla.org/) based implementation, the same used by Jax and TensorFlow. It uses CGO (it's a C++ library), but it supports GPUs and TPUs, as well as a fast CPU, proper JIT compilation. Limited to static shapes though.
-- The project [go-darwinml](https://github.com/gomlx/go-darwinml/) is an **experimental** support to Apple's CoreML, with accelerate for GPU (Metal) and CPU (arm64).
+- Package `gobackend`: a native Go implementation, hence very portable
+  (including it runs in WASM). It covers 80% of the API (some ops are still
+  missing). We are working on SIMD versions: AVX512 and AVX2 using
+  `simd/archsimd` for now, only for _matmul_ (with huge performance gains).
+- Package
+  [`compute/xla`](https://github.com/gomlx/go-xla/tree/main/compute/xla): an
+  [XLA (PJRT)](https://openxla.org/) based implementation, the same used by Jax
+  and TensorFlow. It uses CGO (it's a C++ library), but it supports GPUs and
+  TPUs, as well as a fast CPU, proper JIT compilation. Limited to static shapes
+  though.
+- The project [go-darwinml](https://github.com/gomlx/go-darwinml/) is an
+  **experimental** support to Apple's CoreML, with accelerate for GPU (Metal)
+  and CPU (arm64).
 
 ## Using the `compute.Backend` interface
 
@@ -22,13 +32,14 @@ The `compute.Backend` API is currently implemented by:
 
 **Short term:**
 
-- Add dynamic shapes support.
-- Add initial SIMD implementation for the `native` (using `go-highway`).
+- [x] Add basic dynamic shapes support. (experimental, see `./docs/DynamicShapes.md`)
+- [x] Add initial SIMD implementation for the Go backend (AVX512 and AVX2, using plain `simd/archsimd`).
 
 **Future:**
 
 We are exploring support (Backend implementations) for:
 
+* Integrate more SIMD using go-highway for the Go backend.
 * ONNX Runtime: dynamically generate an ONNX proto and use ORT to execute it;
 * [llama.cpp](https://github.com/ggml-org/llama.cpp): using [github.com/hybridgroup/yzma](https://github.com/hybridgroup/yzma) a "pure-go" binding;
 * [WebNN](https://learn.microsoft.com/en-us/windows/ai/directml/webnn-overview) or WebGL.
@@ -50,6 +61,28 @@ func TestCompliance(t *testing.T) {
 }
 ```
 
-Consider using GoMLX tests against your Backend to test that they are working -- just set the environment variable `GOMLX_BACKEND` to your new backend, and you can run arbitrary tests.
-Also, once you have enough ops implemented, you can use some of the example models to benchmark your backend against some of the others.
+Consider using GoMLX tests against your Backend to test that they are working --
+just set the environment variable `GOMLX_BACKEND` to your new backend, and you
+can run arbitrary tests. Also, once you have enough ops implemented, you can use
+some of the example models to benchmark your backend against some of the others.
 
+## Environment Variables
+
+- `GOMLX_BACKEND`: defines the backend engine to use (if using `backends.New()`). The value is formatted as "<backend_name>[:<backend_config>]",
+  with the config part being optional. Examples:
+  - `GOMLX_BACKEND=go`: Use the `SimpleGo` backend, the pure Go implementation that is very portable but slow.
+  - `GOMLX_BACKEND="xla:cpu"`: Use XLA (the faster backend, only runs on Linux now) for CPU
+  - `GOMLX_BACKEND="xla:cuda"`: Use XLA for for Nvidia CUDA
+  - `GOMLX_BACKEND="xla:/path/to/my/pjrt_plugin.so"`: Use XLA with an arbitrary PJRT. PJRT is a plugin system for XLA to support different hardware.
+    One can install PJRTs build for NVIDIA GPUs (there is an installation script for that), there is also one for ROCm (not tested by the author),
+    for TPU (Google Cloud) and reports of PJRTs being built to even new accelerators (e.g.: [TensTorrent XLA](https://github.com/tenstorrent/tt-xla))
+- For the native Go backend:
+  - `GOMLX_SIMD_AVX512`: set to `0` or `false` to disable AVX512 SIMD implementation in the native Go backend. The default is enabled if AVX512 is present.
+  - `GOMLX_SIMD_AVX2`: set to `0` or `false` to disable AVX2 SIMD implementation in the native Go backend. The default is enabled if AVX2 is present.
+  - `GOMLX_FUSION`: if set to `0`, `false` to disable fused operations in the native Go backend. The default is enabled.
+- For the [XLA backend](https://github.com/gomlx/go-xla/tree/main/compute/xla)
+  - `PJRT_PLUGIN_LIBRARY_PATH`: the underlying XLA backend uses this variable as an extra directory to search for plugin locations.
+    It searches for the systems library paths (`$LD_LIBRARY_PATH`, `/etc/ld.so.conf`), the default `/usr/local/lib/gomlx/pjrt` and `$PJRT_PLUGIN_LIBRARY_PATH` if set.
+  - `GOMLX_NO_AUTO_INSTALL`: if set to `1`, GoMLX will not automatically install PJRTs when running on a system without them.
+  - `XLA_FLAGS`: optional controls for XLA backend. It should be set to a semicolon (";") separated list of options. If you set to `--help` 
+    the backend will print out some help for all options. There is also a description on the page [XLA Flags Guidance](https://openxla.org/xla/flags_guidance).

--- a/capabilities.go
+++ b/capabilities.go
@@ -23,6 +23,12 @@ type Capabilities struct {
 	// If not listed, it's assumed to be false, hence not supported.
 	DTypes map[dtypes.DType]bool
 
+	// DynamicAxes indicates whether the backend supports named dynamic axes
+	// and shape specialization. When true, graph parameters can have symbolic
+	// dimensions (shapes.DynamicDim) with named axes, and the backend will
+	// lazily specialize execution for each concrete axis binding.
+	DynamicAxes bool
+
 	// PreferConstantsForVariables indicates that the backend prefers context variables
 	// (model weights) to be embedded as constants in the computation graph rather than
 	// passed as parameters (inputs) at execution time. This enables optimizations like

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,3 +7,8 @@
   - Fixed definition of `Bitcast` when casting to a larger target dtype: the rank is shrinked by 1.
 - Package `support`:
   - The following packages were moved from `github.com/gomlx/gomlx/pkg/support/...` to `support/...`: `xslices`, `xsync`, `sets` and `humanize`.
+
+- Package `shapes`: added initial support for dynamic shapes (see `./docs/DynamicShapes.md` for overall idea):
+  - Add `Shape.Resolve(AxisBindings) (Shape, error)` method.
+  - Add `Shape.IsDynamic()` method.
+  - Add `DynamicDim` type.

--- a/docs/DynamicShapes.md
+++ b/docs/DynamicShapes.md
@@ -1,27 +1,48 @@
 # Dynamic Shapes
 
 Dynamic shapes support for the `compute.Backend` for now entails allowing a computation graph to be defined
-with input parameters having symbolic axes: these axes have unspecified dimensions but can be named (e.g.: "batchSize").
+with input parameters having symbolic axes: these axes have unspecified dimensions but can be named 
+(e.g.: "batchSize") and can have a "sentinel" dimension value `shapes.DynamicDim` (-1) indicating that
+the particular axis length is dynamic (unknown at compile time).
+
+Dynamic axes **must be named**, since we use the symbolic names to resolve the shape during execution.
 
 These names are validated (if operands have named axes, their names must match). 
 
-Compilation leave the concrete shapes unresolved: symbolic shapes are only made concrete during executiong when the input shape is known. This avoids recompilation when only batch size (or other marked axes) change between calls.
+Compilation leave the concrete shapes unresolved: symbolic shapes are only made concrete during executiong when the
+input shape is known. This avoids recompilation when only batch size (or other marked axes) change between calls.
 
 ## What is not included
 
 Data dynamism, when the shapes depend on the content of the data (e.g.: it won't support a `Unique(x)` operation,
 whose results depends on how many unique values there are in `x`).
 
-## Phases
+Only input shapes conditioned dynamism: the shapes of the inputs can be dynamic, but must be resolvable given the
+input shapes.
 
-- **Phase 0**: Named dynamic axes foundation — `DynamicDim` sentinel, axis names on shapes, `Shape.Resolve()` / `Shape.HasDynamicDims()` / `AxisBindings`
-- **Phase 1**: Two-level JIT shape specialization — `ShapeSpecialization` with shallow node copies and resolved shapes, cached per binding key via `sync.Map`
-- **Phase 2**: Power-of-2 buffer pool bucketing — prevents excessive pool fragmentation when buffer sizes vary across specializations
-- **Phase 3**: Dynamic shapes for DotGeneral, ConvGeneral, Gather, Broadcast, Reshape, ReduceMean, and Concatenate — graph builders accept dynamic inputs and specialization recomputes shape-dependent `node.data`
+# Shape Resolution, the `shapes.AxisBindings`
+
+During execution dynamic shapes must be "resolved" to the concrete input shapes. 
+For this resolution we use `shapes.AxisBindings`, which is a map from axis names to axis lengths.
 
 ## Key design decisions
 
-- **Per-specialization `node.data` override**: Shallow copies in `createSpecialization` already create new `*Node` structs. For DotGeneral/ConvGeneral/Gather, new data structs are created with values recomputed from resolved concrete shapes. Executors read `node.data` unchanged — they get the specialization-specific copy.
-- **No executor changes**: All `exec*.go` files are untouched. Executors work on resolved nodes with concrete shapes and data.
-- **Axis name propagation**: Every `DynamicDim` in output shapes carries an axis name so `Shape.Resolve()` works at specialization time. `propagateDynamicAxisNames` in `function_dedup.go` ensures this for ops that don't explicitly set names.
-- **`DynamicAxes` capability flag**: Backends declare support; `graph.Exec.WithDynamicAxes()` checks the flag and returns a clear error if unsupported.
+- **Per-specialization `node.data` override**: Shallow copies in `createSpecialization` already create new `*Node`
+  structs. For DotGeneral/ConvGeneral/Gather, new data structs are created with values recomputed from resolved concrete
+  shapes. Executors read `node.data` unchanged — they get the specialization-specific copy.
+- **No executor changes**: All `exec*.go` files are untouched. Executors work on resolved nodes with concrete shapes and
+  data.
+- **Axis name propagation**: Every `DynamicDim` in output shapes carries an axis name so `Shape.Resolve()` works at
+  specialization time. `propagateDynamicAxisNames` in `function_dedup.go` ensures this for ops that don't explicitly set
+  names.
+- **`DynamicAxes` capability flag**: Backends declare support; `graph.Exec.WithDynamicAxes()` checks the flag and
+  returns a clear error if unsupported.
+
+## TODO:
+
+Allow instead of axisNames, have axis "expressions". E.g.: if we are doing data augmentation in a certain way of 
+the input batch, and we concatenate the original batch with the augmented one on axis 0, the new axis 0 should
+be be of size "=batchSize+batchSize" (or "=2*batchSize"), where "=" indicates an expression involving other axes
+bindings.
+
+For now we don't solve this.

--- a/docs/DynamicShapes.md
+++ b/docs/DynamicShapes.md
@@ -1,0 +1,27 @@
+# Dynamic Shapes
+
+Dynamic shapes support for the `compute.Backend` for now entails allowing a computation graph to be defined
+with input parameters having symbolic axes: these axes have unspecified dimensions but can be named (e.g.: "batchSize").
+
+These names are validated (if operands have named axes, their names must match). 
+
+Compilation leave the concrete shapes unresolved: symbolic shapes are only made concrete during executiong when the input shape is known. This avoids recompilation when only batch size (or other marked axes) change between calls.
+
+## What is not included
+
+Data dynamism, when the shapes depend on the content of the data (e.g.: it won't support a `Unique(x)` operation,
+whose results depends on how many unique values there are in `x`).
+
+## Phases
+
+- **Phase 0**: Named dynamic axes foundation — `DynamicDim` sentinel, axis names on shapes, `Shape.Resolve()` / `Shape.HasDynamicDims()` / `AxisBindings`
+- **Phase 1**: Two-level JIT shape specialization — `ShapeSpecialization` with shallow node copies and resolved shapes, cached per binding key via `sync.Map`
+- **Phase 2**: Power-of-2 buffer pool bucketing — prevents excessive pool fragmentation when buffer sizes vary across specializations
+- **Phase 3**: Dynamic shapes for DotGeneral, ConvGeneral, Gather, Broadcast, Reshape, ReduceMean, and Concatenate — graph builders accept dynamic inputs and specialization recomputes shape-dependent `node.data`
+
+## Key design decisions
+
+- **Per-specialization `node.data` override**: Shallow copies in `createSpecialization` already create new `*Node` structs. For DotGeneral/ConvGeneral/Gather, new data structs are created with values recomputed from resolved concrete shapes. Executors read `node.data` unchanged — they get the specialization-specific copy.
+- **No executor changes**: All `exec*.go` files are untouched. Executors work on resolved nodes with concrete shapes and data.
+- **Axis name propagation**: Every `DynamicDim` in output shapes carries an axis name so `Shape.Resolve()` works at specialization time. `propagateDynamicAxisNames` in `function_dedup.go` ensures this for ops that don't explicitly set names.
+- **`DynamicAxes` capability flag**: Backends declare support; `graph.Exec.WithDynamicAxes()` checks the flag and returns a clear error if unsupported.

--- a/dtypes/dtype_enum.go
+++ b/dtypes/dtype_enum.go
@@ -4,10 +4,15 @@ package dtypes
 
 //go:generate go tool enumer -type=DType -yaml -json -text -values -output=gen_dtype_enumer.go dtype_enum.go
 
-// DType is an enum represents the data type of a buffer or a scalar.
+// DType is an enum represents the data type of any buffer, scalar, tensor, multi-dimensional array, etc.
 //
 // Not all DType are supported by all backends. This is a collection of all data types GoMLX
 // know about and some more it doesn't yet handle.
+//
+// ## Half-precision data types
+//
+// Float16 and BFloat16 support in Go uses the simple implementations in [github.com/gomlx/compute/dtypes/float16]
+// and [github.com/gomlx/compute/dtypes/bfloat16].
 type DType int32
 
 const (

--- a/dtypes/dtypes.go
+++ b/dtypes/dtypes.go
@@ -1,10 +1,17 @@
 // Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
 
-// Package dtypes includes the DType enum for all supported data types for GoMLX.
+// Package dtypes includes the DType enum for all supported data types for GoMLX and the compute backends.
 //
-// It includes several converters to/from Go native types (and reflect.Type), and constants for min/max values for
-// types, slice of DType types manipulation, etc. It also includes some constraint interfaces to be used with generics
+// It includes several converters to/from Go native types (using generic functions and reflect.Type), and
+// constants for min/max values for types, slice of DType types manipulation, etc.
+//
+// It also includes some constraint interfaces to be used with generics
 // (Number, NumberNotComplex, GoFloat).
+//
+// ## Half-precision data types
+//
+// Float16 and BFloat16 support uses the simple implementations in [github.com/gomlx/compute/dtypes/float16]
+// and [github.com/gomlx/compute/dtypes/bfloat16].
 package dtypes
 
 import (

--- a/dtypes/dtypes.go
+++ b/dtypes/dtypes.go
@@ -10,7 +10,7 @@
 //
 // ## Half-precision data types
 //
-// Float16 and BFloat16 support uses the simple implementations in [github.com/gomlx/compute/dtypes/float16]
+// Float16 and BFloat16 support in Go uses the simple implementations in [github.com/gomlx/compute/dtypes/float16]
 // and [github.com/gomlx/compute/dtypes/bfloat16].
 package dtypes
 

--- a/internal/gobackend/builder.go
+++ b/internal/gobackend/builder.go
@@ -185,6 +185,15 @@ type Node struct {
 	Data any
 }
 
+// RecomputableNodeData is an interface that can be implemented by the Data field of a Node
+// to allow recomputing shape-dependent metadata when specializing a dynamic graph.
+type RecomputableNodeData interface {
+	// Recompute shape-dependent metadata from the resolved input shapes.
+	// Returns a new Data object (or the same one if it's mutable and updated in-place).
+	Recompute(backend *Backend, resolvedNodes []*Node, originalNode *Node) (any, error)
+}
+
+
 // MultiOutputValues converts a multi-output node's outputs to []compute.Value.
 func (node *Node) MultiOutputValues() []compute.Value {
 	outputs := make([]compute.Value, len(node.MultiOutputsNodes))

--- a/internal/gobackend/capabilities.go
+++ b/internal/gobackend/capabilities.go
@@ -92,8 +92,8 @@ var Capabilities = compute.Capabilities{
 
 		// Other operations:
 		compute.OpTypeArgMinMax:            true,
-		compute.OpTypeBitcast:              true,
 		compute.OpTypeBroadcastInDim:       true,
+
 		compute.OpTypeConcatenate:          true,
 		compute.OpTypeConvertDType:         true,
 		compute.OpTypeDot:                  true,

--- a/internal/gobackend/capabilities.go
+++ b/internal/gobackend/capabilities.go
@@ -92,8 +92,8 @@ var Capabilities = compute.Capabilities{
 
 		// Other operations:
 		compute.OpTypeArgMinMax:            true,
+		compute.OpTypeBitcast:              true,
 		compute.OpTypeBroadcastInDim:       true,
-
 		compute.OpTypeConcatenate:          true,
 		compute.OpTypeConvertDType:         true,
 		compute.OpTypeDot:                  true,

--- a/internal/gobackend/dot/dot.go
+++ b/internal/gobackend/dot/dot.go
@@ -55,6 +55,51 @@ type NodeData struct {
 	implementation *ImplementationRegistration
 }
 
+// SetSizes computes and sets the internal sizes (BatchSize, LHSCrossSize, RHSCrossSize, ContractingSize)
+// from the concrete LHS and RHS shapes.
+func (d *NodeData) SetSizes(lhsShape, rhsShape shapes.Shape) {
+	numBatchAxes := len(d.LHSBatchAxes)
+	d.BatchSize = 1
+	for i := range numBatchAxes {
+		d.BatchSize *= lhsShape.Dimensions[d.LHSBatchAxes[i]]
+	}
+
+	d.ContractingSize = 1
+	for _, axis := range d.LHSContractingAxes {
+		d.ContractingSize *= lhsShape.Dimensions[axis]
+	}
+
+	lhsRank := lhsShape.Rank()
+	d.LHSCrossSize = 1
+	isBatchOrContractingLHS := make([]bool, lhsRank)
+	for _, axis := range d.LHSBatchAxes {
+		isBatchOrContractingLHS[axis] = true
+	}
+	for _, axis := range d.LHSContractingAxes {
+		isBatchOrContractingLHS[axis] = true
+	}
+	for axis := 0; axis < lhsRank; axis++ {
+		if !isBatchOrContractingLHS[axis] {
+			d.LHSCrossSize *= lhsShape.Dimensions[axis]
+		}
+	}
+
+	rhsRank := rhsShape.Rank()
+	d.RHSCrossSize = 1
+	isBatchOrContractingRHS := make([]bool, rhsRank)
+	for _, axis := range d.RHSBatchAxes {
+		isBatchOrContractingRHS[axis] = true
+	}
+	for _, axis := range d.RHSContractingAxes {
+		isBatchOrContractingRHS[axis] = true
+	}
+	for axis := 0; axis < rhsRank; axis++ {
+		if !isBatchOrContractingRHS[axis] {
+			d.RHSCrossSize *= rhsShape.Dimensions[axis]
+		}
+	}
+}
+
 // EqualNodeData implements nodeDataComparable for dotGeneralNodeData.
 func (d *NodeData) EqualNodeData(other gobackend.NodeDataComparable) bool {
 	o := other.(*NodeData)
@@ -70,31 +115,36 @@ func (d *NodeData) EqualNodeData(other gobackend.NodeDataComparable) bool {
 		slices.Equal(d.RHSBatchAxes, o.RHSBatchAxes)
 }
 
-// SetSizes sets the dot-general sizes according to the axes dimensions.
-// Assumes shape has been normalized to one of the two supported layouts.
-func (d *NodeData) SetSizes(lhsShape, rhsShape shapes.Shape) {
-	d.BatchSize = 1
-	if len(d.LHSBatchAxes) > 0 {
-		d.BatchSize = lhsShape.Dimensions[d.LHSBatchAxes[0]]
+// Recompute implements gobackend.RecomputableNodeData for NodeData.
+func (d *NodeData) Recompute(backend *gobackend.Backend, resolvedNodes []*gobackend.Node, originalNode *gobackend.Node) (any, error) {
+	newData := &NodeData{
+		InputDType:         d.InputDType,
+		OutputDType:        d.OutputDType,
+		Config:             d.Config,
+		Layout:             d.Layout,
+		LHSContractingAxes: slices.Clone(d.LHSContractingAxes),
+		LHSBatchAxes:       slices.Clone(d.LHSBatchAxes),
+		RHSContractingAxes: slices.Clone(d.RHSContractingAxes),
+		RHSBatchAxes:       slices.Clone(d.RHSBatchAxes),
 	}
-	d.LHSCrossSize = 1
-	for i, dim := range lhsShape.Dimensions {
-		if !slices.Contains(d.LHSContractingAxes, i) && !slices.Contains(d.LHSBatchAxes, i) {
-			d.LHSCrossSize *= dim
-		}
+
+	// Get resolved (concrete) input shapes.
+	lhsShape := resolvedNodes[originalNode.Inputs[0].Index].Shape
+	rhsShape := resolvedNodes[originalNode.Inputs[1].Index].Shape
+
+	// Recompute sizes from concrete shapes.
+	newData.SetSizes(lhsShape, rhsShape)
+
+	// Re-find implementation (might change based on new sizes).
+	newData.implementation = FindRegisteredImplementation(newData.Layout, newData.InputDType, newData.OutputDType)
+	if newData.implementation == nil {
+		return nil, errors.Errorf("specialization: no DotGeneral implementation found for layout=%s and dtypes=%s,%s",
+			newData.Layout, newData.InputDType, newData.OutputDType)
 	}
-	d.RHSCrossSize = 1
-	for i, dim := range rhsShape.Dimensions {
-		if !slices.Contains(d.RHSContractingAxes, i) && !slices.Contains(d.RHSBatchAxes, i) {
-			d.RHSCrossSize *= dim
-		}
-	}
-	d.ContractingSize = 1
-	if len(d.LHSContractingAxes) > 0 {
-		// We could have gotten from lhs or rhs, they must match.
-		d.ContractingSize = lhsShape.Dimensions[d.LHSContractingAxes[0]]
-	}
+
+	return newData, nil
 }
+
 
 // DotGeneral takes as input lhs (left-hand-side) and rhs (right-hand-side) specifications
 // for a general vector product -- a generalized "Einsum". Each axis can be:

--- a/internal/gobackend/dot/matmul/avx512_router.go
+++ b/internal/gobackend/dot/matmul/avx512_router.go
@@ -34,7 +34,7 @@ func avx512RouterFloat32( //alt:f32
 	if klog.V(1).Enabled() {
 		variant := "large (avx512)"
 		if useSmallVariant {
-			variant = "small (nosimd)"
+			variant = "small (avx512)"
 		}
 		klog.Infof("Using %s variant for AVX512 dot-product kernel, layout=%s, "+
 			"lhs=[%d, %d, %d], rhs=[%d, %d, %d], output=[%d, %d, %d]",

--- a/internal/gobackend/dot/matmul/gen_avx512_router_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_router_bf16.go
@@ -39,7 +39,7 @@ func avx512RouterBFloat16( //alt:bf16
 	if klog.V(1).Enabled() {
 		variant := "large (avx512)"
 		if useSmallVariant {
-			variant = "small (nosimd)"
+			variant = "small (avx512)"
 		}
 		klog.Infof("Using %s variant for AVX512 dot-product kernel, layout=%s, "+
 			"lhs=[%d, %d, %d], rhs=[%d, %d, %d], output=[%d, %d, %d]",

--- a/internal/gobackend/dot/matmul/gen_avx512_router_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_router_f16.go
@@ -39,7 +39,7 @@ func avx512RouterFloat16( //alt:f16
 	if klog.V(1).Enabled() {
 		variant := "large (avx512)"
 		if useSmallVariant {
-			variant = "small (nosimd)"
+			variant = "small (avx512)"
 		}
 		klog.Infof("Using %s variant for AVX512 dot-product kernel, layout=%s, "+
 			"lhs=[%d, %d, %d], rhs=[%d, %d, %d], output=[%d, %d, %d]",

--- a/internal/gobackend/dot/matmul/gen_avx512_router_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_router_f64.go
@@ -39,7 +39,7 @@ func avx512RouterFloat64( //alt:f64
 	if klog.V(1).Enabled() {
 		variant := "large (avx512)"
 		if useSmallVariant {
-			variant = "small (nosimd)"
+			variant = "small (avx512)"
 		}
 		klog.Infof("Using %s variant for AVX512 dot-product kernel, layout=%s, "+
 			"lhs=[%d, %d, %d], rhs=[%d, %d, %d], output=[%d, %d, %d]",

--- a/internal/gobackend/exec.go
+++ b/internal/gobackend/exec.go
@@ -3,6 +3,8 @@
 package gobackend
 
 import (
+	"sync"
+
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/shapes"
 	"github.com/pkg/errors"
@@ -23,6 +25,10 @@ type Executable struct {
 
 	// mainFn is the compiled main function.
 	mainFn *FunctionExecutable
+
+	// specializations caches resolved-shape versions of the graph for dynamic graphs.
+	// map[string]*ShapeSpecialization where key is bindings.Key()
+	specializations sync.Map
 }
 
 // Compile time check.
@@ -39,6 +45,7 @@ var _ compute.Executable = (*Executable)(nil)
 func (e *Executable) Finalize() {
 	e.builder.Finalize()
 	e.builder = nil
+	e.specializations.Clear()
 }
 
 // Inputs returns the list of parameters names and shapes, in order created by the Builder.Parameter calls.
@@ -201,17 +208,46 @@ func (e *Executable) Execute(inputs []compute.Buffer, donate []bool, _ compute.D
 			return nil, errors.Errorf("Execute: input buffer #%d flat data is set to nil (!?)", ii)
 		}
 		nodeInput := params[ii]
-		if !inputBuffer.RawShape.Equal(nodeInput.Shape) {
-			paramName := nodeInput.Data.(*NodeParameter).Name
-			return nil, errors.Errorf("Execute: parameter %q (input #%d) for %q: expected shape %s, got %s",
-				paramName, ii, e.builder.name, nodeInput.Shape, inputBuffer.RawShape)
+		if !nodeInput.Shape.HasDynamicDims() {
+			if !inputBuffer.RawShape.EqualDimensions(nodeInput.Shape) {
+				return nil, errors.Errorf("Execute: parameter %q (input #%d) for %q: expected shape %s, got %s",
+					nodeInput.Data.(*NodeParameter).Name, ii, e.builder.name, nodeInput.Shape, inputBuffer.RawShape)
+			}
+			if inputBuffer.RawShape.DType != nodeInput.Shape.DType {
+				return nil, errors.Errorf("Execute: parameter %q (input #%d) for %q: expected DType %s, got %s",
+					nodeInput.Data.(*NodeParameter).Name, ii, e.builder.name, nodeInput.Shape.DType, inputBuffer.RawShape.DType)
+			}
+		} else {
+			// In the case of dynamic shapes, we only check the DType and Rank.
+			// The dimensions are used to extract bindings below.
+			if inputBuffer.RawShape.DType != nodeInput.Shape.DType {
+				return nil, errors.Errorf("Execute: parameter %q (input #%d) for %q: expected DType %s, got %s",
+					nodeInput.Data.(*NodeParameter).Name, ii, e.builder.name, nodeInput.Shape.DType, inputBuffer.RawShape.DType)
+			}
+			if inputBuffer.RawShape.Rank() != nodeInput.Shape.Rank() {
+				return nil, errors.Errorf("Execute: parameter %q (input #%d) for %q: expected rank %d, got %d",
+					nodeInput.Data.(*NodeParameter).Name, ii, e.builder.name, nodeInput.Shape.Rank(), inputBuffer.RawShape.Rank())
+			}
 		}
 		bufInputs[ii] = inputBuffer
 	}
 
+	// Handle dynamic shapes: extract bindings and get specialization.
+	var spec *ShapeSpecialization
+	if hasDynamicParameters(params) {
+		bindings, err := extractBindingsFromInputs(params, bufInputs)
+		if err != nil {
+			return nil, errors.WithMessage(err, "Execute")
+		}
+		spec, err = e.getOrCreateSpecialization(bindings)
+		if err != nil {
+			return nil, errors.WithMessage(err, "Execute")
+		}
+	}
+
 	// Delegate to FunctionExecutable
 	// Main function doesn't have captured values, so pass nil for both
-	outputs, err := e.mainFn.Execute(e.backend, bufInputs, donate, nil, nil)
+	outputs, err := e.mainFn.Execute(e.backend, bufInputs, donate, nil, nil, spec)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/exec.go
+++ b/internal/gobackend/exec.go
@@ -208,7 +208,7 @@ func (e *Executable) Execute(inputs []compute.Buffer, donate []bool, _ compute.D
 			return nil, errors.Errorf("Execute: input buffer #%d flat data is set to nil (!?)", ii)
 		}
 		nodeInput := params[ii]
-		if !nodeInput.Shape.HasDynamicDims() {
+		if !nodeInput.Shape.IsDynamic() {
 			if !inputBuffer.RawShape.EqualDimensions(nodeInput.Shape) {
 				return nil, errors.Errorf("Execute: parameter %q (input #%d) for %q: expected shape %s, got %s",
 					nodeInput.Data.(*NodeParameter).Name, ii, e.builder.name, nodeInput.Shape, inputBuffer.RawShape)

--- a/internal/gobackend/executable.go
+++ b/internal/gobackend/executable.go
@@ -169,8 +169,9 @@ type funcExecBuffers struct {
 // capturedInputs are the values captured from parent scopes (for closures).
 // donateCaptures indicates which captured inputs can be donated to the closure.
 // If donateCaptures is nil, no captured inputs will be donated.
+// spec is the shape specialization for the current execution, or nil for static graphs.
 func (fe *FunctionExecutable) Execute(backend *Backend, inputs []*Buffer, donate []bool, capturedInputs []*Buffer,
-	donateCaptures []bool) ([]*Buffer, error) {
+	donateCaptures []bool, spec *ShapeSpecialization) ([]*Buffer, error) {
 	// Use function's parameters (not builder.inputs) for proper function/closure support
 	funcParams := fe.Function.Parameters
 	if len(inputs) != len(funcParams) {
@@ -232,9 +233,9 @@ func (fe *FunctionExecutable) Execute(backend *Backend, inputs []*Buffer, donate
 	// Execute
 	var err error
 	if executionMode == OpsExecutionSequential {
-		err = fe.executeSequentially(backend, execBuf)
+		err = fe.executeSequentially(backend, execBuf, spec)
 	} else {
-		err = fe.executeParallel(backend, execBuf)
+		err = fe.executeParallel(backend, execBuf, spec)
 	}
 	if err != nil {
 		fe.ExecutionBuffersPool.Put(execBuf)
@@ -283,7 +284,7 @@ func (fe *FunctionExecutable) Execute(backend *Backend, inputs []*Buffer, donate
 }
 
 // executeSequentially executes nodes one after another in topological order.
-func (fe *FunctionExecutable) executeSequentially(backend *Backend, execBuf *funcExecBuffers) error {
+func (fe *FunctionExecutable) executeSequentially(backend *Backend, execBuf *funcExecBuffers, spec *ShapeSpecialization) error {
 	// Pre-allocate input buffers for reuse
 	execBuf.opInputBuffers = make([]*Buffer, fe.MaxInputs)
 	execBuf.opInputsOwned = make([]bool, fe.MaxInputs)
@@ -303,7 +304,10 @@ func (fe *FunctionExecutable) executeSequentially(backend *Backend, execBuf *fun
 		}
 
 		node := fe.Function.Nodes[nodeIdx]
-		if err := fe.executeNode(backend, node, execBuf); err != nil {
+		if spec != nil {
+			node = spec.resolvedNodes[nodeIdx]
+		}
+		if err := fe.executeNode(backend, node, execBuf, spec); err != nil {
 			return err
 		}
 	}
@@ -311,7 +315,7 @@ func (fe *FunctionExecutable) executeSequentially(backend *Backend, execBuf *fun
 }
 
 // executeParallel executes nodes in parallel based on dependency graph.
-func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExecBuffers) error {
+func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExecBuffers, spec *ShapeSpecialization) error {
 	var (
 		readyToExecute chan int
 		collectErrors  []error
@@ -354,6 +358,9 @@ func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExe
 		nodeExecFn := func() {
 			defer wg.Done()
 			node := fe.Function.Nodes[nodeIdx]
+			if spec != nil {
+				node = spec.resolvedNodes[nodeIdx]
+			}
 
 			defer func(nodeIdx int) {
 				execMu.Lock()
@@ -404,7 +411,7 @@ func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExe
 				return
 			}
 
-			if err := fe.executeNode(backend, node, execBuf); err != nil {
+			if err := fe.executeNode(backend, node, execBuf, spec); err != nil {
 				appendErrorFn(err)
 				return
 			}
@@ -425,7 +432,7 @@ func (fe *FunctionExecutable) executeParallel(backend *Backend, execBuf *funcExe
 }
 
 // executeNode executes a single node and stores its result.
-func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf *funcExecBuffers) error {
+func (fe *FunctionExecutable) executeNode(backend *Backend, node *Node, execBuf *funcExecBuffers, spec *ShapeSpecialization) error {
 	nodeIdx := node.Index
 
 	// Handle constants specially

--- a/internal/gobackend/function.go
+++ b/internal/gobackend/function.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gomlx/compute/dtypes"
 	"github.com/gomlx/compute/notimplemented"
 	"github.com/gomlx/compute/shapes"
+	"github.com/gomlx/compute/support/sets"
 	"github.com/pkg/errors"
 )
 
@@ -52,6 +53,9 @@ type Function struct {
 	// compiled holds pre-compiled execution info.
 	// This is set during Return() to allow efficient execution.
 	Compiled *FunctionExecutable
+
+	// knownDynamicAxisNames holds all dynamic axis names introduced by parameters.
+	knownDynamicAxisNames sets.Set[string]
 }
 
 // capturedNodeData is the data stored in a captured value node.
@@ -325,6 +329,20 @@ func (f *Function) Parameter(name string, shape shapes.Shape, sharding *compute.
 	}
 	n, _ := f.GetOrCreateNode(compute.OpTypeParameter, shape, nil, data)
 	f.Parameters = append(f.Parameters, n)
+
+	rootFn := f
+	for rootFn.RawParent != nil {
+		rootFn = rootFn.RawParent
+	}
+	if rootFn.knownDynamicAxisNames == nil {
+		rootFn.knownDynamicAxisNames = sets.Make[string]()
+	}
+	for i, dim := range shape.Dimensions {
+		if dim == shapes.DynamicDim && shape.AxisNames != nil && shape.AxisNames[i] != "" {
+			rootFn.knownDynamicAxisNames.Insert(shape.AxisNames[i])
+		}
+	}
+
 	return n, nil
 }
 
@@ -408,4 +426,16 @@ func (f *Function) AllReduce(_ []compute.Value, _ compute.ReduceOpType, _ [][]in
 	return nil, errors.Wrapf(
 		notimplemented.NotImplementedError,
 		"AllReduce not supported for %q builder", BackendName)
+}
+
+// KnownDynamicAxisNames returns the set of dynamically defined axis names known by the function.
+func (f *Function) KnownDynamicAxisNames() sets.Set[string] {
+	rootFn := f
+	for rootFn.RawParent != nil {
+		rootFn = rootFn.RawParent
+	}
+	if rootFn.knownDynamicAxisNames == nil {
+		rootFn.knownDynamicAxisNames = sets.Make[string]()
+	}
+	return rootFn.knownDynamicAxisNames
 }

--- a/internal/gobackend/function_test.go
+++ b/internal/gobackend/function_test.go
@@ -453,7 +453,7 @@ func TestCompiledClosureExecute(t *testing.T) {
 
 	// Execute the closure
 	b := backend.(*gobackend.Backend)
-	outputs, err := cc.Execute(b, []*gobackend.Buffer{xBuf, yBuf}, nil, nil, nil)
+	outputs, err := cc.Execute(b, []*gobackend.Buffer{xBuf, yBuf}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -531,7 +531,7 @@ func TestCompiledClosureMultipleExecutions(t *testing.T) {
 		}
 		inputBuf := inputBuf_compute.(*gobackend.Buffer)
 
-		outputs, err := cc.Execute(b, []*gobackend.Buffer{inputBuf}, nil, nil, nil)
+		outputs, err := cc.Execute(b, []*gobackend.Buffer{inputBuf}, nil, nil, nil, nil)
 		if err != nil {
 			t.Fatalf("Execution %d failed: %+v", i, err)
 		}
@@ -584,7 +584,7 @@ func TestCompiledClosureWithConstants(t *testing.T) {
 
 	// Execute with no inputs
 	goBackend := backend.(*gobackend.Backend)
-	outputs, err := cc.Execute(goBackend, []*gobackend.Buffer{}, nil, nil, nil)
+	outputs, err := cc.Execute(goBackend, []*gobackend.Buffer{}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -647,7 +647,7 @@ func TestCompiledClosureMultipleOutputs(t *testing.T) {
 	inputBuf := makeBuffer(t, shapes.Make(dtypes.Float32, 2), []float32{5.0, 10.0})
 
 	b := backend.(*gobackend.Backend)
-	outputs, err := cc.Execute(b, []*gobackend.Buffer{inputBuf}, nil, nil, nil)
+	outputs, err := cc.Execute(b, []*gobackend.Buffer{inputBuf}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -731,7 +731,7 @@ func TestCompiledClosureChainedOperations(t *testing.T) {
 	inputBuf := makeBuffer(t, shapes.Make(dtypes.Float32, 2), []float32{1.0, 2.0})
 
 	goBackend := backend.(*gobackend.Backend)
-	outputs, err := cc.Execute(goBackend, []*gobackend.Buffer{inputBuf}, nil, nil, nil)
+	outputs, err := cc.Execute(goBackend, []*gobackend.Buffer{inputBuf}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -787,7 +787,7 @@ func TestCompiledClosureInputValidation(t *testing.T) {
 	goBackend := backend.(*gobackend.Backend)
 
 	// Too few inputs
-	_, err = cc.Execute(goBackend, []*gobackend.Buffer{xBuf}, nil, nil, nil)
+	_, err = cc.Execute(goBackend, []*gobackend.Buffer{xBuf}, nil, nil, nil, nil)
 	if err == nil {
 		t.Errorf("Expected error for too few inputs")
 	} else if !strings.Contains(err.Error(), "expects 2 inputs, got 1") {
@@ -795,7 +795,7 @@ func TestCompiledClosureInputValidation(t *testing.T) {
 	}
 
 	// Too many inputs
-	_, err = cc.Execute(goBackend, []*gobackend.Buffer{xBuf, xBuf, xBuf}, nil, nil, nil)
+	_, err = cc.Execute(goBackend, []*gobackend.Buffer{xBuf, xBuf, xBuf}, nil, nil, nil, nil)
 	if err == nil {
 		t.Errorf("Expected error for too many inputs")
 	} else if !strings.Contains(err.Error(), "expects 2 inputs, got 3") {
@@ -932,7 +932,7 @@ func TestClosureExecuteWithCapturedValues(t *testing.T) {
 	// Execute the closure with captured values
 	// Expected: [10, 20] + [1, 2] = [11, 22]
 	goBackend := backend.(*gobackend.Backend)
-	outputs, err := cc.Execute(goBackend, []*gobackend.Buffer{inputBuf}, nil, []*gobackend.Buffer{capturedBuf}, nil)
+	outputs, err := cc.Execute(goBackend, []*gobackend.Buffer{inputBuf}, nil, []*gobackend.Buffer{capturedBuf}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -1020,7 +1020,7 @@ func TestClosureExecuteWithNestedCapturedValues(t *testing.T) {
 	// Execute the nested closure with captured values
 	// Expected: [100, 200] * [2, 3] = [200, 600]
 	goBackend := backend.(*gobackend.Backend)
-	outputs, err := cc.Execute(goBackend, []*gobackend.Buffer{inputBuf}, nil, []*gobackend.Buffer{capturedBuf}, nil)
+	outputs, err := cc.Execute(goBackend, []*gobackend.Buffer{inputBuf}, nil, []*gobackend.Buffer{capturedBuf}, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}

--- a/internal/gobackend/ops/argminmax.go
+++ b/internal/gobackend/ops/argminmax.go
@@ -46,7 +46,7 @@ func ArgMinMax(f *gobackend.Function,
 		return nil, err
 	}
 	operand := inputs[0]
-	outputShape, err := shapeinference.ArgMinMaxOp(operand.Shape, axis, outputDType)
+	outputShape, err := shapeinference.ArgMinMax(operand.Shape, axis, outputDType)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/bitcast.go
+++ b/internal/gobackend/ops/bitcast.go
@@ -35,7 +35,7 @@ func Bitcast(f *gobackend.Function, operandOp compute.Value, targetDType dtypes.
 		return nil, err
 	}
 	operand := inputs[0]
-	outputShape, err := shapeinference.BitcastOp(operand.Shape, targetDType)
+	outputShape, err := shapeinference.Bitcast(operand.Shape, targetDType)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/broadcastindim.go
+++ b/internal/gobackend/ops/broadcastindim.go
@@ -63,7 +63,7 @@ func BroadcastInDim(
 	operand := inputs[0]
 
 	opType := compute.OpTypeBroadcastInDim
-	err = shapeinference.BroadcastInDimOp(operand.Shape, outputShape, broadcastAxes)
+	err = shapeinference.BroadcastInDim(operand.Shape, outputShape, broadcastAxes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/broadcastindim.go
+++ b/internal/gobackend/ops/broadcastindim.go
@@ -63,7 +63,7 @@ func BroadcastInDim(
 	operand := inputs[0]
 
 	opType := compute.OpTypeBroadcastInDim
-	err = shapeinference.BroadcastInDim(operand.Shape, outputShape, broadcastAxes)
+	err = shapeinference.BroadcastInDim(operand.Shape, outputShape, broadcastAxes, f.KnownDynamicAxisNames())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/call.go
+++ b/internal/gobackend/ops/call.go
@@ -81,7 +81,7 @@ func execCall(
 	data := node.Data.(*callNode) //nolint:errcheck
 	targetFn := data.target
 
-	outputs, err := targetFn.Compiled.Execute(backend, inputs, inputsOwned, nil, nil)
+	outputs, err := targetFn.Compiled.Execute(backend, inputs, inputsOwned, nil, nil, nil)
 	// Mark donated inputs as consumed.
 	for i, owned := range inputsOwned {
 		if owned {

--- a/internal/gobackend/ops/concatenate.go
+++ b/internal/gobackend/ops/concatenate.go
@@ -31,7 +31,7 @@ func Concatenate(f *gobackend.Function, axis int, operandOps ...compute.Value) (
 	for i, opNode := range operands {
 		inputShapes[i] = opNode.Shape
 	}
-	outputShape, err := shapeinference.ConcatenateOp(inputShapes, axis)
+	outputShape, err := shapeinference.Concatenate(inputShapes, axis)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/convgeneral.go
+++ b/internal/gobackend/ops/convgeneral.go
@@ -51,7 +51,7 @@ func ConvGeneral(f *gobackend.Function, inputOp, kernelOp compute.Value, axes co
 	input, kernel := inputs[0], inputs[1]
 
 	// Run shape inference.
-	outputShape, err := shapeinference.ConvGeneralOp(input.Shape, kernel.Shape, axes, strides, paddings, inputDilations, kernelDilations, channelGroupCount, batchGroupCount)
+	outputShape, err := shapeinference.ConvGeneral(input.Shape, kernel.Shape, axes, strides, paddings, inputDilations, kernelDilations, channelGroupCount, batchGroupCount)
 	if err != nil {
 		err = errors.WithMessagef(err, "ConvGeneral: input=%s, kernel=%s, output=%s, axes=%+v, strides=%v, paddings=%v, inputDilations=%v, kernelDilations=%v, channelGroupCount=%d, batchGroupCount=%d\n",
 			input.Shape, kernel.Shape, outputShape, axes, strides, paddings, inputDilations, kernelDilations, channelGroupCount, batchGroupCount)

--- a/internal/gobackend/ops/convgeneral.go
+++ b/internal/gobackend/ops/convgeneral.go
@@ -146,6 +146,40 @@ type convNode struct {
 	dilatedInputSpatialDims []int
 }
 
+// Recompute implements gobackend.RecomputableNodeData for convNode.
+func (c *convNode) Recompute(backend *gobackend.Backend, resolvedNodes []*gobackend.Node, originalNode *gobackend.Node) (any, error) {
+	inputShape := resolvedNodes[originalNode.Inputs[0].Index].Shape
+	kernelShape := resolvedNodes[originalNode.Inputs[1].Index].Shape
+
+	newData := &convNode{
+		axes:               c.axes,
+		strides:            slices.Clone(c.strides),
+		paddings:           slices.Clone(c.paddings),
+		inputDilations:     slices.Clone(c.inputDilations),
+		kernelDilations:    slices.Clone(c.kernelDilations),
+		channelGroupCount:  c.channelGroupCount,
+		batchGroupCount:    c.batchGroupCount,
+		hasInputDilations:  c.hasInputDilations,
+		hasKernelDilations: c.hasKernelDilations,
+	}
+
+	newData.inputStrides = inputShape.Strides()
+	newData.kernelStrides = kernelShape.Strides()
+
+	spatialRank := inputShape.Rank() - 2
+	newData.dilatedInputSpatialDims = make([]int, spatialRank)
+	newData.inputSpatialStrides = make([]int, spatialRank)
+	for spatialIdx, inputAxis := range c.axes.InputSpatial {
+		newData.inputSpatialStrides[spatialIdx] = newData.inputStrides[inputAxis]
+		dim := inputShape.Dimensions[inputAxis]
+		if dim > 0 {
+			newData.dilatedInputSpatialDims[spatialIdx] = (dim-1)*c.inputDilations[spatialIdx] + 1
+		}
+	}
+
+	return newData, nil
+}
+
 // EqualNodeData implements nodeDataComparable for convNode.
 func (c *convNode) EqualNodeData(other gobackend.NodeDataComparable) bool {
 	o := other.(*convNode)

--- a/internal/gobackend/ops/gather.go
+++ b/internal/gobackend/ops/gather.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gomlx/compute/shapeinference"
 	"github.com/gomlx/compute/shapes"
 	"github.com/gomlx/compute/support/sets"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -19,6 +20,41 @@ type gatherNode struct {
 	indexVectorAxis                                                  int
 	offsetOutputAxes, collapsedSlicesAxes, startIndexMap, sliceSizes []int
 	indicesAreSorted                                                 bool
+}
+
+// Recompute implements gobackend.RecomputableNodeData for gatherNode.
+func (g *gatherNode) Recompute(backend *gobackend.Backend, resolvedNodes []*gobackend.Node, originalNode *gobackend.Node) (any, error) {
+	operandShape := resolvedNodes[originalNode.Inputs[0].Index].Shape
+
+	// Check if any sliceSize needs updating.
+	needsUpdate := false
+	for i, s := range g.sliceSizes {
+		if s == shapes.DynamicDim {
+			if operandShape.Dimensions[i] == shapes.DynamicDim {
+				return nil, errors.Errorf("recomputeGatherData: operand axis %d is still DynamicDim after resolution", i)
+			}
+			needsUpdate = true
+			break
+		}
+	}
+	if !needsUpdate {
+		return g, nil
+	}
+
+	newData := &gatherNode{
+		indexVectorAxis:     g.indexVectorAxis,
+		offsetOutputAxes:    slices.Clone(g.offsetOutputAxes),
+		collapsedSlicesAxes: slices.Clone(g.collapsedSlicesAxes),
+		startIndexMap:       slices.Clone(g.startIndexMap),
+		sliceSizes:          slices.Clone(g.sliceSizes),
+		indicesAreSorted:    g.indicesAreSorted,
+	}
+	for i, s := range newData.sliceSizes {
+		if s == shapes.DynamicDim {
+			newData.sliceSizes[i] = operandShape.Dimensions[i]
+		}
+	}
+	return newData, nil
 }
 
 // EqualNodeData implements nodeDataComparable for gatherNode.

--- a/internal/gobackend/ops/gen_dtypemaps_registration.go
+++ b/internal/gobackend/ops/gen_dtypemaps_registration.go
@@ -298,6 +298,10 @@ func init() {
 	reduceWindowProductDTypeMap.Register(dtypes.Float16, gobackend.PriorityGeneric, reduceWindowProductBuildUpdateFnHalf[float16.Float16])
 
 	// DTypeMap: reduceWindowSumDTypeMap
+	reduceWindowSumDTypeMap.Register(dtypes.BFloat16, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFnHalf[bfloat16.BFloat16])
+	reduceWindowSumDTypeMap.Register(dtypes.Float16, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFnHalf[float16.Float16])
+
+	// DTypeMap: reduceWindowSumDTypeMap
 	reduceWindowSumDTypeMap.Register(dtypes.Float32, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFn[float32])
 	reduceWindowSumDTypeMap.Register(dtypes.Float64, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFn[float64])
 	reduceWindowSumDTypeMap.Register(dtypes.Int16, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFn[int16])
@@ -308,10 +312,6 @@ func init() {
 	reduceWindowSumDTypeMap.Register(dtypes.Uint32, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFn[uint32])
 	reduceWindowSumDTypeMap.Register(dtypes.Uint64, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFn[uint64])
 	reduceWindowSumDTypeMap.Register(dtypes.Uint8, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFn[uint8])
-
-	// DTypeMap: reduceWindowSumDTypeMap
-	reduceWindowSumDTypeMap.Register(dtypes.BFloat16, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFnHalf[bfloat16.BFloat16])
-	reduceWindowSumDTypeMap.Register(dtypes.Float16, gobackend.PriorityGeneric, reduceWindowSumBuildUpdateFnHalf[float16.Float16])
 
 	// DTypeMap: scatterDTypeMap
 	scatterDTypeMap.Register(dtypes.BFloat16, gobackend.PriorityGeneric, execScatterGeneric[bfloat16.BFloat16])

--- a/internal/gobackend/ops/if.go
+++ b/internal/gobackend/ops/if.go
@@ -128,7 +128,7 @@ func execIf(
 	}
 
 	// Execute the branch with proper donation of captured values
-	outputs, err := branchFn.Compiled.Execute(backend, nil, nil, capturedInputs, donateCaptures)
+	outputs, err := branchFn.Compiled.Execute(backend, nil, nil, capturedInputs, donateCaptures, nil)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "If: executing branch")
 	}

--- a/internal/gobackend/ops/pad.go
+++ b/internal/gobackend/ops/pad.go
@@ -23,7 +23,7 @@ func Pad(f *gobackend.Function, operandOp, fillValueOp compute.Value, axesConfig
 	}
 	operand, fillValue := inputs[0], inputs[1]
 
-	outputShape, err := shapeinference.PadOp(operand.Shape, axesConfig...)
+	outputShape, err := shapeinference.Pad(operand.Shape, axesConfig...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/reduce.go
+++ b/internal/gobackend/ops/reduce.go
@@ -100,7 +100,7 @@ func reduceImpls(f *gobackend.Function, reduceOpType compute.OpType, operandValu
 			axes = append(axes, axis)
 		}
 	}
-	outputShape, err := shapeinference.ReduceOp(operand.Shape, axes)
+	outputShape, err := shapeinference.Reduce(operand.Shape, axes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/reducewindow.go
+++ b/internal/gobackend/ops/reducewindow.go
@@ -64,7 +64,7 @@ func ReduceWindow(f *gobackend.Function,
 		return nil, err
 	}
 	operand := inputs[0]
-	outputShape, err := shapeinference.ReduceWindowOp(
+	outputShape, err := shapeinference.ReduceWindow(
 		operand.Shape,
 		windowDimensions,
 		strides,

--- a/internal/gobackend/ops/reshape.go
+++ b/internal/gobackend/ops/reshape.go
@@ -21,7 +21,7 @@ func Reshape(f *gobackend.Function, operandValue compute.Value, dims ...int) (co
 	}
 	operand := inputs[0]
 	opType := compute.OpTypeReshape
-	outputShape, err := shapeinference.ReshapeOp(operand.Shape, dims)
+	outputShape, err := shapeinference.Reshape(operand.Shape, dims)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/scatter.go
+++ b/internal/gobackend/ops/scatter.go
@@ -102,7 +102,7 @@ func scatterImpls(
 	}
 	operand, indices, updates := inputs[0], inputs[1], inputs[2]
 	// Check that parameters are valid.
-	outputShape, err := shapeinference.ScatterOp(
+	outputShape, err := shapeinference.Scatter(
 		operand.Shape,
 		indices.Shape,
 		updates.Shape,

--- a/internal/gobackend/ops/slice.go
+++ b/internal/gobackend/ops/slice.go
@@ -125,7 +125,7 @@ func Slice(f *gobackend.Function, operandOp compute.Value, starts, limits, strid
 	}
 
 	// Calculate output shape.
-	outputShape, err := shapeinference.SliceOp(operand.Shape, data.starts, data.limits, data.strides)
+	outputShape, err := shapeinference.Slice(operand.Shape, data.starts, data.limits, data.strides)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/slice.go
+++ b/internal/gobackend/ops/slice.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/internal/gobackend"
 	"github.com/gomlx/compute/shapeinference"
+	"github.com/gomlx/compute/shapes"
 	"github.com/pkg/errors"
 )
 
@@ -17,6 +18,37 @@ func init() {
 // sliceNode is attached to the gobackend.Node.data field for Slice.
 type sliceNode struct {
 	starts, limits, strides []int
+}
+
+// Recompute implements gobackend.RecomputableNodeData for sliceNode.
+func (s *sliceNode) Recompute(backend *gobackend.Backend, resolvedNodes []*gobackend.Node, originalNode *gobackend.Node) (any, error) {
+	operandShape := resolvedNodes[originalNode.Inputs[0].Index].Shape
+
+	needsUpdate := false
+	for i, lim := range s.limits {
+		if lim == shapes.DynamicDim {
+			if operandShape.Dimensions[i] == shapes.DynamicDim {
+				return nil, errors.Errorf("recomputeSliceData: operand axis %d is still DynamicDim after resolution", i)
+			}
+			needsUpdate = true
+			break
+		}
+	}
+	if !needsUpdate {
+		return s, nil
+	}
+
+	newData := &sliceNode{
+		starts:  slices.Clone(s.starts),
+		limits:  slices.Clone(s.limits),
+		strides: slices.Clone(s.strides),
+	}
+	for i, lim := range newData.limits {
+		if lim == shapes.DynamicDim {
+			newData.limits[i] = operandShape.Dimensions[i]
+		}
+	}
+	return newData, nil
 }
 
 // EqualNodeData implements nodeDataComparable for sliceNode.
@@ -62,20 +94,26 @@ func Slice(f *gobackend.Function, operandOp compute.Value, starts, limits, strid
 		strides: make([]int, rank),
 	}
 	for axis := 0; axis < rank; axis++ {
+		dimSize := operand.Shape.Dimensions[axis]
+
 		// Start
 		start := starts[axis]
-		if start < 0 {
-			start = operand.Shape.Dimensions[axis] + start
+		if dimSize != shapes.DynamicDim {
+			if start < 0 {
+				start = dimSize + start
+			}
+			start = min(max(start, 0), dimSize)
 		}
-		start = min(max(start, 0), operand.Shape.Dimensions[axis])
 		data.starts[axis] = start
 
 		// Limit
 		limit := limits[axis]
-		if limit < 0 {
-			limit = operand.Shape.Dimensions[axis] + limit
+		if dimSize != shapes.DynamicDim {
+			if limit < 0 {
+				limit = dimSize + limit
+			}
+			limit = min(max(limit, 0), dimSize)
 		}
-		limit = min(max(limit, 0), operand.Shape.Dimensions[axis])
 		data.limits[axis] = limit
 
 		// Stride

--- a/internal/gobackend/ops/sort.go
+++ b/internal/gobackend/ops/sort.go
@@ -264,7 +264,7 @@ func execSort(backend *gobackend.Backend, node *gobackend.Node, inputs []*goback
 					}
 
 					// Execute comparator - DON'T donate captured inputs, they're reused
-					compOutputs, err := compFn.Compiled.Execute(backend, compInputs, nil, compCaptured, nil)
+					compOutputs, err := compFn.Compiled.Execute(backend, compInputs, nil, compCaptured, nil, nil)
 					if err != nil {
 						panic(err) // Abort sort immediately
 					}

--- a/internal/gobackend/ops/transpose.go
+++ b/internal/gobackend/ops/transpose.go
@@ -30,7 +30,7 @@ func Transpose(f *gobackend.Function, operandValue compute.Value, permutations .
 	}
 	operand := inputs[0]
 
-	outputShape, err := shapeinference.TransposeOp(operand.Shape, permutations)
+	outputShape, err := shapeinference.Transpose(operand.Shape, permutations)
 	if err != nil {
 		// This should have been validated during graph build, but we check again just in case.
 		return nil, err

--- a/internal/gobackend/ops/where.go
+++ b/internal/gobackend/ops/where.go
@@ -18,7 +18,7 @@ func Where(f *gobackend.Function, conditionOp, onTrueOp, onFalseOp compute.Value
 		return nil, err
 	}
 	condition, onTrue, onFalse := inputs[0], inputs[1], inputs[2]
-	outputShape, err := shapeinference.WhereOp(condition.Shape, onTrue.Shape, onFalse.Shape)
+	outputShape, err := shapeinference.Where(condition.Shape, onTrue.Shape, onFalse.Shape)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/while.go
+++ b/internal/gobackend/ops/while.go
@@ -142,7 +142,7 @@ func execWhile(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobac
 	// Loop while condition is true
 	for iter := 0; ; iter++ {
 		// Evaluate condition - DON'T donate state or captured buffers since we may need them
-		condOutputs, err := condFn.Compiled.Execute(backend, state, nil, condCaptured, nil)
+		condOutputs, err := condFn.Compiled.Execute(backend, state, nil, condCaptured, nil, nil)
 		if err != nil {
 			return nil, errors.WithMessagef(err, "While: evaluating condition at iteration %d", iter)
 		}
@@ -167,7 +167,7 @@ func execWhile(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobac
 
 		// Execute body to get new state
 		// DON'T donate captured buffers - they're reused across iterations
-		newState, err := bodyFn.Compiled.Execute(backend, state, donateState, bodyCaptured, nil)
+		newState, err := bodyFn.Compiled.Execute(backend, state, donateState, bodyCaptured, nil, nil)
 		// After bodyFn, all donated state is consumed.
 		donateState = donateAll // After first iteration, we always own everything
 

--- a/internal/gobackend/specialization.go
+++ b/internal/gobackend/specialization.go
@@ -40,12 +40,12 @@ func hasDynamicParameters(params []*Node) bool {
 // shapes against concrete input buffer shapes. Returns merged bindings across all
 // parameters, or an error if shapes are incompatible or bindings conflict.
 func extractBindingsFromInputs(params []*Node, inputs []*Buffer) (shapes.AxisBindings, error) {
-	var allBindings []shapes.AxisBindings
+	bindings := make(shapes.AxisBindings)
 	for i, param := range params {
 		if !param.Shape.IsDynamic() {
 			continue
 		}
-		b, err := shapes.ExtractBindings(param.Shape, inputs[i].RawShape)
+		err := bindings.Extract(param.Shape, inputs[i].RawShape)
 		if err != nil {
 			paramName := ""
 			if pd, ok := param.Data.(*NodeParameter); ok {
@@ -53,12 +53,8 @@ func extractBindingsFromInputs(params []*Node, inputs []*Buffer) (shapes.AxisBin
 			}
 			return nil, errors.WithMessagef(err, "parameter %d %q", i, paramName)
 		}
-		allBindings = append(allBindings, b)
 	}
-	if len(allBindings) == 0 {
-		return shapes.AxisBindings{}, nil
-	}
-	return shapes.MergeBindings(allBindings...)
+	return bindings, nil
 }
 
 // createSpecialization builds a ShapeSpecialization for the given bindings.

--- a/internal/gobackend/specialization.go
+++ b/internal/gobackend/specialization.go
@@ -66,18 +66,6 @@ func extractBindingsFromInputs(params []*Node, inputs []*Buffer) (shapes.AxisBin
 // multiOutputsNodes pointers to the resolved copies, and recomputes
 // shape-dependent node.Data for operations that implement RecomputableNodeData.
 func (e *Executable) createSpecialization(bindings shapes.AxisBindings) (spec *ShapeSpecialization, err error) {
-	// shapes.Shape.Resolve panics on missing bindings, non-positive values, or unnamed
-	// dynamic axes. Recover those panics and surface them as errors.
-	defer func() {
-		if r := recover(); r != nil {
-			spec = nil
-			if rErr, ok := r.(error); ok {
-				err = errors.WithMessage(rErr, "createSpecialization")
-			} else {
-				err = errors.Errorf("createSpecialization: %v", r)
-			}
-		}
-	}()
 
 	origNodes := e.builder.MainFn.Nodes
 	resolved := make([]*Node, len(origNodes))
@@ -87,12 +75,16 @@ func (e *Executable) createSpecialization(bindings shapes.AxisBindings) (spec *S
 		if orig == nil {
 			continue
 		}
+		resolvedShape, err := orig.Shape.Resolve(bindings)
+		if err != nil {
+			return nil, errors.WithMessage(err, "createSpecialization: Shape.Resolve")
+		}
 		n := &Node{
 			Index:              orig.Index,
 			Inputs:             orig.Inputs,
 			CapturedInputs:     orig.CapturedInputs,
 			OpType:             orig.OpType,
-			Shape:              orig.Shape.Resolve(bindings),
+			Shape:              resolvedShape,
 			Builder:            orig.Builder,
 			Function:           orig.Function,
 			Data:               orig.Data,
@@ -104,7 +96,10 @@ func (e *Executable) createSpecialization(bindings shapes.AxisBindings) (spec *S
 		if orig.MultiOutputsShapes != nil {
 			n.MultiOutputsShapes = make([]shapes.Shape, len(orig.MultiOutputsShapes))
 			for j, s := range orig.MultiOutputsShapes {
-				n.MultiOutputsShapes[j] = s.Resolve(bindings)
+				n.MultiOutputsShapes[j], err = s.Resolve(bindings)
+				if err != nil {
+					return nil, errors.WithMessage(err, "createSpecialization: Shape.Resolve multi-output")
+				}
 			}
 			// MultiOutputsNodes will be rewired in the second pass.
 			n.MultiOutputsNodes = orig.MultiOutputsNodes

--- a/internal/gobackend/specialization.go
+++ b/internal/gobackend/specialization.go
@@ -29,7 +29,7 @@ type ShapeSpecialization struct {
 // hasDynamicParameters returns true if any parameter node has dynamic dimensions.
 func hasDynamicParameters(params []*Node) bool {
 	for _, p := range params {
-		if p.Shape.HasDynamicDims() {
+		if p.Shape.IsDynamic() {
 			return true
 		}
 	}
@@ -42,7 +42,7 @@ func hasDynamicParameters(params []*Node) bool {
 func extractBindingsFromInputs(params []*Node, inputs []*Buffer) (shapes.AxisBindings, error) {
 	var allBindings []shapes.AxisBindings
 	for i, param := range params {
-		if !param.Shape.HasDynamicDims() {
+		if !param.Shape.IsDynamic() {
 			continue
 		}
 		b, err := shapes.ExtractBindings(param.Shape, inputs[i].RawShape)
@@ -150,13 +150,13 @@ func (e *Executable) createSpecialization(bindings shapes.AxisBindings) (spec *S
 // anyInputHasDynamicDims returns true if any input (including captured) of the node has dynamic dimensions.
 func anyInputHasDynamicDims(n *Node) bool {
 	for _, input := range n.Inputs {
-		if input.Shape.HasDynamicDims() {
+		if input.Shape.IsDynamic() {
 			return true
 		}
 	}
 	for _, closureCaptures := range n.CapturedInputs {
 		for _, capturedInput := range closureCaptures {
-			if capturedInput.Shape.HasDynamicDims() {
+			if capturedInput.Shape.IsDynamic() {
 				return true
 			}
 		}

--- a/internal/gobackend/specialization.go
+++ b/internal/gobackend/specialization.go
@@ -1,0 +1,180 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package gobackend
+
+import (
+	"github.com/gomlx/compute/shapes"
+	"github.com/pkg/errors"
+)
+
+// ShapeSpecialization holds a resolved-shape copy of the graph nodes
+// for a specific set of axis bindings. Each specialization is created
+// lazily on first execution with a given binding and cached for reuse.
+//
+// The resolvedNodes are shallow copies of the original Function.nodes.
+// Only the shape field (and multiOutputsShapes for multi-output nodes)
+// is resolved; all other fields (inputs, capturedInputs, opType, etc.)
+// are shared with the originals. This allows executor functions to read
+// node.Shape and get concrete values without any signature changes.
+type ShapeSpecialization struct {
+	// bindings that produced this specialization.
+	bindings shapes.AxisBindings
+
+	// resolvedNodes is a shallow copy of the original Function.Nodes slice.
+	// Each node has its Shape field resolved (no DynamicDim values).
+	// All other fields (Inputs, Data, OpType, etc.) point to the originals.
+	resolvedNodes []*Node
+}
+
+// hasDynamicParameters returns true if any parameter node has dynamic dimensions.
+func hasDynamicParameters(params []*Node) bool {
+	for _, p := range params {
+		if p.Shape.HasDynamicDims() {
+			return true
+		}
+	}
+	return false
+}
+
+// extractBindingsFromInputs extracts axis bindings by matching symbolic parameter
+// shapes against concrete input buffer shapes. Returns merged bindings across all
+// parameters, or an error if shapes are incompatible or bindings conflict.
+func extractBindingsFromInputs(params []*Node, inputs []*Buffer) (shapes.AxisBindings, error) {
+	var allBindings []shapes.AxisBindings
+	for i, param := range params {
+		if !param.Shape.HasDynamicDims() {
+			continue
+		}
+		b, err := shapes.ExtractBindings(param.Shape, inputs[i].RawShape)
+		if err != nil {
+			paramName := ""
+			if pd, ok := param.Data.(*NodeParameter); ok {
+				paramName = pd.Name
+			}
+			return nil, errors.WithMessagef(err, "parameter %d %q", i, paramName)
+		}
+		allBindings = append(allBindings, b)
+	}
+	if len(allBindings) == 0 {
+		return shapes.AxisBindings{}, nil
+	}
+	return shapes.MergeBindings(allBindings...)
+}
+
+// createSpecialization builds a ShapeSpecialization for the given bindings.
+// It creates shallow copies of all nodes with shapes resolved, rewires
+// multiOutputsNodes pointers to the resolved copies, and recomputes
+// shape-dependent node.Data for operations that implement RecomputableNodeData.
+func (e *Executable) createSpecialization(bindings shapes.AxisBindings) (spec *ShapeSpecialization, err error) {
+	// shapes.Shape.Resolve panics on missing bindings, non-positive values, or unnamed
+	// dynamic axes. Recover those panics and surface them as errors.
+	defer func() {
+		if r := recover(); r != nil {
+			spec = nil
+			if rErr, ok := r.(error); ok {
+				err = errors.WithMessage(rErr, "createSpecialization")
+			} else {
+				err = errors.Errorf("createSpecialization: %v", r)
+			}
+		}
+	}()
+
+	origNodes := e.builder.MainFn.Nodes
+	resolved := make([]*Node, len(origNodes))
+
+	// First pass: shallow copy each node and resolve its shape.
+	for i, orig := range origNodes {
+		if orig == nil {
+			continue
+		}
+		n := &Node{
+			Index:              orig.Index,
+			Inputs:             orig.Inputs,
+			CapturedInputs:     orig.CapturedInputs,
+			OpType:             orig.OpType,
+			Shape:              orig.Shape.Resolve(bindings),
+			Builder:            orig.Builder,
+			Function:           orig.Function,
+			Data:               orig.Data,
+			IsNodeSelectOutput: orig.IsNodeSelectOutput,
+			SelectOutputIdx:    orig.SelectOutputIdx,
+		}
+
+		// Resolve multi-output shapes if present.
+		if orig.MultiOutputsShapes != nil {
+			n.MultiOutputsShapes = make([]shapes.Shape, len(orig.MultiOutputsShapes))
+			for j, s := range orig.MultiOutputsShapes {
+				n.MultiOutputsShapes[j] = s.Resolve(bindings)
+			}
+			// MultiOutputsNodes will be rewired in the second pass.
+			n.MultiOutputsNodes = orig.MultiOutputsNodes
+		}
+
+		resolved[i] = n
+	}
+
+	// Second pass: rewire MultiOutputsNodes to point to resolved copies.
+	for _, n := range resolved {
+		if n == nil {
+			continue
+		}
+		if n.MultiOutputsNodes != nil {
+			rewired := make([]*Node, len(n.MultiOutputsNodes))
+			for i, sub := range n.MultiOutputsNodes {
+				rewired[i] = resolved[sub.Index]
+			}
+			n.MultiOutputsNodes = rewired
+		}
+	}
+
+	// Third pass: recompute shape-dependent node.Data for ops that need it.
+	for i, orig := range origNodes {
+		if orig == nil || !anyInputHasDynamicDims(orig) {
+			continue // Static inputs → original data is fine
+		}
+		if recomputable, ok := orig.Data.(RecomputableNodeData); ok {
+			newData, recomputeErr := recomputable.Recompute(e.backend, resolved, orig)
+			if recomputeErr != nil {
+				return nil, errors.WithMessagef(recomputeErr, "specialization: recomputing data for node %d (%s)", i, orig.OpType)
+			}
+			resolved[i].Data = newData
+		}
+	}
+
+	return &ShapeSpecialization{
+		bindings:      bindings,
+		resolvedNodes: resolved,
+	}, nil
+}
+
+// anyInputHasDynamicDims returns true if any input (including captured) of the node has dynamic dimensions.
+func anyInputHasDynamicDims(n *Node) bool {
+	for _, input := range n.Inputs {
+		if input.Shape.HasDynamicDims() {
+			return true
+		}
+	}
+	for _, closureCaptures := range n.CapturedInputs {
+		for _, capturedInput := range closureCaptures {
+			if capturedInput.Shape.HasDynamicDims() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getOrCreateSpecialization returns a cached specialization for the given bindings,
+// creating one if it doesn't exist. Thread-safe via sync.Map.
+func (e *Executable) getOrCreateSpecialization(bindings shapes.AxisBindings) (*ShapeSpecialization, error) {
+	key := bindings.Key()
+	if spec, ok := e.specializations.Load(key); ok {
+		return spec.(*ShapeSpecialization), nil
+	}
+	newSpec, err := e.createSpecialization(bindings)
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := e.specializations.LoadOrStore(key, newSpec)
+	return actual.(*ShapeSpecialization), nil
+}

--- a/notimplemented/gen_standard_ops.go
+++ b/notimplemented/gen_standard_ops.go
@@ -203,8 +203,10 @@ func (f Function) Div(lhs compute.Value, rhs compute.Value) (compute.Value, erro
 //   - Contracted (contracting axes), where the output does multiply the values and reduce sum
 //     those dimensions.
 //
-// It follows that the resulting dimension number starts with the batch dimension, then the 'lhs'
-// non-contracting/non-batch dimension, and finally the 'rhs' non-contracting/non-batch dimension.
+// The resulting shape is [batchIndices..., <lhs cross indices...>, <rhs cross indices...>], the
+// indices come in the order they were provided. The output dtype is by default the same as
+// the input, except if configured otherwise in config.OutputDType.
+//
 // It provides the basic means of implementing Einsum.
 func (f Function) DotGeneral(lhs compute.Value, lhsContractingAxes []int, lhsBatchAxes []int, rhs compute.Value, rhsContractingAxes []int, rhsBatchAxes []int, config compute.DotGeneralConfig) (compute.Value, error) {
 	return nil, f.baseErrFn(compute.OpTypeDotGeneral)

--- a/shapeinference/convgeneral_test.go
+++ b/shapeinference/convgeneral_test.go
@@ -242,7 +242,7 @@ func TestConvGeneralOp(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := ConvGeneralOp(tc.input, tc.kernel, tc.axes,
+			output, err := ConvGeneral(tc.input, tc.kernel, tc.axes,
 				tc.strides, tc.paddings, tc.inputDilations, tc.kernelDilations,
 				tc.channelGroupCount, tc.batchGroupCount)
 			if tc.expectedError != "" {

--- a/shapeinference/dotgeneral.go
+++ b/shapeinference/dotgeneral.go
@@ -46,8 +46,10 @@ func DotGeneral(
 		if rAxis < 0 || rAxis >= rhs.Rank() {
 			return output, errors.Errorf("DotGeneral rhs contracting axis %d out of bounds for rank %d", rAxis, rhs.Rank())
 		}
-		if lhs.Dimensions[axis] != rhs.Dimensions[rAxis] {
-			return output, errors.Errorf("DotGeneral contracting dimensions do not match: lhs[%d]=%d, rhs[%d]=%d", axis, lhs.Dimensions[axis], rAxis, rhs.Dimensions[rAxis])
+		lDim := lhs.Dimensions[axis]
+		rDim := rhs.Dimensions[rAxis]
+		if lDim != shapes.DynamicDim && rDim != shapes.DynamicDim && lDim != rDim {
+			return output, errors.Errorf("DotGeneral contracting dimensions do not match: lhs[%d]=%d, rhs[%d]=%d", axis, lDim, rAxis, rDim)
 		}
 	}
 
@@ -64,8 +66,10 @@ func DotGeneral(
 		if rAxis < 0 || rAxis >= rhs.Rank() {
 			return output, errors.Errorf("DotGeneral rhs batch axis %d out of bounds for rank %d", rAxis, rhs.Rank())
 		}
-		if lhs.Dimensions[axis] != rhs.Dimensions[rAxis] {
-			return output, errors.Errorf("DotGeneral batch dimensions do not match: lhs[%d]=%d, rhs[%d]=%d", axis, lhs.Dimensions[axis], rAxis, rhs.Dimensions[rAxis])
+		lDim := lhs.Dimensions[axis]
+		rDim := rhs.Dimensions[rAxis]
+		if lDim != shapes.DynamicDim && rDim != shapes.DynamicDim && lDim != rDim {
+			return output, errors.Errorf("DotGeneral batch dimensions do not match: lhs[%d]=%d, rhs[%d]=%d", axis, lDim, rAxis, rDim)
 		}
 	}
 
@@ -90,20 +94,50 @@ func DotGeneral(
 
 	outputRank := len(lhsBatchAxes) + (lhs.Rank() - len(lhsBatchAxes) - len(lhsContractingAxes)) + (rhs.Rank() - len(rhsBatchAxes) - len(rhsContractingAxes))
 	dims := make([]int, 0, outputRank)
+	var axisNames []string
+	if lhs.AxisNames != nil || rhs.AxisNames != nil {
+		axisNames = make([]string, 0, outputRank)
+	}
 
-	for _, axis := range lhsBatchAxes {
-		dims = append(dims, lhs.Dimensions[axis])
+	for i, axis := range lhsBatchAxes {
+		lDim := lhs.Dimensions[axis]
+		rDim := rhs.Dimensions[rhsBatchAxes[i]]
+		if lDim == shapes.DynamicDim || rDim == shapes.DynamicDim {
+			dims = append(dims, shapes.DynamicDim)
+		} else {
+			dims = append(dims, lDim)
+		}
+		if axisNames != nil {
+			lName := lhs.AxisName(axis)
+			rName := rhs.AxisName(rhsBatchAxes[i])
+			unified, err := shapes.UnifyAxisName(lName, rName)
+			if err != nil {
+				return output, errors.Wrapf(err, "axis name conflict in DotGeneral batch axis %d", i)
+			}
+			axisNames = append(axisNames, unified)
+		}
 	}
 	for axis := 0; axis < lhs.Rank(); axis++ {
 		if !isLHSUsed[axis] {
 			dims = append(dims, lhs.Dimensions[axis])
+			if axisNames != nil {
+				axisNames = append(axisNames, lhs.AxisName(axis))
+			}
 		}
 	}
 	for axis := 0; axis < rhs.Rank(); axis++ {
 		if !isRHSUsed[axis] {
 			dims = append(dims, rhs.Dimensions[axis])
+			if axisNames != nil {
+				axisNames = append(axisNames, rhs.AxisName(axis))
+			}
 		}
 	}
 
-	return shapes.Make(outDType, dims...), nil
+	output = shapes.Shape{
+		DType:      outDType,
+		Dimensions: dims,
+		AxisNames:  axisNames,
+	}
+	return output, nil
 }

--- a/shapeinference/dotgeneral.go
+++ b/shapeinference/dotgeneral.go
@@ -48,7 +48,11 @@ func DotGeneral(
 		}
 		lDim := lhs.Dimensions[axis]
 		rDim := rhs.Dimensions[rAxis]
-		if lDim != shapes.DynamicDim && rDim != shapes.DynamicDim && lDim != rDim {
+		if lDim == shapes.DynamicDim && rDim == shapes.DynamicDim {
+			if lhs.AxisName(axis) != rhs.AxisName(rAxis) {
+				return output, errors.Errorf("DotGeneral contracting axis #%d has different axis names (axis name conflict) for lhs (%q) and rhs (%q)", i, lhs.AxisName(axis), rhs.AxisName(rAxis))
+			}
+		} else if lDim != shapes.DynamicDim && rDim != shapes.DynamicDim && lDim != rDim {
 			return output, errors.Errorf("DotGeneral contracting dimensions do not match: lhs[%d]=%d, rhs[%d]=%d", axis, lDim, rAxis, rDim)
 		}
 	}
@@ -68,7 +72,11 @@ func DotGeneral(
 		}
 		lDim := lhs.Dimensions[axis]
 		rDim := rhs.Dimensions[rAxis]
-		if lDim != shapes.DynamicDim && rDim != shapes.DynamicDim && lDim != rDim {
+		if lDim == shapes.DynamicDim && rDim == shapes.DynamicDim {
+			if lhs.AxisName(axis) != rhs.AxisName(rAxis) {
+				return output, errors.Errorf("DotGeneral batch axis #%d has different axis names (axis name conflict) for lhs (%q) and rhs (%q)", i, lhs.AxisName(axis), rhs.AxisName(rAxis))
+			}
+		} else if lDim != shapes.DynamicDim && rDim != shapes.DynamicDim && lDim != rDim {
 			return output, errors.Errorf("DotGeneral batch dimensions do not match: lhs[%d]=%d, rhs[%d]=%d", axis, lDim, rAxis, rDim)
 		}
 	}

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -554,8 +554,18 @@ func Transpose(operand shapes.Shape, permutations []int) (output shapes.Shape, e
 	return
 }
 
-// BroadcastInDim verifies that the arguments are valid. The output shape is already known, so nothing is returned.
-func BroadcastInDim(operand, outputShape shapes.Shape, broadcastAxes []int) error {
+// BroadcastInDim verifies that the arguments are valid.
+//
+// The output shape is the same as the input is already known, so nothing is returned.
+//
+// Dynamic shapes: When broadcasting, an operand axis with a dynamic length
+// cannot be broadcast and must be preserved as dynamic in the output -- their axis names
+// must exactly match in the outputShape.
+// But new dynamic dimensions can be introduced in the output -- either mapping from an axis with dimension 1,
+// or from a newly introduced axis. Notice that introducing new dynamic axis names that are not resolved
+// by any input parameter will result in an error.
+func BroadcastInDim(operand, outputShape shapes.Shape, broadcastAxes []int,
+	knownDynamicAxisNames sets.Set[string]) error {
 	if len(broadcastAxes) != operand.Rank() {
 		return errors.Errorf("there must be exactly one broadcastAxes (%v) per axis in the operand (%s)",
 			broadcastAxes, operand)
@@ -575,13 +585,52 @@ func BroadcastInDim(operand, outputShape shapes.Shape, broadcastAxes []int) erro
 				broadcastAxes, axisInOutput, axisInOperand, outputShape.Rank()-1)
 		}
 		preservedSet.Insert(axisInOutput)
-		oDim := operand.Dimensions[axisInOperand]
+		inDim := operand.Dimensions[axisInOperand]
 		outDim := outputShape.Dimensions[axisInOutput]
-		if oDim != shapes.DynamicDim && outDim != shapes.DynamicDim && oDim != 1 && oDim != outDim {
+
+		if inDim == shapes.DynamicDim {
+			if outDim != shapes.DynamicDim {
+				return errors.Errorf("dynamic axis %d in operand shape %s mapped to broadcastAxes[%d]=%d must be preserved as dynamic in output shape %s", axisInOperand, operand, axisInOperand, axisInOutput, outputShape)
+			}
+			nameOperand := ""
+			if operand.AxisNames != nil {
+				nameOperand = operand.AxisNames[axisInOperand]
+			}
+			nameOutput := ""
+			if outputShape.AxisNames != nil {
+				nameOutput = outputShape.AxisNames[axisInOutput]
+			}
+			if nameOperand != nameOutput {
+				return errors.Errorf("dynamic axis %d in operand shape %s mapped to broadcastAxes[%d]=%d must preserve its axis name %q, but output shape %s has axis name %q", axisInOperand, operand, axisInOperand, axisInOutput, nameOperand, outputShape, nameOutput)
+			}
+		} else if inDim != 1 && inDim != outDim {
 			return errors.Errorf("the values of outputShape (%v) that are being broadcast (listed in broadcastAxes) "+
 				"must match the corresponding value in the operand shape (%s) or be 1 (if broadcasting), "+
 				"but the value of outputShape.Dimensions[%d]=%d does not match the value in operand.Shape().Dimensions[%d]=%d",
-				outputShape, operand, axisInOutput, outDim, axisInOperand, oDim)
+				outputShape, operand, axisInOutput, outDim, axisInOperand, inDim)
+		}
+
+		if outDim == shapes.DynamicDim && inDim != shapes.DynamicDim {
+			// Newly introduced dynamic axis by broadcasting dimension 1
+			name := ""
+			if outputShape.AxisNames != nil {
+				name = outputShape.AxisNames[axisInOutput]
+			}
+			if knownDynamicAxisNames == nil || !knownDynamicAxisNames.Has(name) {
+				return errors.Errorf("cannot introduce an unknown dynamic axis name -- the dynamic axis must be known from the input parameters (axis %d with name %q, known: %v)", axisInOutput, name, knownDynamicAxisNames)
+			}
+		}
+	}
+
+	for axisInOutput, outDim := range outputShape.Dimensions {
+		if !preservedSet.Has(axisInOutput) && outDim == shapes.DynamicDim {
+			name := ""
+			if outputShape.AxisNames != nil {
+				name = outputShape.AxisNames[axisInOutput]
+			}
+			if knownDynamicAxisNames == nil || !knownDynamicAxisNames.Has(name) {
+				return errors.Errorf("cannot introduce an unknown dynamic axis name -- the dynamic axis must be known from the input parameters (axis %d with name %q, known: %v)", axisInOutput, name, knownDynamicAxisNames)
+			}
 		}
 	}
 	return nil

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -351,7 +351,7 @@ func UnaryOp(opType compute.OpType, operand shapes.Shape) (output shapes.Shape, 
 	return
 }
 
-// WhereOp returns the shape resulting from the Where operation.
+// Where returns the shape resulting from the Where operation.
 //
 // Shape constraints for the operation:
 //
@@ -362,7 +362,7 @@ func UnaryOp(opType compute.OpType, operand shapes.Shape) (output shapes.Shape, 
 //
 // Note: If you need to select between values of different dtypes, use ConvertDType to convert them
 // to a common dtype before calling Where.
-func WhereOp(condition, onTrue, onFalse shapes.Shape) (output shapes.Shape, err error) {
+func Where(condition, onTrue, onFalse shapes.Shape) (output shapes.Shape, err error) {
 	if condition.DType != dtypes.Bool {
 		err = errors.Errorf("condition for Where() must be a boolean, got %s instead", condition)
 		return
@@ -396,11 +396,11 @@ func WhereOp(condition, onTrue, onFalse shapes.Shape) (output shapes.Shape, err 
 	return
 }
 
-// ReshapeOp to the given dimensions: trivial output shape, but this function also checks
+// Reshape to the given dimensions: trivial output shape, but this function also checks
 // that the sizes are the same.
 //
 // Notice the compute.Reshape doesn't support auto-scaling dimensions (set to -1), as graph.Reshape does.
-func ReshapeOp(operand shapes.Shape, dims []int) (output shapes.Shape, err error) {
+func Reshape(operand shapes.Shape, dims []int) (output shapes.Shape, err error) {
 	if operand.HasDynamicDims() {
 		// Dynamic path: skip size validation (deferred to specialization time).
 		// DynamicDim values in target dims are allowed — they propagate through
@@ -417,10 +417,10 @@ func ReshapeOp(operand shapes.Shape, dims []int) (output shapes.Shape, err error
 	return
 }
 
-// TransposeOp all axes of the operand.
+// Transpose all axes of the operand.
 // There must be one value in permutations for each axis in the operand.
 // The output will have: output.Shape.Dimension[ii] = operand.Shape.Dimension[permutations[i]].
-func TransposeOp(operand shapes.Shape, permutations []int) (output shapes.Shape, err error) {
+func Transpose(operand shapes.Shape, permutations []int) (output shapes.Shape, err error) {
 	rank := operand.Rank()
 	if len(permutations) != rank {
 		err = errors.Errorf("Transpose() requires all axes permutations to be defined, operand has shape %s, but %d permutations were given",
@@ -458,8 +458,8 @@ func TransposeOp(operand shapes.Shape, permutations []int) (output shapes.Shape,
 	return
 }
 
-// BroadcastInDimOp verifies that the arguments are valid. The output shape is already known, so nothing is returned.
-func BroadcastInDimOp(operand, outputShape shapes.Shape, broadcastAxes []int) error {
+// BroadcastInDim verifies that the arguments are valid. The output shape is already known, so nothing is returned.
+func BroadcastInDim(operand, outputShape shapes.Shape, broadcastAxes []int) error {
 	if len(broadcastAxes) != operand.Rank() {
 		return errors.Errorf("there must be exactly one broadcastAxes (%v) per axis in the operand (%s)",
 			broadcastAxes, operand)
@@ -489,8 +489,8 @@ func BroadcastInDimOp(operand, outputShape shapes.Shape, broadcastAxes []int) er
 	return nil
 }
 
-// ReduceOp works for the ReduceMax, ReduceMin, ReduceSum and ReduceProduct ops.
-func ReduceOp(operand shapes.Shape, axes []int) (output shapes.Shape, err error) {
+// Reduce works for the ReduceMax, ReduceMin, ReduceSum and ReduceProduct ops.
+func Reduce(operand shapes.Shape, axes []int) (output shapes.Shape, err error) {
 	if len(axes) == 0 {
 		return operand, nil
 	}
@@ -644,9 +644,9 @@ func Gather(operand, startIndices shapes.Shape, indexVectorAxis int, offsetOutpu
 	return output, nil
 }
 
-// ConcatenateOp calculates the output shape of a Concatenate operation.
+// Concatenate calculates the output shape of a Concatenate operation.
 // It takes a slice of input shapes and the dimension along which to concatenate.
-func ConcatenateOp(inputs []shapes.Shape, axis int) (output shapes.Shape, err error) {
+func Concatenate(inputs []shapes.Shape, axis int) (output shapes.Shape, err error) {
 	if len(inputs) == 0 {
 		return shapes.Invalid(), errors.Errorf("ConcatenateOp requires at least one input shape")
 	}
@@ -733,11 +733,11 @@ func ConcatenateOp(inputs []shapes.Shape, axis int) (output shapes.Shape, err er
 	return output, nil
 }
 
-// ScatterOp checks that the parameters are consistent. The output shape returned is the unchanged operand -- the scattered
+// Scatter checks that the parameters are consistent. The output shape returned is the unchanged operand -- the scattered
 // updates are applied to the operand, but its shape is unchanged.
 //
 // The Scatter operations indicesAreSorted and uniqueIndices don't play a role in this.
-func ScatterOp(operand, indices, updates shapes.Shape, indexVectorAxis int, updateWindowAxes, insertedWindowAxes, scatterAxesToOperandAxes []int) (output shapes.Shape, err error) {
+func Scatter(operand, indices, updates shapes.Shape, indexVectorAxis int, updateWindowAxes, insertedWindowAxes, scatterAxesToOperandAxes []int) (output shapes.Shape, err error) {
 	if operand.DType == dtypes.InvalidDType || indices.DType == dtypes.InvalidDType || updates.DType == dtypes.InvalidDType {
 		return shapes.Invalid(), errors.Errorf("invalid shape for operand (%s), indices (%s) or updates (%s) for ScatterOp", operand, indices, updates)
 	}
@@ -815,13 +815,13 @@ func ScatterOp(operand, indices, updates shapes.Shape, indexVectorAxis int, upda
 	return operand, nil
 }
 
-// SliceOp calculates the output shape for a Slice operation.
+// Slice calculates the output shape for a Slice operation.
 // It checks that starts, limits, and strides have the correct length (matching operand rank),
 // and that the slice parameters are valid for the operand's dimensions.
 // Strides must be positive.
-func SliceOp(operand shapes.Shape, starts, limits, strides []int) (output shapes.Shape, err error) {
+func Slice(operand shapes.Shape, starts, limits, strides []int) (output shapes.Shape, err error) {
 	rank := operand.Rank()
-	opName := "SliceOp"
+	opName := "Slice"
 	if operand.DType == dtypes.InvalidDType {
 		return shapes.Invalid(), errors.Errorf("%s: invalid operand shape %s", opName, operand)
 	}
@@ -874,8 +874,8 @@ func SliceOp(operand shapes.Shape, starts, limits, strides []int) (output shapes
 	return output, nil
 }
 
-// DynamicSliceOp calculates the output shape for a DynamicSlice operation.
-func DynamicSliceOp(operand shapes.Shape, sliceSizes []int) (output shapes.Shape, err error) {
+// DynamicSlice calculates the output shape for a DynamicSlice operation.
+func DynamicSlice(operand shapes.Shape, sliceSizes []int) (output shapes.Shape, err error) {
 	if operand.DType == dtypes.InvalidDType {
 		return output, errors.Errorf("invalid operand shape %s for DynamicSlice", operand)
 	}
@@ -902,8 +902,8 @@ func DynamicSliceOp(operand shapes.Shape, sliceSizes []int) (output shapes.Shape
 	return output, nil
 }
 
-// DynamicUpdateSliceOp calculates the output shape for a DynamicUpdateSlice operation.
-func DynamicUpdateSliceOp(operand, update shapes.Shape) (output shapes.Shape, err error) {
+// DynamicUpdateSlice calculates the output shape for a DynamicUpdateSlice operation.
+func DynamicUpdateSlice(operand, update shapes.Shape) (output shapes.Shape, err error) {
 	if operand.DType != update.DType {
 		return shapes.Invalid(), errors.Errorf("DynamicUpdateSlice requires operand and update to have the same DType, got %s and %s",
 			operand.DType, update.DType)
@@ -915,9 +915,9 @@ func DynamicUpdateSliceOp(operand, update shapes.Shape) (output shapes.Shape, er
 	return operand.Clone(), nil
 }
 
-// ArgMinMaxOp calculates the output shape for an ArgMinMax operation.
+// ArgMinMax calculates the output shape for an ArgMinMax operation.
 // It will be the shape of the operand minus the "reduce" axis.
-func ArgMinMaxOp(operand shapes.Shape, axis int, outputDType dtypes.DType) (output shapes.Shape, err error) {
+func ArgMinMax(operand shapes.Shape, axis int, outputDType dtypes.DType) (output shapes.Shape, err error) {
 	if !outputDType.IsInt() {
 		err = errors.Errorf("ArgMinMax outputDType must be an integer type, got %s", outputDType)
 		return
@@ -950,10 +950,10 @@ func ArgMinMaxOp(operand shapes.Shape, axis int, outputDType dtypes.DType) (outp
 	return
 }
 
-// ReduceWindowOp returns the expected output shape for the operation.
+// ReduceWindow returns the expected output shape for the operation.
 //
 // Notice it doesn't take as input the reductionType parameter, since it doesn't affect the output shape.
-func ReduceWindowOp(operand shapes.Shape, windowDimensions, strides, baseDilations, windowDilations []int, paddings [][2]int) (shapes.Shape, error) {
+func ReduceWindow(operand shapes.Shape, windowDimensions, strides, baseDilations, windowDilations []int, paddings [][2]int) (shapes.Shape, error) {
 	if !operand.Ok() {
 		return shapes.Invalid(), errors.Errorf("ReduceWindowOp: invalid operand shape %s", operand)
 	}
@@ -1063,8 +1063,8 @@ func ReduceWindowOp(operand shapes.Shape, windowDimensions, strides, baseDilatio
 	return result, nil
 }
 
-// ConvGeneralOp returns the expected output shape for the ConvGeneral operation.
-func ConvGeneralOp(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
+// ConvGeneral returns the expected output shape for the ConvGeneral operation.
+func ConvGeneral(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 	strides []int, paddings [][2]int,
 	inputDilations, kernelDilations []int,
 	channelGroupCount, batchGroupCount int) (shapes.Shape, error) {
@@ -1171,7 +1171,7 @@ func ConvGeneralOp(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 	}
 
 	// Check that channels (feature dimensions) are valid.
-		inputChannels := input.Dim(axes.InputChannels)
+	inputChannels := input.Dim(axes.InputChannels)
 	outputChannels := kernel.Dim(axes.KernelOutputChannels)
 	if channelGroupCount < 1 {
 		return errorf("channelGroupCount=%d must be >= 1 for input shape %s", channelGroupCount, input)
@@ -1265,8 +1265,8 @@ func ConvGeneralOp(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 	return output, nil
 }
 
-// BitcastOp calculates the output shape for a Bitcast operation.
-func BitcastOp(operand shapes.Shape, targetDType dtypes.DType) (output shapes.Shape, err error) {
+// Bitcast calculates the output shape for a Bitcast operation.
+func Bitcast(operand shapes.Shape, targetDType dtypes.DType) (output shapes.Shape, err error) {
 	if operand.DType == targetDType {
 		return operand, nil
 	}
@@ -1295,8 +1295,8 @@ func BitcastOp(operand shapes.Shape, targetDType dtypes.DType) (output shapes.Sh
 	return output, nil
 }
 
-// PadOp returns the expected output shape for the Pad operation.
-func PadOp(operand shapes.Shape, axesConfig ...compute.PadAxis) (output shapes.Shape, err error) {
+// Pad returns the expected output shape for the Pad operation.
+func Pad(operand shapes.Shape, axesConfig ...compute.PadAxis) (output shapes.Shape, err error) {
 	if !operand.Ok() {
 		return shapes.Invalid(), errors.Errorf("PadOp: invalid operand shape %s", operand)
 	}

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -235,11 +235,13 @@ func BinaryOp(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (output sh
 		return
 	}
 	if NumberOperations.Has(opType) && !(lhsShape.DType.IsInt() || lhsShape.DType.IsFloat() || lhsShape.DType.IsComplex()) {
-		err = errors.Errorf("numeric BinaryOp %s must have a number (Int32, Float32, Complex64, ...) data type as input, got %s", opType, lhsShape)
+		err = errors.Errorf("numeric BinaryOp %s must have a number (Int32, Float32, BFloat16, Complex64, ...) "+
+			"data type as input, got %s", opType, lhsShape)
 		return
 	}
 	if FloatOperations.Has(opType) && !lhsShape.DType.IsFloat() {
-		err = errors.Errorf("float BinaryOp %s must have a float (Float32, Float64, ...) data type as input, got %s", opType, lhsShape)
+		err = errors.Errorf("float BinaryOp %s must have a float (Float32, Float64, ...) data type as input, got %s",
+			opType, lhsShape)
 		return
 	}
 	if FloatOrComplexOperations.Has(opType) && !(lhsShape.DType.IsFloat() || lhsShape.DType.IsComplex()) {
@@ -247,7 +249,9 @@ func BinaryOp(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (output sh
 		return
 	}
 	if ComplexOperations.Has(opType) && !lhsShape.DType.IsComplex() {
-		err = errors.Errorf("complex BinaryOp %s must have a complex (Complex64, Complex128) data type as input, got %s", opType, lhsShape)
+		err = errors.Errorf(
+			"complex BinaryOp %s must have a complex (Complex64, Complex128) data type as input, got %s",
+			opType, lhsShape)
 		return
 	}
 
@@ -265,9 +269,9 @@ func binaryOpImpl(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (outpu
 
 	// Other cases, either the dimensions match or one of them is 1.
 	if lhsShape.Rank() != rhsShape.Rank() {
-		err = errors.Errorf("if operands are not scalars, their rank must match for BinaryOp (%s), got shapes %s and %s",
+		err = errors.Errorf("if operands are not scalars, their rank must match for BinaryOp (%s); got shapes %s and %s",
 			opType, lhsShape, rhsShape)
-		return
+		return shapes.Invalid(), err
 	}
 	output = lhsShape.Clone()
 	for axis := range output.Rank() {
@@ -279,15 +283,31 @@ func binaryOpImpl(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (outpu
 				output.Dimensions[axis] = rhsDim // broadcast: use rhs (possibly dynamic)
 			} else if rhsDim == 1 {
 				output.Dimensions[axis] = lhsDim // broadcast: use lhs (possibly dynamic)
-			} else {
+			} else if lhsDim == rhsDim {
+				// Both dynamic: they must have mathing symbolic value.
+				if lhsShape.AxisNames[axis] != rhsShape.AxisNames[axis] {
+					err = errors.Errorf(
+						"axis #%d is dynamic for both operands, but have different axis names for BinaryOp (%s), "+
+							"they cannot be implicitly broadcast; got shapes %s and %s",
+						axis, opType, lhsShape, rhsShape)
+					return shapes.Invalid(), err
+				}
 				output.Dimensions[axis] = shapes.DynamicDim // both dynamic or one dynamic non-broadcast
+			} else {
+				// One side is dynamic and the other is not 1.
+				err = errors.Errorf(
+					"axis #%d is dynamic for one operand, and the other is not 1 for BinaryOp (%s), "+
+						"they can't be implicitly broadcast; got shapes %s and %s",
+					axis, opType, lhsShape, rhsShape)
+				return shapes.Invalid(), err
 			}
 			continue
 		}
 		if lhsDim != 1 && rhsDim != 1 && lhsDim != rhsDim {
-			err = errors.Errorf("dimension of axis #%d doesn't match and cannot be broadcast for BinaryOp (%s), got shapes %s and %s",
+			err = errors.Errorf(
+				"dimension of axis #%d doesn't match and cannot be broadcast for BinaryOp (%s), got shapes %s and %s",
 				axis, opType, lhsShape, rhsShape)
-			return
+			return shapes.Invalid(), err
 		}
 		output.Dimensions[axis] = max(lhsDim, rhsDim)
 	}
@@ -295,12 +315,13 @@ func binaryOpImpl(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (outpu
 	// Unify axis names.
 	output.AxisNames, err = shapes.UnifyAxisNames(lhsShape, rhsShape)
 	if err != nil {
-		err = errors.Wrapf(err, "axis name conflict in BinaryOp (%s)", opType)
+		return shapes.Invalid(), errors.Wrapf(err, "axis name conflict in BinaryOp (%s)", opType)
 	}
-	return
+	return output, nil
 }
 
-// ComparisonOp returns the broadcast shape with dtype set to Bool, for comparison operations (Equal, LessThan, GreaterOrEqual, etc.)
+// ComparisonOp returns the broadcast shape with dtype set to Bool, for comparison operations (Equal, LessThan,
+// GreaterOrEqual, etc.)
 func ComparisonOp(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (output shapes.Shape, err error) {
 	if !ComparisonOperations.Has(opType) {
 		err = errors.Errorf("operation %s is not in the ComparisonOperations set, cannot process it with ComparisonOp", opType)
@@ -489,7 +510,9 @@ func BroadcastInDim(operand, outputShape shapes.Shape, broadcastAxes []int) erro
 	preservedSet := sets.Make[int](len(broadcastAxes))
 	for axisInOperand, axisInOutput := range broadcastAxes {
 		if axisInOutput < 0 || axisInOutput >= outputShape.Rank() {
-			return errors.Errorf("broadcastAxes (%v) defines a value out-of-range (%d-th value -> %d), they must be between 0 and outputShape.Rank()-1=%d",
+			return errors.Errorf(
+				"broadcastAxes (%v) defines a value out-of-range (%d-th value -> %d), they must be "+
+					"between 0 and outputShape.Rank()-1=%d",
 				broadcastAxes, axisInOperand, axisInOutput, outputShape.Rank()-1)
 		}
 		if preservedSet.Has(axisInOutput) {

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -753,11 +753,12 @@ func Gather(operand, startIndices shapes.Shape, indexVectorAxis int, offsetOutpu
 	// - Remaining axes are filled in order from the batch axes, taken from startIndices.
 	output = shapes.Make(operand.DType)
 	output.Dimensions = make([]int, batchRank+len(offsetOutputAxes))
+	output.AxisNames = make([]string, output.Rank())
 
 	setOffsetOutputAxes := sets.Make[int]()
 	for _, offsetOutputAxis := range offsetOutputAxes {
 		if offsetOutputAxis < 0 || offsetOutputAxis >= output.Rank() {
-			return shapes.Invalid(), errors.Errorf("offset output axis %d is out of range for output of rank %d", offsetOutputAxis, output.Rank())
+			return shapes.Invalid(), errors.Errorf("offset output axis %d is out of range for output of rank %d", output.Rank(), output.Rank())
 		}
 		if setOffsetOutputAxes.Has(offsetOutputAxis) {
 			return shapes.Invalid(), errors.Errorf("offset output axis %d is defined more than once: offsetOutputAxes=%v", offsetOutputAxis, offsetOutputAxes)
@@ -765,12 +766,22 @@ func Gather(operand, startIndices shapes.Shape, indexVectorAxis int, offsetOutpu
 		setOffsetOutputAxes.Insert(offsetOutputAxis)
 	}
 	offsetDims := make([]int, 0, len(offsetOutputAxes))
+	offsetNames := make([]string, 0, len(offsetOutputAxes))
 	for axis, sliceSize := range sliceSizes {
 		if setCollapsedAxes.Has(axis) {
 			// This is a collapsed axis and not used as an offset.
 			continue
 		}
 		offsetDims = append(offsetDims, sliceSize)
+		name := ""
+		if operand.AxisNames != nil {
+			name = operand.AxisNames[axis]
+		}
+		if sliceSize != operand.Dimensions[axis] {
+			// Sliced axis: it's not the same symbolic dimension anymore.
+			name = ""
+		}
+		offsetNames = append(offsetNames, name)
 	}
 	offsetDimsIdx := 0
 	batchDimsIdx := 0
@@ -778,6 +789,7 @@ func Gather(operand, startIndices shapes.Shape, indexVectorAxis int, offsetOutpu
 		if setOffsetOutputAxes.Has(axis) {
 			// Take an offset dimension from sliceSizes:
 			output.Dimensions[axis] = offsetDims[offsetDimsIdx]
+			output.AxisNames[axis] = offsetNames[offsetDimsIdx]
 			offsetDimsIdx++
 		} else {
 			// Take a batch dimension:
@@ -785,6 +797,9 @@ func Gather(operand, startIndices shapes.Shape, indexVectorAxis int, offsetOutpu
 				batchDimsIdx++
 			}
 			output.Dimensions[axis] = startIndices.Dimensions[batchDimsIdx]
+			if startIndices.AxisNames != nil {
+				output.AxisNames[axis] = startIndices.AxisNames[batchDimsIdx]
+			}
 			batchDimsIdx++
 		}
 	}
@@ -833,7 +848,10 @@ func Concatenate(inputs []shapes.Shape, axis int) (output shapes.Shape, err erro
 			if d == axis {
 				// For concat axis: if either is dynamic, result is dynamic.
 				if output.Dimensions[d] == shapes.DynamicDim || currentShape.Dimensions[d] == shapes.DynamicDim {
-					output.Dimensions[d] = shapes.DynamicDim
+					// Concatenating on a dynamic axis is not supported yet, because we
+					// don't have axis expressions to represent the new size.
+					return shapes.Invalid(), errors.Errorf("ConcatenateOp: concatenation on a dynamic axis (%d, names %q and %q) is not supported yet (requires axis expressions)",
+						d, output.AxisName(d), currentShape.AxisName(d))
 				} else {
 					output.Dimensions[d] += currentShape.Dimensions[d]
 				}
@@ -997,9 +1015,28 @@ func Slice(operand shapes.Shape, starts, limits, strides []int) (output shapes.S
 				opName, axis, stride, operand)
 		}
 
+		// The first one is always taken, so we use the ceiling of the division.
+		outputDimSize := (limit - start + (stride - 1)) / stride
+
 		// Skip bounds validation for dynamic axes.
 		if dimSize == shapes.DynamicDim {
-			output.Dimensions[axis] = shapes.DynamicDim
+			// If outputDimSize is static (which it is here because starts/limits are []int),
+			// we can return it as static.
+			output.Dimensions[axis] = outputDimSize
+			if outputDimSize == shapes.DynamicDim {
+				// Remains dynamic: it must have a name.
+				// For now we only support "full" slices of dynamic axes to keep the same name.
+				if start != 0 || stride != 1 || limit != shapes.DynamicDim {
+					return shapes.Invalid(), errors.Errorf("%s: partial slice of a dynamic axis (%d, name %q) is not supported yet (requires axis expressions)",
+						opName, axis, operand.AxisName(axis))
+				}
+				// Identity slice: keep the name.
+			} else {
+				// Became static: drop the name (no longer a dynamic axis).
+				if output.AxisNames != nil {
+					output.AxisNames[axis] = ""
+				}
+			}
 			continue
 		}
 
@@ -1013,8 +1050,6 @@ func Slice(operand shapes.Shape, starts, limits, strides []int) (output shapes.S
 				opName, limit, axis, start, dimSize, operand)
 		}
 
-		// The first one is always taken, so we use the ceiling of the division.
-		outputDimSize := (limit - start + (stride - 1)) / stride
 		output.Dimensions[axis] = outputDimSize
 	}
 
@@ -1044,7 +1079,14 @@ func DynamicSlice(operand shapes.Shape, sliceSizes []int) (output shapes.Shape, 
 	output = shapes.Shape{
 		DType:      operand.DType,
 		Dimensions: slices.Clone(sliceSizes),
-		AxisNames:  slices.Clone(operand.AxisNames),
+		AxisNames:  make([]string, operand.Rank()),
+	}
+	for axis, sliceSize := range sliceSizes {
+		if operand.AxisNames != nil {
+			if sliceSize == operand.Dimensions[axis] {
+				output.AxisNames[axis] = operand.AxisNames[axis]
+			}
+		}
 	}
 	return output, nil
 }
@@ -1134,11 +1176,6 @@ func ReduceWindow(operand shapes.Shape, windowDimensions, strides, baseDilations
 	outputDims := make([]int, rank)
 	for i := range rank {
 		inputDim := operand.Dimensions[i]
-		// Skip output size calculation for dynamic axes — output is also dynamic.
-		if inputDim == shapes.DynamicDim {
-			outputDims[i] = shapes.DynamicDim
-			continue
-		}
 		windowDim := 1
 		if len(windowDimensions) > 0 {
 			windowDim = windowDimensions[i]
@@ -1176,6 +1213,18 @@ func ReduceWindow(operand shapes.Shape, windowDimensions, strides, baseDilations
 			if windowDilation < 1 {
 				return shapes.Invalid(), errors.Errorf("ReduceWindowOp: windowDilations[%d]=%d must be >= 1 for operand shape %s", i, windowDilation, operand)
 			}
+		}
+
+		// Skip output size calculation for dynamic axes — output is also dynamic.
+		if inputDim == shapes.DynamicDim {
+			// If it's a dynamic dimension, we currently don't support any operation that
+			// changes its size, because we don't have axis expressions to represent the new size.
+			if windowDim != 1 || stride != 1 || paddingLow != 0 || paddingHigh != 0 || baseDilation != 1 || windowDilation != 1 {
+				return shapes.Invalid(), errors.Errorf("ReduceWindowOp: operation on a dynamic axis (%d, name %q) that changes its size is not supported yet (requires axis expressions)",
+					i, operand.AxisName(i))
+			}
+			outputDims[i] = shapes.DynamicDim
+			continue
 		}
 
 		// Effective input dimension after base dilation.
@@ -1361,12 +1410,6 @@ func ConvGeneral(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 	for spatialAxisIdx, inputAxis := range axes.InputSpatial {
 		inputDim := input.Dim(inputAxis)
 
-		// Dynamic spatial dims: propagate DynamicDim without arithmetic.
-		if inputDim == shapes.DynamicDim {
-			output.Dimensions[axes.OutputSpatial[spatialAxisIdx]] = shapes.DynamicDim
-			continue
-		}
-
 		filterAxis := axes.KernelSpatial[spatialAxisIdx]
 		kernelDim := kernel.Dim(filterAxis)
 		stride := 1
@@ -1383,6 +1426,18 @@ func ConvGeneral(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 		}
 		if kernelDilations != nil {
 			kernelDilation = kernelDilations[spatialAxisIdx]
+		}
+
+		// Dynamic spatial dims: propagate DynamicDim without arithmetic.
+		if inputDim == shapes.DynamicDim {
+			// If it's a dynamic dimension, we currently don't support any operation that
+			// changes its size, because we don't have axis expressions to represent the new size.
+			if kernelDim != 1 || stride != 1 || padding[0] != 0 || padding[1] != 0 || inputDilation != 1 || kernelDilation != 1 {
+				return shapes.Invalid(), errors.Errorf("ConvGeneralOp: operation on a dynamic axis (%d, name %q) that changes its size is not supported yet (requires axis expressions)",
+					inputAxis, input.AxisName(inputAxis))
+			}
+			output.Dimensions[axes.OutputSpatial[spatialAxisIdx]] = shapes.DynamicDim
+			continue
 		}
 
 		// Calculate outputDim of the convolution.
@@ -1433,12 +1488,23 @@ func Bitcast(operand shapes.Shape, targetDType dtypes.DType) (output shapes.Shap
 		// Larger target: collapse the last axis.
 		ratio := targetBits / operandBits
 		lastDim := dims[len(dims)-1]
+		if lastDim == shapes.DynamicDim {
+			return shapes.Invalid(), errors.Errorf("Bitcast: cannot collapse a dynamic last dimension (axis %d, name %q)",
+				len(dims)-1, operand.AxisName(-1))
+		}
 		if lastDim != ratio {
 			return shapes.Invalid(), errors.Errorf("Bitcast: last dim %d is not equal to element-size ratio operandBits(%d)/targetBits(%d)=%d", lastDim, operandBits, targetBits, ratio)
 		}
 		dims = dims[:len(dims)-1]
 	}
-	output = shapes.Make(targetDType, dims...)
+
+	names := make([]string, len(dims))
+	for i := range min(len(dims), operand.Rank()) {
+		if operand.AxisNames != nil {
+			names[i] = operand.AxisNames[i]
+		}
+	}
+	output = shapes.MakeDynamic(targetDType, dims, names)
 	return output, nil
 }
 
@@ -1458,6 +1524,16 @@ func Pad(operand shapes.Shape, axesConfig ...compute.PadAxis) (output shapes.Sha
 			return shapes.Invalid(), errors.Errorf("PadOp: interior padding must be non-negative, got %d for axis %d", config.Interior, axis)
 		}
 		dim := operand.Dimensions[axis]
+		if dim == shapes.DynamicDim {
+			// If it's a dynamic dimension, we currently don't support padding, because we
+			// don't have axis expressions to represent the new size.
+			if config.Start != 0 || config.End != 0 || config.Interior != 0 {
+				return shapes.Invalid(), errors.Errorf("PadOp: padding on a dynamic axis (%d, name %q) is not supported yet (requires axis expressions)",
+					axis, operand.AxisName(axis))
+			}
+			continue
+		}
+
 		interiorPadding := 0
 		if dim > 0 {
 			interiorPadding = (dim - 1) * config.Interior

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -440,22 +440,77 @@ func Where(condition, onTrue, onFalse shapes.Shape) (output shapes.Shape, err er
 // Reshape to the given dimensions: trivial output shape, but this function also checks
 // that the sizes are the same.
 //
-// Notice the compute.Reshape doesn't support auto-scaling dimensions (set to -1), as graph.Reshape does.
+// This version of reshape doesn't support reshaping dynamic dimensions (axes with [shapes.DynamicDim]).
+// Any dynamic dimensions in the input must be matched by dynamic dimensions in the output, and their
+// axis names are preserved. If new axes are created, the dynamic axis in the input x and dimensions are
+// matched in order.
 func Reshape(operand shapes.Shape, dims []int) (output shapes.Shape, err error) {
-	if operand.IsDynamic() {
-		// Dynamic path: skip size validation (deferred to specialization time).
-		// DynamicDim values in target dims are allowed — they propagate through
-		// reshape operations and are resolved during shape specialization.
-		output = shapes.Shape{DType: operand.DType, Dimensions: slices.Clone(dims)}
-		return output, nil
+	outputIsDynamic := slices.Contains(dims, shapes.DynamicDim)
+	if !operand.IsDynamic() {
+		if outputIsDynamic {
+			err = errors.Errorf(
+				"Reshape() cannot reshape a concrete shape (%s) to a dynamic dimension (target dims=%v)",
+				operand, dims)
+			return shapes.Invalid(), err
+		}
+
+		output = shapes.Make(operand.DType, dims...)
+		if operand.Size() != output.Size() {
+			err = errors.Errorf("Reshape() cannot reshape %s to dimensions %v, their size don't match",
+				operand, dims)
+			return shapes.Invalid(), err
+		}
+		return
 	}
-	output = shapes.Make(operand.DType, dims...)
-	if operand.Size() != output.Size() {
-		err = errors.Errorf("Reshape() cannot reshape %s to dimensions %v, their size don't match",
+
+	// Dynamic path: skip size validation (deferred to specialization time).
+	if !outputIsDynamic {
+		err = errors.Errorf(
+			"Reshape() cannot reshape a dynamic shape to a concrete shape; got input=%s target dims=%v",
 			operand, dims)
 		return shapes.Invalid(), err
 	}
-	return
+
+	// Extract dynamic axis names from operand in order.
+	var dynamicNames []string
+	for i, d := range operand.Dimensions {
+		if d == shapes.DynamicDim {
+			// We can assume operand.AxisNames has the same length as operand.Dimensions
+			// when the shape is dynamic.
+			dynamicNames = append(dynamicNames, operand.AxisNames[i])
+		}
+	}
+
+	// Count dynamic axes in the target dims.
+	numTargetDynamic := 0
+	for _, d := range dims {
+		if d == shapes.DynamicDim {
+			numTargetDynamic++
+		}
+	}
+
+	if len(dynamicNames) != numTargetDynamic {
+		err = errors.Errorf(
+			"Reshape() requires the number of dynamic dimensions in the input (%d) to match the target dims (%d); got input=%s target dims=%v",
+			len(dynamicNames), numTargetDynamic, operand, dims)
+		return shapes.Invalid(), err
+	}
+
+	// Build output axis names, mapping dynamic axes in order.
+	// This also preserves the invariant that len(axisNames) == len(dims) for dynamic shapes.
+	axisNames := make([]string, len(dims))
+	dynIdx := 0
+	for i, d := range dims {
+		if d == shapes.DynamicDim {
+			axisNames[i] = dynamicNames[dynIdx]
+			dynIdx++
+		}
+	}
+
+	// DynamicDim values in target dims are allowed — they propagate through
+	// reshape operations and are resolved during shape specialization.
+	output = shapes.MakeDynamic(operand.DType, dims, axisNames)
+	return output, nil
 }
 
 // Transpose all axes of the operand.

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -253,12 +253,29 @@ func binaryOpImpl(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (outpu
 	for axis := range output.Rank() {
 		lhsDim := lhsShape.Dimensions[axis]
 		rhsDim := rhsShape.Dimensions[axis]
+		if lhsDim == shapes.DynamicDim || rhsDim == shapes.DynamicDim {
+			// At least one side is dynamic.
+			if lhsDim == 1 {
+				output.Dimensions[axis] = rhsDim // broadcast: use rhs (possibly dynamic)
+			} else if rhsDim == 1 {
+				output.Dimensions[axis] = lhsDim // broadcast: use lhs (possibly dynamic)
+			} else {
+				output.Dimensions[axis] = shapes.DynamicDim // both dynamic or one dynamic non-broadcast
+			}
+			continue
+		}
 		if lhsDim != 1 && rhsDim != 1 && lhsDim != rhsDim {
 			err = errors.Errorf("dimension of axis #%d doesn't match and cannot be broadcast for BinaryOp (%s), got shapes %s and %s",
 				axis, opType, lhsShape, rhsShape)
 			return
 		}
 		output.Dimensions[axis] = max(lhsDim, rhsDim)
+	}
+
+	// Unify axis names.
+	output.AxisNames, err = shapes.UnifyAxisNames(lhsShape, rhsShape)
+	if err != nil {
+		err = errors.Wrapf(err, "axis name conflict in BinaryOp (%s)", opType)
 	}
 	return
 }
@@ -384,6 +401,13 @@ func WhereOp(condition, onTrue, onFalse shapes.Shape) (output shapes.Shape, err 
 //
 // Notice the compute.Reshape doesn't support auto-scaling dimensions (set to -1), as graph.Reshape does.
 func ReshapeOp(operand shapes.Shape, dims []int) (output shapes.Shape, err error) {
+	if operand.HasDynamicDims() {
+		// Dynamic path: skip size validation (deferred to specialization time).
+		// DynamicDim values in target dims are allowed — they propagate through
+		// reshape operations and are resolved during shape specialization.
+		output = shapes.Shape{DType: operand.DType, Dimensions: slices.Clone(dims)}
+		return output, nil
+	}
 	output = shapes.Make(operand.DType, dims...)
 	if operand.Size() != output.Size() {
 		err = errors.Errorf("Reshape() cannot reshape %s to dimensions %v, their size don't match",
@@ -427,6 +451,9 @@ func TransposeOp(operand shapes.Shape, permutations []int) (output shapes.Shape,
 	for axis := range output.Dimensions {
 		srcAxis := permutations[axis]
 		output.Dimensions[axis] = operand.Dimensions[srcAxis]
+		if operand.AxisNames != nil {
+			output.AxisNames[axis] = operand.AxisNames[srcAxis]
+		}
 	}
 	return
 }
@@ -450,11 +477,13 @@ func BroadcastInDimOp(operand, outputShape shapes.Shape, broadcastAxes []int) er
 				broadcastAxes, axisInOutput, axisInOperand, outputShape.Rank()-1)
 		}
 		preservedSet.Insert(axisInOutput)
-		if operand.Dimensions[axisInOperand] != 1 && operand.Dimensions[axisInOperand] != outputShape.Dimensions[axisInOutput] {
+		oDim := operand.Dimensions[axisInOperand]
+		outDim := outputShape.Dimensions[axisInOutput]
+		if oDim != shapes.DynamicDim && outDim != shapes.DynamicDim && oDim != 1 && oDim != outDim {
 			return errors.Errorf("the values of outputShape (%v) that are being broadcast (listed in broadcastAxes) "+
 				"must match the corresponding value in the operand shape (%s) or be 1 (if broadcasting), "+
 				"but the value of outputShape.Dimensions[%d]=%d does not match the value in operand.Shape().Dimensions[%d]=%d",
-				outputShape, operand, axisInOutput, outputShape.Dimensions[axisInOutput], axisInOperand, operand.Dimensions[axisInOperand])
+				outputShape, operand, axisInOutput, outDim, axisInOperand, oDim)
 		}
 	}
 	return nil
@@ -465,11 +494,14 @@ func ReduceOp(operand shapes.Shape, axes []int) (output shapes.Shape, err error)
 	if len(axes) == 0 {
 		return operand, nil
 	}
-	output = shapes.Make(operand.DType)
+	output = shapes.Shape{DType: operand.DType}
 	outputRank := operand.Rank() - len(axes)
 	if outputRank > 0 {
 		// Copy over dimensions that will stay.
 		output.Dimensions = make([]int, 0, outputRank)
+		if operand.AxisNames != nil {
+			output.AxisNames = make([]string, 0, outputRank)
+		}
 		for _, axis := range axes {
 			if axis < 0 || axis >= operand.Rank() {
 				return shapes.Invalid(), errors.Errorf("Reduce operation require each axis to be 0 <= axis < rank, but got invalid axis %d for shape %s", axis, operand)
@@ -479,6 +511,9 @@ func ReduceOp(operand shapes.Shape, axes []int) (output shapes.Shape, err error)
 		for axis, dim := range operand.Dimensions {
 			if !axesSet.Has(axis) {
 				output.Dimensions = append(output.Dimensions, dim)
+				if operand.AxisNames != nil {
+					output.AxisNames = append(output.AxisNames, operand.AxisNames[axis])
+				}
 			}
 		}
 	}
@@ -521,10 +556,14 @@ func Gather(operand, startIndices shapes.Shape, indexVectorAxis int, offsetOutpu
 		return output, errors.Errorf("sliceSizes must have one value per operand axes, so it length (%d) must match operand rank (%d)", len(sliceSizes), operand.Rank())
 	}
 	for axis, sliceSize := range sliceSizes {
+		if sliceSize == shapes.DynamicDim {
+			// Dynamic slice size: skip validation, will be resolved at specialization time.
+			continue
+		}
 		if sliceSize < 0 {
 			return output, errors.Errorf("sliceSize %d for axis %d is negative, it must be non-negative", sliceSize, axis)
 		}
-		if operand.Dimensions[axis] < sliceSize {
+		if operand.Dimensions[axis] != shapes.DynamicDim && operand.Dimensions[axis] < sliceSize {
 			return output, errors.Errorf("sliceSize %d for axis %d is larger than the corresponding operand dimension %d", sliceSize, axis, operand.Dimensions[axis])
 		}
 	}
@@ -645,12 +684,49 @@ func ConcatenateOp(inputs []shapes.Shape, axis int) (output shapes.Shape, err er
 
 		for d := range rank {
 			if d == axis {
-				output.Dimensions[d] += currentShape.Dimensions[d]
+				// For concat axis: if either is dynamic, result is dynamic.
+				if output.Dimensions[d] == shapes.DynamicDim || currentShape.Dimensions[d] == shapes.DynamicDim {
+					output.Dimensions[d] = shapes.DynamicDim
+				} else {
+					output.Dimensions[d] += currentShape.Dimensions[d]
+				}
 			} else {
-				if currentShape.Dimensions[d] != output.Dimensions[d] {
+				// For non-concat axes: allow dynamic dims on either side.
+				if output.Dimensions[d] == shapes.DynamicDim || currentShape.Dimensions[d] == shapes.DynamicDim {
+					// Dynamic dims are assumed compatible; keep dynamic.
+					if output.Dimensions[d] != shapes.DynamicDim {
+						output.Dimensions[d] = currentShape.Dimensions[d]
+					}
+				} else if currentShape.Dimensions[d] != output.Dimensions[d] {
 					return shapes.Invalid(), errors.Errorf("mismatched dimensions for ConcatenateOp at axis %d (non-concatenation axis): input #0 has %d, input #%d has %d",
 						d, output.Dimensions[d], i, currentShape.Dimensions[d])
 				}
+			}
+		}
+
+		// Unify axis names from current input.
+		if output.AxisNames != nil || currentShape.AxisNames != nil {
+			for d := range rank {
+				outputName := ""
+				if output.AxisNames != nil {
+					outputName = output.AxisNames[d]
+				}
+				inputName := ""
+				if currentShape.AxisNames != nil {
+					inputName = currentShape.AxisNames[d]
+				}
+				unified, nameErr := shapes.UnifyAxisName(outputName, inputName)
+				if nameErr != nil {
+					if d != axis {
+						return shapes.Invalid(), errors.Wrapf(nameErr, "axis name conflict at axis %d in ConcatenateOp", d)
+					}
+					// Concat axis with different names: drop the name.
+					unified = ""
+				}
+				if output.AxisNames == nil {
+					output.AxisNames = make([]string, rank)
+				}
+				output.AxisNames[d] = unified
 			}
 		}
 	}
@@ -682,7 +758,7 @@ func ScatterOp(operand, indices, updates shapes.Shape, indexVectorAxis int, upda
 	if indexVectorAxis < indices.Rank() {
 		numIndexedAxes = indices.Dimensions[indexVectorAxis]
 	}
-	if len(scatterAxesToOperandAxes) != numIndexedAxes {
+	if numIndexedAxes != shapes.DynamicDim && len(scatterAxesToOperandAxes) != numIndexedAxes {
 		return shapes.Invalid(), errors.Errorf("scatterAxesToOperandAxes length (%d) must match the size of indices's indexVectorAxis dimension (%d)",
 			len(scatterAxesToOperandAxes), indices.Dimensions[indexVectorAxis])
 	}
@@ -729,9 +805,11 @@ func ScatterOp(operand, indices, updates shapes.Shape, indexVectorAxis int, upda
 	}
 	for ii, updatesAxis := range updateWindowAxes {
 		operandAxis := operandUpdatedWindowAxes[ii]
-		if updates.Dimensions[updatesAxis] > operand.Dimensions[operandAxis] {
+		uDim := updates.Dimensions[updatesAxis]
+		oDim := operand.Dimensions[operandAxis]
+		if uDim != shapes.DynamicDim && oDim != shapes.DynamicDim && uDim > oDim {
 			return shapes.Invalid(), errors.Errorf("updates.Dimensions[axis=%d](%d) > operand.Dimensions[axis=%d](%d), updates won't fit into the operand",
-				updatesAxis, updates.Dimensions[updatesAxis], operandAxis, operand.Dimensions[operandAxis])
+				updatesAxis, uDim, operandAxis, oDim)
 		}
 	}
 	return operand, nil
@@ -760,6 +838,7 @@ func SliceOp(operand shapes.Shape, starts, limits, strides []int) (output shapes
 	output = shapes.Shape{
 		DType:      operand.DType,
 		Dimensions: make([]int, rank),
+		AxisNames:  slices.Clone(operand.AxisNames),
 	}
 
 	for axis := range rank {
@@ -770,6 +849,13 @@ func SliceOp(operand shapes.Shape, starts, limits, strides []int) (output shapes
 			return shapes.Invalid(), errors.Errorf("%s: stride must be positive, but got stride[%d]=%d for operand shape %s",
 				opName, axis, stride, operand)
 		}
+
+		// Skip bounds validation for dynamic axes.
+		if dimSize == shapes.DynamicDim {
+			output.Dimensions[axis] = shapes.DynamicDim
+			continue
+		}
+
 		if start < 0 || start > dimSize {
 			return shapes.Invalid(), errors.Errorf("%s: start index %d is out of bounds for axis %d with size %d (operand shape %s)",
 				opName, start, axis, dimSize, operand)
@@ -786,6 +872,47 @@ func SliceOp(operand shapes.Shape, starts, limits, strides []int) (output shapes
 	}
 
 	return output, nil
+}
+
+// DynamicSliceOp calculates the output shape for a DynamicSlice operation.
+func DynamicSliceOp(operand shapes.Shape, sliceSizes []int) (output shapes.Shape, err error) {
+	if operand.DType == dtypes.InvalidDType {
+		return output, errors.Errorf("invalid operand shape %s for DynamicSlice", operand)
+	}
+	if len(sliceSizes) != operand.Rank() {
+		return output, errors.Errorf("sliceSizes must have one value per operand axes, so it length (%d) must match operand rank (%d)", len(sliceSizes), operand.Rank())
+	}
+	for axis, sliceSize := range sliceSizes {
+		if sliceSize == shapes.DynamicDim {
+			// Dynamic slice size: skip validation, will be resolved at specialization time.
+			continue
+		}
+		if sliceSize < 0 {
+			return output, errors.Errorf("sliceSize %d for axis %d is negative, it must be non-negative", sliceSize, axis)
+		}
+		if operand.Dimensions[axis] != shapes.DynamicDim && operand.Dimensions[axis] < sliceSize {
+			return output, errors.Errorf("sliceSize %d for axis %d is larger than the corresponding operand dimension %d", sliceSize, axis, operand.Dimensions[axis])
+		}
+	}
+	output = shapes.Shape{
+		DType:      operand.DType,
+		Dimensions: slices.Clone(sliceSizes),
+		AxisNames:  slices.Clone(operand.AxisNames),
+	}
+	return output, nil
+}
+
+// DynamicUpdateSliceOp calculates the output shape for a DynamicUpdateSlice operation.
+func DynamicUpdateSliceOp(operand, update shapes.Shape) (output shapes.Shape, err error) {
+	if operand.DType != update.DType {
+		return shapes.Invalid(), errors.Errorf("DynamicUpdateSlice requires operand and update to have the same DType, got %s and %s",
+			operand.DType, update.DType)
+	}
+	if operand.Rank() != update.Rank() {
+		return shapes.Invalid(), errors.Errorf("DynamicUpdateSlice requires operand and update to have the same rank, got rank %d and %d",
+			operand.Rank(), update.Rank())
+	}
+	return operand.Clone(), nil
 }
 
 // ArgMinMaxOp calculates the output shape for an ArgMinMax operation.
@@ -809,14 +936,24 @@ func ArgMinMaxOp(operand shapes.Shape, axis int, outputDType dtypes.DType) (outp
 	}
 	newDims := slices.Clone(operand.Dimensions)
 	newDims = slices.Delete(newDims, axis, axis+1)
-	output = shapes.Make(outputDType, newDims...)
+	// Build output shape directly to support dynamic dims (-1).
+	output = shapes.Shape{
+		DType:      outputDType,
+		Dimensions: newDims,
+	}
+	// Remove the axis name at the deleted position.
+	if operand.AxisNames != nil {
+		newNames := slices.Clone(operand.AxisNames)
+		newNames = slices.Delete(newNames, axis, axis+1)
+		output.AxisNames = newNames
+	}
 	return
 }
 
 // ReduceWindowOp returns the expected output shape for the operation.
 //
 // Notice it doesn't take as input the reductionType parameter, since it doesn't affect the output shape.
-func ReduceWindowOp(operand shapes.Shape, windowDimensions, strides, inputDilations, windowDilations []int, paddings [][2]int) (shapes.Shape, error) {
+func ReduceWindowOp(operand shapes.Shape, windowDimensions, strides, baseDilations, windowDilations []int, paddings [][2]int) (shapes.Shape, error) {
 	if !operand.Ok() {
 		return shapes.Invalid(), errors.Errorf("ReduceWindowOp: invalid operand shape %s", operand)
 	}
@@ -832,8 +969,8 @@ func ReduceWindowOp(operand shapes.Shape, windowDimensions, strides, inputDilati
 	if len(paddings) != 0 && len(paddings) != rank {
 		return shapes.Invalid(), errors.Errorf("ReduceWindowOp: len(paddings)=%d, but operand rank is %d", len(paddings), rank)
 	}
-	if inputDilations != nil && len(inputDilations) != rank {
-		return shapes.Invalid(), errors.Errorf("ReduceWindowOp: inputDilations is not nil and len(inputDilations)=%d, but operand rank is %d", len(inputDilations), rank)
+	if baseDilations != nil && len(baseDilations) != rank {
+		return shapes.Invalid(), errors.Errorf("ReduceWindowOp: baseDilations is not nil and len(baseDilations)=%d, but operand rank is %d", len(baseDilations), rank)
 	}
 	if windowDilations != nil && len(windowDilations) != rank {
 		return shapes.Invalid(), errors.Errorf("ReduceWindowOp: windowDilations is not nil and len(windowDilations)=%d, but operand rank is %d", len(windowDilations), rank)
@@ -849,7 +986,12 @@ func ReduceWindowOp(operand shapes.Shape, windowDimensions, strides, inputDilati
 	// Each output dimension is calculated orthogonally to the others.
 	outputDims := make([]int, rank)
 	for i := range rank {
-		inputDim := operand.Dimensions[i] // Already validated to be > 0 by shapes.Make
+		inputDim := operand.Dimensions[i]
+		// Skip output size calculation for dynamic axes — output is also dynamic.
+		if inputDim == shapes.DynamicDim {
+			outputDims[i] = shapes.DynamicDim
+			continue
+		}
 		windowDim := 1
 		if len(windowDimensions) > 0 {
 			windowDim = windowDimensions[i]
@@ -874,10 +1016,10 @@ func ReduceWindowOp(operand shapes.Shape, windowDimensions, strides, inputDilati
 		}
 
 		baseDilation := 1
-		if inputDilations != nil {
-			baseDilation = inputDilations[i]
+		if baseDilations != nil {
+			baseDilation = baseDilations[i]
 			if baseDilation < 1 {
-				return shapes.Invalid(), errors.Errorf("ReduceWindowOp: inputDilations[%d]=%d must be >= 1 for operand shape %s", i, baseDilation, operand)
+				return shapes.Invalid(), errors.Errorf("ReduceWindowOp: baseDilations[%d]=%d must be >= 1 for operand shape %s", i, baseDilation, operand)
 			}
 		}
 
@@ -912,7 +1054,13 @@ func ReduceWindowOp(operand shapes.Shape, windowDimensions, strides, inputDilati
 		outputDims[i] = numerator/stride + 1
 	}
 
-	return shapes.Make(operand.DType, outputDims...), nil
+	// Build output shape directly to support dynamic dims (-1) in output.
+	result := shapes.Shape{
+		DType:      operand.DType,
+		Dimensions: outputDims,
+		AxisNames:  slices.Clone(operand.AxisNames),
+	}
+	return result, nil
 }
 
 // ConvGeneralOp returns the expected output shape for the ConvGeneral operation.
@@ -1023,19 +1171,21 @@ func ConvGeneralOp(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 	}
 
 	// Check that channels (feature dimensions) are valid.
-	inputChannels := input.Dim(axes.InputChannels)
+		inputChannels := input.Dim(axes.InputChannels)
 	outputChannels := kernel.Dim(axes.KernelOutputChannels)
 	if channelGroupCount < 1 {
 		return errorf("channelGroupCount=%d must be >= 1 for input shape %s", channelGroupCount, input)
 	}
-	if inputChannels%channelGroupCount != 0 {
-		return errorf("input channels dimension %d must be divisible by channelGroupCount %d", inputChannels, channelGroupCount)
+	if inputChannels != shapes.DynamicDim {
+		if inputChannels%channelGroupCount != 0 {
+			return errorf("input channels dimension %d must be divisible by channelGroupCount %d", inputChannels, channelGroupCount)
+		}
 	}
 	if outputChannels%channelGroupCount != 0 {
 		return errorf("kernel output channels dimension %d must be divisible by channelGroupCount %d", outputChannels, channelGroupCount)
 	}
 	kernelInputChannels := kernel.Dim(axes.KernelInputChannels)
-	if inputChannels != kernelInputChannels*channelGroupCount {
+	if inputChannels != shapes.DynamicDim && inputChannels != kernelInputChannels*channelGroupCount {
 		return errorf("we must have inputChannels (=%d) = kernelInputChannels (=%d) * channelGroupCount (=%d) -- input shape is %s, kernel shape is %s",
 			inputChannels, kernelInputChannels, channelGroupCount, input, kernel)
 	}
@@ -1045,7 +1195,7 @@ func ConvGeneralOp(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 	if batchGroupCount < 1 {
 		return errorf("batchGroupCount=%d must be >= 1 for input shape %s", batchGroupCount, input)
 	}
-	if inputBatch%batchGroupCount != 0 {
+	if inputBatch != shapes.DynamicDim && inputBatch%batchGroupCount != 0 {
 		return errorf("input batch dimension %d must be divisible by batchGroupCount %d", inputBatch, batchGroupCount)
 	}
 	if outputChannels%batchGroupCount != 0 {
@@ -1054,27 +1204,37 @@ func ConvGeneralOp(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 
 	// Find the output shape.
 	output := input.Clone()
-	output.Dimensions[axes.OutputBatch] = inputBatch / batchGroupCount
+	if inputBatch == shapes.DynamicDim {
+		output.Dimensions[axes.OutputBatch] = shapes.DynamicDim
+	} else {
+		output.Dimensions[axes.OutputBatch] = inputBatch / batchGroupCount
+	}
 	output.Dimensions[axes.OutputChannels] = outputChannels
 
 	for spatialAxisIdx, inputAxis := range axes.InputSpatial {
 		inputDim := input.Dim(inputAxis)
+
+		// Dynamic spatial dims: propagate DynamicDim without arithmetic.
+		if inputDim == shapes.DynamicDim {
+			output.Dimensions[axes.OutputSpatial[spatialAxisIdx]] = shapes.DynamicDim
+			continue
+		}
+
 		filterAxis := axes.KernelSpatial[spatialAxisIdx]
 		kernelDim := kernel.Dim(filterAxis)
 		stride := 1
 		var padding [2]int
-
-		if len(strides) > 0 {
+		if strides != nil {
 			stride = strides[spatialAxisIdx]
 		}
-		if len(paddings) > 0 {
+		if paddings != nil {
 			padding = paddings[spatialAxisIdx]
 		}
 		inputDilation, kernelDilation := 1, 1
-		if len(inputDilations) > 0 {
+		if inputDilations != nil {
 			inputDilation = inputDilations[spatialAxisIdx]
 		}
-		if len(kernelDilations) > 0 {
+		if kernelDilations != nil {
 			kernelDilation = kernelDilations[spatialAxisIdx]
 		}
 

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -401,7 +401,7 @@ func Where(condition, onTrue, onFalse shapes.Shape) (output shapes.Shape, err er
 //
 // Notice the compute.Reshape doesn't support auto-scaling dimensions (set to -1), as graph.Reshape does.
 func Reshape(operand shapes.Shape, dims []int) (output shapes.Shape, err error) {
-	if operand.HasDynamicDims() {
+	if operand.IsDynamic() {
 		// Dynamic path: skip size validation (deferred to specialization time).
 		// DynamicDim values in target dims are allowed — they propagate through
 		// reshape operations and are resolved during shape specialization.

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -11,7 +11,27 @@
 // The majority of the unary functions don't change the shape, except those that explicitly say that in their name,
 // like Reshape, etc.
 //
-// For the remainder ops, it defines one function per OpType, except for trivial ones and a few that are not implemented yet (e.g.: FFT.)
+// For the remainder ops, it defines one function per OpType.
+//
+// ## Dynamic Shapes
+//
+// This package supports "dynamic shapes" where one or more dimensions of a tensor are unknown at
+// graph build time. These dimensions are represented by the [shapes.DynamicDim] sentinel value (-1).
+//
+// When dynamic shapes are involved, shape inference follows these principles:
+//
+//   - **Validation Deferral:** Many validation checks that depend on concrete dimension sizes (like
+//     checking if a reshape is valid, or if slice indices are within bounds) are deferred.
+//     These checks are typically performed by the backend during "shape specialization"
+//     once the concrete shapes are known.
+//   - **Propagation:** Symbolic dimensions propagate through operations. For example, in a [BinaryOp],
+//     if one operand has a dynamic dimension and the other has a matching static dimension or is also
+//     dynamic, the output dimension will be dynamic.
+//   - **Broadcasting:** During [BinaryOp] or [BroadcastInDim], a dimension of 1 is considered
+//     compatible with a [shapes.DynamicDim] and will be broadcast to it.
+//   - **Axis Names:** Axis names are used to track and validate symbolic axes across operations.
+//     If multiple operands have named axes, [shapes.UnifyAxisNames] is used to ensure they match
+//     and to propagate them to the output.
 package shapeinference
 
 import (

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes"
 	"github.com/gomlx/compute/shapes"
+	"github.com/gomlx/compute/support/sets"
 	"github.com/gomlx/compute/support/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -879,20 +880,37 @@ func TestTransposeOp_AxisNames(t *testing.T) {
 	})
 }
 
-func TestBroadcastInDimOp_AxisNames(t *testing.T) {
+func TestBroadcastInDim(t *testing.T) {
 	t.Run("DynamicDimMatch", func(t *testing.T) {
 		operand := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		outputShape := S(F32, 32, 512)
-		err := BroadcastInDim(operand, outputShape, []int{0, 1})
+		outputShape := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		err := BroadcastInDim(operand, outputShape, []int{0, 1}, nil)
 		require.NoError(t, err)
 	})
 
 	t.Run("DynamicDimMismatch", func(t *testing.T) {
-		// Static 32 cannot be broadcast to static 64, but dynamic is assumed OK.
-		// Wait, if output is static, it must match or be 1.
-		operand := S(F32, 32, 512)
+		// A dynamic dimension cannot be broadcast to a static dimension.
+		operand := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		outputShape := S(F32, 32, 512)
+		err := BroadcastInDim(operand, outputShape, []int{0, 1}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be preserved as dynamic in output shape")
+	})
+
+	t.Run("BroadcastToUnknownDynamicAxis", func(t *testing.T) {
+		// Broadcasting dimension 1 to a dynamic dimension is allowed, if its name is known.
+		operand := S(F32, 1, 512)
 		outputShape := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		err := BroadcastInDim(operand, outputShape, []int{0, 1})
+		err := BroadcastInDim(operand, outputShape, []int{0, 1}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot introduce an unknown dynamic axis name -- the dynamic axis must be known from the input parameters")
+	})
+
+	t.Run("BroadcastToKnownDynamicAxis", func(t *testing.T) {
+		// Broadcasting dimension 1 to a dynamic dimension is allowed, if its name is known.
+		operand := SD(F32, []int{-1, 512}, []string{"seqLen", ""})
+		outputShape := SD(F32, []int{-1, -1, 512}, []string{"batch", "seqLen", ""})
+		err := BroadcastInDim(operand, outputShape, []int{1, 2}, sets.MakeWith("batch"))
 		require.NoError(t, err)
 	})
 }

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -159,7 +159,7 @@ func TestScatterOp(t *testing.T) {
 	insertedWindowAxes1 := []int{0}
 	scatterAxesToOperandAxes1 := []int{0} // Index coordinate vector element 0 maps to operand axis 0
 	expected1 := operand1
-	output1, err := ScatterOp(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1)
+	output1, err := Scatter(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1)
 	require.NoError(t, err)
 	require.True(t, expected1.Equal(output1), "Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
 
@@ -176,7 +176,7 @@ func TestScatterOp(t *testing.T) {
 	insertedWindowAxes2 := []int{0, 1}       // Axis 0, 1 of operand are the dimensions determined by the indices[i,j,:]
 	scatterAxesToOperandAxes2 := []int{0, 1} // index coord 0 -> operand axis 0, index coord 1 -> operand axis 1
 	expected2 := operand2
-	output2, err := ScatterOp(operand2, indices2, updates2, indexVectorAxis2, updateWindowAxes2, insertedWindowAxes2, scatterAxesToOperandAxes2)
+	output2, err := Scatter(operand2, indices2, updates2, indexVectorAxis2, updateWindowAxes2, insertedWindowAxes2, scatterAxesToOperandAxes2)
 	require.NoError(t, err)
 	require.True(t, expected2.Equal(output2), "Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
 
@@ -190,7 +190,7 @@ func TestScatterOp(t *testing.T) {
 	insertedWindowAxes3 := []int{1, 2}
 	scatterAxesToOperandAxes3 := []int{1, 2} // indices are used for different axes in the operand this time.
 	expected3 := operand2                    // Still expect operand shape
-	output3, err := ScatterOp(operand3, indices3, updates3, indexVectorAxis3, updateWindowAxes3, insertedWindowAxes3, scatterAxesToOperandAxes3)
+	output3, err := Scatter(operand3, indices3, updates3, indexVectorAxis3, updateWindowAxes3, insertedWindowAxes3, scatterAxesToOperandAxes3)
 	require.NoError(t, err)
 	require.True(t, expected3.Equal(output3), "Valid Case 3 Failed (IndexVecAxis=1): Expected %s, got %s", expected3, output3)
 
@@ -204,7 +204,7 @@ func TestScatterOp(t *testing.T) {
 	insertedWindowAxes4 := []int{0}       // No window axes in operand (index selects full slice - which is scalar here)
 	scatterAxesToOperandAxes4 := []int{0} // Index coord 0 -> operand axis 0
 	expected4 := operand4
-	output4, err := ScatterOp(operand4, indices4, updates4, indexVectorAxis4, updateWindowAxes4, insertedWindowAxes4, scatterAxesToOperandAxes4)
+	output4, err := Scatter(operand4, indices4, updates4, indexVectorAxis4, updateWindowAxes4, insertedWindowAxes4, scatterAxesToOperandAxes4)
 	require.NoError(t, err)
 	require.True(t, expected4.Equal(output4), "Valid Case 4 Failed (No Window): Expected %s, got %s", expected4, output4)
 
@@ -216,51 +216,51 @@ func TestScatterOp(t *testing.T) {
 	updateWindowAxes5 := []int{0}
 	insertedWindowAxes5 := []int{0, 2}
 	scatterAxesToOperandAxes5 := []int{0, 2}
-	output5, err := ScatterOp(operand5, indices5, updates5, indexVectorAxis5, updateWindowAxes5, insertedWindowAxes5, scatterAxesToOperandAxes5)
+	output5, err := Scatter(operand5, indices5, updates5, indexVectorAxis5, updateWindowAxes5, insertedWindowAxes5, scatterAxesToOperandAxes5)
 	require.NoError(t, err)
 	require.True(t, operand5.Equal(output5), "Valid Case 5 Failed (No Window): Expected %s, got %s", operand5, output5)
 
 	// --- Error Cases ---
 
 	// Error Case 1: Mismatched DType (Operand vs Updates) - unchanged
-	_, err = ScatterOp(S(F32, 4, 5), S(I8, 2, 1), S(I8, 2, 5), 1, []int{1}, []int{1}, []int{0})
+	_, err = Scatter(S(F32, 4, 5), S(I8, 2, 1), S(I8, 2, 5), 1, []int{1}, []int{1}, []int{0})
 	require.Error(t, err)
 
 	// Error Case 2: Invalid DType for indices - unchanged
-	_, err = ScatterOp(S(F32, 4, 5), S(F32, 2, 1), S(F32, 2, 5), 1, []int{1}, []int{1}, []int{0})
+	_, err = Scatter(S(F32, 4, 5), S(F32, 2, 1), S(F32, 2, 5), 1, []int{1}, []int{1}, []int{0})
 	require.Error(t, err)
 
 	// Error Case 3: indexVectorAxis out of bounds
-	_, err = ScatterOp(operand1, indices1, updates1, 2, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1) // indices1 rank 2, axis 2 invalid
+	_, err = Scatter(operand1, indices1, updates1, 2, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1) // indices1 rank 2, axis 2 invalid
 	require.Error(t, err)
 
-	_, err = ScatterOp(operand1, indices1, updates1, -1, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1) // Negative axis
+	_, err = Scatter(operand1, indices1, updates1, -1, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1) // Negative axis
 	require.Error(t, err)
 
 	// Error Case 4: len(updateWindowAxes) != len(insertedWindowAxes)
-	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, []int{1}, []int{1, 0}, scatterAxesToOperandAxes1) // inserted has len 2, update has len 1
+	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, []int{1}, []int{1, 0}, scatterAxesToOperandAxes1) // inserted has len 2, update has len 1
 	require.Error(t, err)
 
 	// Error Case 5: len(scatterAxesToOperandAxes) != size of index vector dimension
-	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, []int{0, 1}) // scatterAxes has len 2, expected 1
+	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, []int{0, 1}) // scatterAxes has len 2, expected 1
 	require.Error(t, err)
-	_, err = ScatterOp(operand2, indices2, updates2, indexVectorAxis2, updateWindowAxes2, insertedWindowAxes2, []int{0}) // scatterAxes has len 1, expected 2
+	_, err = Scatter(operand2, indices2, updates2, indexVectorAxis2, updateWindowAxes2, insertedWindowAxes2, []int{0}) // scatterAxes has len 1, expected 2
 	require.Error(t, err)
 
 	// Error Case 6: Invalid axis index in updateWindowAxes
-	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, []int{2}, insertedWindowAxes1, scatterAxesToOperandAxes1) // axis 2 invalid for rank 2 updates
+	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, []int{2}, insertedWindowAxes1, scatterAxesToOperandAxes1) // axis 2 invalid for rank 2 updates
 	require.Error(t, err)
 
 	// Error Case 7: Invalid axis index in insertedWindowAxes
-	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, []int{2}, scatterAxesToOperandAxes1) // axis 2 invalid for rank 2 operand
+	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, []int{2}, scatterAxesToOperandAxes1) // axis 2 invalid for rank 2 operand
 	require.Error(t, err)
 
 	// Error Case 8: Invalid axis index in scatterAxesToOperandAxes
-	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, []int{2}) // axis 2 invalid for rank 2 operand
+	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, []int{2}) // axis 2 invalid for rank 2 operand
 	require.Error(t, err)
 
 	// Error Case 9: Update dimension is larger than the corresponding dimension in the operand:
-	_, err = ScatterOp(operand5, indices5, updates5, indexVectorAxis5, updateWindowAxes5, []int{0, 1}, scatterAxesToOperandAxes5) // axis 2 invalid for rank 2 operand
+	_, err = Scatter(operand5, indices5, updates5, indexVectorAxis5, updateWindowAxes5, []int{0, 1}, scatterAxesToOperandAxes5) // axis 2 invalid for rank 2 operand
 	require.Error(t, err)
 }
 
@@ -274,7 +274,7 @@ func TestSliceOp(t *testing.T) {
 	limits1 := []int{8}
 	strides1 := []int{1}
 	expected1 := S(F32, 6)
-	output1, err := SliceOp(operand1, starts1, limits1, strides1)
+	output1, err := Slice(operand1, starts1, limits1, strides1)
 	require.NoError(t, err)
 	require.True(t, expected1.Equal(output1), "%s Valid Case 1 Failed: Expected %s, got %s", opName, expected1, output1)
 
@@ -284,7 +284,7 @@ func TestSliceOp(t *testing.T) {
 	limits2 := []int{4, 5}
 	strides2 := []int{1, 1}
 	expected2 := S(I32, 3, 3)
-	output2, err := SliceOp(operand2, starts2, limits2, strides2)
+	output2, err := Slice(operand2, starts2, limits2, strides2)
 	require.NoError(t, err)
 	require.True(t, expected2.Equal(output2), "%s Valid Case 2 Failed: Expected %s, got %s", opName, expected2, output2)
 
@@ -297,7 +297,7 @@ func TestSliceOp(t *testing.T) {
 	// Dim 1: (8-0)/3 = 2.66 -> 3 elements (indices 0, 3, 6)
 	// Dim 2: (6-1)/1 = 5 -> 5 elements (indices 1, 2, 3, 4, 5)
 	expected3 := S(Bool, 5, 3, 5)
-	output3, err := SliceOp(operand3, starts3, limits3, strides3)
+	output3, err := Slice(operand3, starts3, limits3, strides3)
 	require.NoError(t, err)
 	require.True(t, expected3.Equal(output3), "%s Valid Case 3 Failed: Expected %s, got %s", opName, expected3, output3)
 
@@ -307,7 +307,7 @@ func TestSliceOp(t *testing.T) {
 	limits4 := []int{6}
 	strides4 := []int{1}
 	expected4 := S(F32, 1)
-	output4, err := SliceOp(operand4, starts4, limits4, strides4)
+	output4, err := Slice(operand4, starts4, limits4, strides4)
 	require.NoError(t, err)
 	require.True(t, expected4.Equal(output4), "%s Valid Case 4 Failed: Expected %s, got %s", opName, expected4, output4)
 
@@ -318,7 +318,7 @@ func TestSliceOp(t *testing.T) {
 	strides5 := []int{2}
 	// Dim 0: (7-0)/2 = 3.5 -> 4 elements (indices 0, 2, 4, 6)
 	expected5 := S(I8, 4)
-	output5, err := SliceOp(operand5, starts5, limits5, strides5)
+	output5, err := Slice(operand5, starts5, limits5, strides5)
 	require.NoError(t, err)
 	require.True(t, expected5.Equal(output5), "%s Valid Case 5 Failed: Expected %s, got %s", opName, expected5, output5)
 
@@ -329,43 +329,43 @@ func TestSliceOp(t *testing.T) {
 	validStrides := []int{1, 1}
 
 	// Error 1: Invalid operand DType
-	_, err = SliceOp(shapes.Shape{DType: dtypes.InvalidDType, Dimensions: []int{10}}, []int{0}, []int{5}, []int{1})
+	_, err = Slice(shapes.Shape{DType: dtypes.InvalidDType, Dimensions: []int{10}}, []int{0}, []int{5}, []int{1})
 	require.Error(t, err)
 
 	// Error 2: Incorrect length for starts
-	_, err = SliceOp(operand, []int{1}, validLimits, validStrides)
+	_, err = Slice(operand, []int{1}, validLimits, validStrides)
 	require.Error(t, err)
 
 	// Error 3: Incorrect length for limits
-	_, err = SliceOp(operand, validStarts, []int{8}, validStrides)
+	_, err = Slice(operand, validStarts, []int{8}, validStrides)
 	require.Error(t, err)
 
 	// Error 4: Incorrect length for strides
-	_, err = SliceOp(operand, validStarts, validLimits, []int{1})
+	_, err = Slice(operand, validStarts, validLimits, []int{1})
 	require.Error(t, err)
 
 	// Error 5: Zero stride
-	_, err = SliceOp(operand, validStarts, validLimits, []int{1, 0})
+	_, err = Slice(operand, validStarts, validLimits, []int{1, 0})
 	require.Error(t, err)
 
 	// Error 6: Negative stride
-	_, err = SliceOp(operand, validStarts, validLimits, []int{-1, 1})
+	_, err = Slice(operand, validStarts, validLimits, []int{-1, 1})
 	require.Error(t, err)
 
 	// Error 7: Start index < 0
-	_, err = SliceOp(operand, []int{-1, 1}, validLimits, validStrides)
+	_, err = Slice(operand, []int{-1, 1}, validLimits, validStrides)
 	require.Error(t, err)
 
 	// Error 8: Start index >= dimSize
-	_, err = SliceOp(operand, []int{10, 1}, validLimits, validStrides)
+	_, err = Slice(operand, []int{10, 1}, validLimits, validStrides)
 	require.Error(t, err)
 
 	// Error 9: Limit index < start index
-	_, err = SliceOp(operand, validStarts, []int{0, 4}, validStrides) // limit[0]=0 < start[0]=1
+	_, err = Slice(operand, validStarts, []int{0, 4}, validStrides) // limit[0]=0 < start[0]=1
 	require.Error(t, err)
 
 	// Error 10: Limit index > dimSize
-	_, err = SliceOp(operand, validStarts, []int{8, 6}, validStrides) // limit[1]=6 > dimSize[1]=5
+	_, err = Slice(operand, validStarts, []int{8, 6}, validStrides) // limit[1]=6 > dimSize[1]=5
 	require.Error(t, err)
 }
 
@@ -375,36 +375,36 @@ func TestArgMinMaxOp(t *testing.T) {
 	// Case 1: 1D tensor
 	operand1 := S(F32, 10)
 	expected1 := S(I32)
-	output1 := must1(ArgMinMaxOp(operand1, 0, I32))
+	output1 := must1(ArgMinMax(operand1, 0, I32))
 	require.True(t, expected1.Equal(output1), "Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
 
 	// Case 2: 2D tensor, single axis
 	operand2 := S(F32, 5, 6)
 	expected2 := S(I8, 5)
-	output2 := must1(ArgMinMaxOp(operand2, 1, expected2.DType))
+	output2 := must1(ArgMinMax(operand2, 1, expected2.DType))
 	require.True(t, expected2.Equal(output2), "Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
 
 	// Case 3: 3D tensor, multiple axes
 	operand3 := S(F32, 4, 5, 6)
 	expected3 := S(U64, 5, 6)
-	output3 := must1(ArgMinMaxOp(operand3, 0, expected3.DType))
+	output3 := must1(ArgMinMax(operand3, 0, expected3.DType))
 	require.True(t, expected3.Equal(output3), "Valid Case 3 Failed: Expected %s, got %s", expected3, output3)
 
 	// --- Error Cases ---
 
 	// Error 1: Invalid operand DType
 	require.Panics(t, func() {
-		must1(ArgMinMaxOp(shapes.Make(dtypes.InvalidDType, 10), 0, I32))
+		must1(ArgMinMax(shapes.Make(dtypes.InvalidDType, 10), 0, I32))
 	})
 
 	// Error 2: Invalid axis (out of bounds)
 	require.Panics(t, func() {
-		must1(ArgMinMaxOp(operand1, 1, I32)) // operand1 is rank 1, axis 1 invalid
+		must1(ArgMinMax(operand1, 1, I32)) // operand1 is rank 1, axis 1 invalid
 	})
 
 	// Error 3: Negative axis
 	require.Panics(t, func() {
-		must1(ArgMinMaxOp(operand2, -1, I32))
+		must1(ArgMinMax(operand2, -1, I32))
 	})
 }
 
@@ -640,7 +640,7 @@ func TestReduceWindowOp(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			outputShape, err := ReduceWindowOp(
+			outputShape, err := ReduceWindow(
 				tc.operandShape,
 				tc.windowDimensions,
 				tc.strides,
@@ -724,7 +724,7 @@ func TestGather(t *testing.T) {
 func TestPad(t *testing.T) {
 	// 1. Prefixing padding; Infixing padding; Suffix padding.
 	t.Run("PrefixInfixSuffix", func(t *testing.T) {
-		output, err := PadOp(
+		output, err := Pad(
 			S(F32, 2, 3),                           // operand
 			PadAxis{Start: 1, End: 0, Interior: 0}, // prefix axis 0
 			PadAxis{Start: 0, End: 2, Interior: 1}, // infix / suffix axis 1
@@ -738,7 +738,7 @@ func TestPad(t *testing.T) {
 	// 2. Check that padding works when it is on the last axis, and when the last axis is untouched.
 	// 3. That untouched axes remain untouched.
 	t.Run("UntouchedAxes", func(t *testing.T) {
-		output, err := PadOp(
+		output, err := Pad(
 			S(F32, 4, 5, 2),                        // operand
 			PadAxis{Start: 0, End: 0, Interior: 0}, // padding on first axis is zero
 			PadAxis{Start: 1, End: 1, Interior: 0}, // padding on middle axis
@@ -752,7 +752,7 @@ func TestPad(t *testing.T) {
 	})
 
 	t.Run("LastAxisPadding", func(t *testing.T) {
-		output, err := PadOp(
+		output, err := Pad(
 			S(F32, 2, 2, 2),                        // operand
 			PadAxis{Start: 0, End: 0, Interior: 0}, // untouched
 			PadAxis{Start: 0, End: 0, Interior: 0}, // untouched
@@ -766,7 +766,7 @@ func TestPad(t *testing.T) {
 	})
 
 	t.Run("MissingAxes", func(t *testing.T) {
-		output, err := PadOp(
+		output, err := Pad(
 			S(F32, 5, 3), // operand
 			PadAxis{Start: 2, End: 2, Interior: 0},
 			// missing axis
@@ -865,7 +865,7 @@ func TestUnaryOp_AxisNames(t *testing.T) {
 func TestTransposeOp_AxisNames(t *testing.T) {
 	t.Run("PermutesNames", func(t *testing.T) {
 		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
-		output, err := TransposeOp(s, []int{1, 0, 2})
+		output, err := Transpose(s, []int{1, 0, 2})
 		require.NoError(t, err)
 		require.Equal(t, []int{-1, -1, 768}, output.Dimensions)
 		require.Equal(t, []string{"seq_len", "batch", ""}, output.AxisNames)
@@ -873,7 +873,7 @@ func TestTransposeOp_AxisNames(t *testing.T) {
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 2, 3)
-		output, err := TransposeOp(s, []int{1, 0})
+		output, err := Transpose(s, []int{1, 0})
 		require.NoError(t, err)
 		require.Nil(t, output.AxisNames)
 	})
@@ -883,7 +883,7 @@ func TestBroadcastInDimOp_AxisNames(t *testing.T) {
 	t.Run("DynamicDimMatch", func(t *testing.T) {
 		operand := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		outputShape := S(F32, 32, 512)
-		err := BroadcastInDimOp(operand, outputShape, []int{0, 1})
+		err := BroadcastInDim(operand, outputShape, []int{0, 1})
 		require.NoError(t, err)
 	})
 
@@ -892,7 +892,7 @@ func TestBroadcastInDimOp_AxisNames(t *testing.T) {
 		// Wait, if output is static, it must match or be 1.
 		operand := S(F32, 32, 512)
 		outputShape := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		err := BroadcastInDimOp(operand, outputShape, []int{0, 1})
+		err := BroadcastInDim(operand, outputShape, []int{0, 1})
 		require.NoError(t, err)
 	})
 }
@@ -901,7 +901,7 @@ func TestReduceOp_AxisNames(t *testing.T) {
 	t.Run("RemovesReducedAxis", func(t *testing.T) {
 		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
 		// Reduce last axis → names for remaining axes preserved.
-		output, err := ReduceOp(s, []int{2})
+		output, err := Reduce(s, []int{2})
 		require.NoError(t, err)
 		require.Equal(t, []int{-1, -1}, output.Dimensions)
 		require.Equal(t, []string{"batch", "seq_len"}, output.AxisNames)
@@ -909,14 +909,14 @@ func TestReduceOp_AxisNames(t *testing.T) {
 
 	t.Run("ReduceToScalar", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		output, err := ReduceOp(s, []int{0, 1})
+		output, err := Reduce(s, []int{0, 1})
 		require.NoError(t, err)
 		require.True(t, output.IsScalar())
 	})
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 4, 5, 6)
-		output, err := ReduceOp(s, []int{1})
+		output, err := Reduce(s, []int{1})
 		require.NoError(t, err)
 		require.Nil(t, output.AxisNames)
 	})
@@ -926,7 +926,7 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 	t.Run("UnifiesNames", func(t *testing.T) {
 		s1 := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		s2 := SD(F32, []int{-1, 256}, []string{"batch", ""})
-		output, err := ConcatenateOp([]shapes.Shape{s1, s2}, 1)
+		output, err := Concatenate([]shapes.Shape{s1, s2}, 1)
 		require.NoError(t, err)
 		require.Equal(t, []string{"batch", ""}, output.AxisNames)
 	})
@@ -935,7 +935,7 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 		// Different names on the concat axis → name is dropped for that axis.
 		s1 := SD(F32, []int{-1, -1}, []string{"batch", "a"})
 		s2 := SD(F32, []int{-1, -1}, []string{"batch", "b"})
-		output, err := ConcatenateOp([]shapes.Shape{s1, s2}, 1) // concat on axis 1
+		output, err := Concatenate([]shapes.Shape{s1, s2}, 1) // concat on axis 1
 		require.NoError(t, err)
 		require.Equal(t, "batch", output.AxisNames[0])
 		require.Equal(t, "", output.AxisNames[1]) // dropped due to conflict
@@ -944,7 +944,7 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 	t.Run("NonConcatAxisNameConflictErrors", func(t *testing.T) {
 		s1 := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		s2 := SD(F32, []int{-1, 512}, []string{"time", ""})
-		_, err := ConcatenateOp([]shapes.Shape{s1, s2}, 1) // concat on axis 1, conflict on axis 0
+		_, err := Concatenate([]shapes.Shape{s1, s2}, 1) // concat on axis 1, conflict on axis 0
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "axis name conflict")
 	})
@@ -952,7 +952,7 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 	t.Run("DynamicConcatAxis", func(t *testing.T) {
 		s1 := SD(F32, []int{-1, -1}, []string{"batch", "seq"})
 		s2 := SD(F32, []int{-1, 128}, []string{"batch", ""})
-		output, err := ConcatenateOp([]shapes.Shape{s1, s2}, 1)
+		output, err := Concatenate([]shapes.Shape{s1, s2}, 1)
 		require.NoError(t, err)
 		require.Equal(t, shapes.DynamicDim, output.Dimensions[1])
 	})
@@ -961,7 +961,7 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 func TestSliceOp_AxisNames(t *testing.T) {
 	t.Run("PreservesNames", func(t *testing.T) {
 		s := S(F32, 10, 20).WithAxisNames("height", "width")
-		output, err := SliceOp(s, []int{2, 5}, []int{8, 15}, []int{1, 1})
+		output, err := Slice(s, []int{2, 5}, []int{8, 15}, []int{1, 1})
 		require.NoError(t, err)
 		require.Equal(t, []string{"height", "width"}, output.AxisNames)
 		require.Equal(t, []int{6, 10}, output.Dimensions)
@@ -969,7 +969,7 @@ func TestSliceOp_AxisNames(t *testing.T) {
 
 	t.Run("DynamicAxis", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		output, err := SliceOp(s, []int{0, 0}, []int{0, 256}, []int{1, 1})
+		output, err := Slice(s, []int{0, 0}, []int{0, 256}, []int{1, 1})
 		require.NoError(t, err)
 		require.Equal(t, shapes.DynamicDim, output.Dimensions[0])
 		require.Equal(t, []string{"batch", ""}, output.AxisNames)
@@ -977,7 +977,7 @@ func TestSliceOp_AxisNames(t *testing.T) {
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 10, 20)
-		output, err := SliceOp(s, []int{0, 0}, []int{5, 10}, []int{1, 1})
+		output, err := Slice(s, []int{0, 0}, []int{5, 10}, []int{1, 1})
 		require.NoError(t, err)
 		require.Nil(t, output.AxisNames)
 	})
@@ -986,7 +986,7 @@ func TestSliceOp_AxisNames(t *testing.T) {
 func TestArgMinMaxOp_AxisNames(t *testing.T) {
 	t.Run("RemovesAxisName", func(t *testing.T) {
 		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
-		output, err := ArgMinMaxOp(s, 2, I32)
+		output, err := ArgMinMax(s, 2, I32)
 		require.NoError(t, err)
 		require.Equal(t, []int{-1, -1}, output.Dimensions)
 		require.Equal(t, []string{"batch", "seq_len"}, output.AxisNames)
@@ -994,7 +994,7 @@ func TestArgMinMaxOp_AxisNames(t *testing.T) {
 
 	t.Run("RemovesFirstAxis", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		output, err := ArgMinMaxOp(s, 0, I32)
+		output, err := ArgMinMax(s, 0, I32)
 		require.NoError(t, err)
 		require.Equal(t, []int{512}, output.Dimensions)
 		require.Equal(t, []string{""}, output.AxisNames)
@@ -1002,7 +1002,7 @@ func TestArgMinMaxOp_AxisNames(t *testing.T) {
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 5, 6)
-		output, err := ArgMinMaxOp(s, 1, I32)
+		output, err := ArgMinMax(s, 1, I32)
 		require.NoError(t, err)
 		require.Nil(t, output.AxisNames)
 	})
@@ -1011,14 +1011,14 @@ func TestArgMinMaxOp_AxisNames(t *testing.T) {
 func TestReduceWindowOp_AxisNames(t *testing.T) {
 	t.Run("PreservesNames", func(t *testing.T) {
 		s := S(F32, 1, 20, 22, 3).WithAxisNames("batch", "height", "width", "channels")
-		output, err := ReduceWindowOp(s, []int{1, 3, 3, 1}, []int{1, 2, 2, 1}, nil, nil, nil)
+		output, err := ReduceWindow(s, []int{1, 3, 3, 1}, []int{1, 2, 2, 1}, nil, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, []string{"batch", "height", "width", "channels"}, output.AxisNames)
 	})
 
 	t.Run("DynamicDim", func(t *testing.T) {
 		s := SD(F32, []int{-1, 10}, []string{"batch", "seq"})
-		output, err := ReduceWindowOp(s, []int{1, 3}, []int{1, 1}, nil, nil, nil)
+		output, err := ReduceWindow(s, []int{1, 3}, []int{1, 1}, nil, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, shapes.DynamicDim, output.Dimensions[0])
 		require.Equal(t, 8, output.Dimensions[1])
@@ -1027,7 +1027,7 @@ func TestReduceWindowOp_AxisNames(t *testing.T) {
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 10)
-		output, err := ReduceWindowOp(s, []int{3}, nil, nil, nil, nil)
+		output, err := ReduceWindow(s, []int{3}, nil, nil, nil, nil)
 		require.NoError(t, err)
 		require.Nil(t, output.AxisNames)
 	})
@@ -1055,9 +1055,8 @@ func TestDotGeneral_DynamicAndNames(t *testing.T) {
 func TestReshapeOp_Dynamic(t *testing.T) {
 	t.Run("PropagatesDynamicDim", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		output, err := ReshapeOp(s, []int{-1, 8, 64})
+		output, err := Reshape(s, []int{-1, 8, 64})
 		require.NoError(t, err)
 		require.Equal(t, []int{-1, 8, 64}, output.Dimensions)
 	})
 }
-

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -794,7 +794,7 @@ func TestBinaryOp_AxisNames(t *testing.T) {
 	t.Run("OneNamed", func(t *testing.T) {
 		// lhs has names, rhs does not → adopt lhs names.
 		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		rhs := S(F32, 32, 512)
+		rhs := S(F32, 1, 512)
 		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
 		require.NoError(t, err)
 		require.Equal(t, []string{"batch", ""}, output.AxisNames)
@@ -813,7 +813,7 @@ func TestBinaryOp_AxisNames(t *testing.T) {
 		rhs := SD(F32, []int{-1, 512}, []string{"time", ""})
 		_, err := BinaryOp(OpTypeAdd, lhs, rhs)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "axis name conflict")
+		require.Contains(t, err.Error(), "different axis names")
 	})
 
 	t.Run("DynamicBroadcast", func(t *testing.T) {
@@ -1058,5 +1058,21 @@ func TestReshapeOp_Dynamic(t *testing.T) {
 		output, err := Reshape(s, []int{-1, 8, 64})
 		require.NoError(t, err)
 		require.Equal(t, []int{-1, 8, 64}, output.Dimensions)
+		require.Equal(t, []string{"batch", "", ""}, output.AxisNames)
+	})
+
+	t.Run("MultipleDynamicDims", func(t *testing.T) {
+		s := SD(F32, []int{10, -1, 512, -1}, []string{"", "batch", "", "seq"})
+		output, err := Reshape(s, []int{-1, -1, 8, 640})
+		require.NoError(t, err)
+		require.Equal(t, []int{-1, -1, 8, 640}, output.Dimensions)
+		require.Equal(t, []string{"batch", "seq", "", ""}, output.AxisNames)
+	})
+
+	t.Run("MismatchedDynamicDims", func(t *testing.T) {
+		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		_, err := Reshape(s, []int{-1, -1, 64})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requires the number of dynamic dimensions in the input (1) to match the target dims (2)")
 	})
 }

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -1220,18 +1220,15 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 
 	t.Run("ConcatAxisNameConflictDrops", func(t *testing.T) {
 		// Different names on the concat axis → name is dropped for that axis.
-		s1 := SD(F32, []int{-1, -1}, []string{"batch", "a"})
-		s2 := SD(F32, []int{-1, -1}, []string{"batch", "b"})
-		output, err := Concatenate([]shapes.Shape{s1, s2}, 1) // concat on axis 1
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
+		s1 := SD(F32, []int{-1, 10}, []string{"batch", "a"})
+		s2 := SD(F32, []int{-1, 10}, []string{"batch", "b"})
+		_, err := Concatenate([]shapes.Shape{s1, s2}, 0) // concat on axis 0 (dynamic)
+		if err == nil {
+			t.Fatalf("Expected error when concatenating on dynamic axis, but got nil")
 		}
-		if ok, diff := testutil.IsEqual("batch", output.AxisNames[0]); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, "batch", output.AxisNames[0])
+		if !strings.Contains(err.Error(), "concatenation on a dynamic axis") {
+			t.Errorf("Expected error message to mention concatenation on dynamic axis, got: %v", err)
 		}
-		if ok, diff := testutil.IsEqual("", output.AxisNames[1]); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, "", output.AxisNames[1])
-		} // dropped due to conflict
 	})
 
 	t.Run("NonConcatAxisNameConflictErrors", func(t *testing.T) {
@@ -1249,12 +1246,9 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 	t.Run("DynamicConcatAxis", func(t *testing.T) {
 		s1 := SD(F32, []int{-1, -1}, []string{"batch", "seq"})
 		s2 := SD(F32, []int{-1, 128}, []string{"batch", ""})
-		output, err := Concatenate([]shapes.Shape{s1, s2}, 1)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if ok, diff := testutil.IsEqual(shapes.DynamicDim, output.Dimensions[1]); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, shapes.DynamicDim, output.Dimensions[1])
+		_, err := Concatenate([]shapes.Shape{s1, s2}, 1) // Concatenating on dynamic axis 1
+		if err == nil {
+			t.Fatalf("Expected error when concatenating on dynamic axis, but got nil")
 		}
 	})
 }
@@ -1276,7 +1270,8 @@ func TestSliceOp_AxisNames(t *testing.T) {
 
 	t.Run("DynamicAxis", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		output, err := Slice(s, []int{0, 0}, []int{0, 256}, []int{1, 1})
+		// Use -1 for limit to mean "full axis" (results in -1 dimension).
+		output, err := Slice(s, []int{0, 0}, []int{-1, 256}, []int{1, 1})
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -1411,43 +1406,142 @@ func TestDotGeneral_DynamicAndNames(t *testing.T) {
 	})
 }
 
-func TestReshapeOp_Dynamic(t *testing.T) {
-	t.Run("PropagatesDynamicDim", func(t *testing.T) {
-		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		output, err := Reshape(s, []int{-1, 8, 64})
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if ok, diff := testutil.IsEqual([]int{-1, 8, 64}, output.Dimensions); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, 8, 64}, output.Dimensions)
-		}
-		if ok, diff := testutil.IsEqual([]string{"batch", "", ""}, output.AxisNames); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "", ""}, output.AxisNames)
-		}
-	})
-
-	t.Run("MultipleDynamicDims", func(t *testing.T) {
-		s := SD(F32, []int{10, -1, 512, -1}, []string{"", "batch", "", "seq"})
-		output, err := Reshape(s, []int{-1, -1, 8, 640})
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if ok, diff := testutil.IsEqual([]int{-1, -1, 8, 640}, output.Dimensions); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, -1, 8, 640}, output.Dimensions)
-		}
-		if ok, diff := testutil.IsEqual([]string{"batch", "seq", "", ""}, output.AxisNames); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "seq", "", ""}, output.AxisNames)
-		}
-	})
-
-	t.Run("MismatchedDynamicDims", func(t *testing.T) {
-		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		_, err := Reshape(s, []int{-1, -1, 64})
+func TestConcatenateOp_Dynamic(t *testing.T) {
+	t.Run("ConcatOnDynamicAxis", func(t *testing.T) {
+		// Concatenating on a dynamic axis should currently be an error because we can't
+		// represent the resulting size (e.g. batchSize + batchSize) symbolically.
+		s1 := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		s2 := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		_, err := Concatenate([]shapes.Shape{s1, s2}, 0)
 		if err == nil {
-			t.Fatalf("Expected error, got nil")
+			t.Fatalf("Expected error when concatenating on dynamic axis, but got nil")
 		}
-		if !strings.Contains(err.Error(), "requires the number of dynamic dimensions in the input (1) to match the target dims (2)") {
-			t.Fatalf("Expected %v to contain %v", err.Error(), "requires the number of dynamic dimensions in the input (1) to match the target dims (2)")
+		if !strings.Contains(err.Error(), "concatenation on a dynamic axis") {
+			t.Errorf("Expected error message to mention concatenation on dynamic axis, got: %v", err)
+		}
+	})
+
+	t.Run("ConcatPreservesDynamicNonConcatAxes", func(t *testing.T) {
+		s1 := SD(F32, []int{-1, 10}, []string{"batch", ""})
+		s2 := SD(F32, []int{-1, 20}, []string{"batch", ""})
+		output, err := Concatenate([]shapes.Shape{s1, s2}, 1)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, 30}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, 30}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
+	})
+}
+
+func TestSliceOp_DynamicCorrect(t *testing.T) {
+	t.Run("StaticSliceOfDynamicAxis", func(t *testing.T) {
+		// Slicing a dynamic axis with static bounds should result in a static output size.
+		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := Slice(s, []int{0, 0}, []int{10, 256}, []int{1, 1})
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		// The first axis should now be static size 10.
+		if ok, diff := testutil.IsEqual([]int{10, 256}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{10, 256}, output.Dimensions)
+		}
+	})
+}
+
+func TestPadOp_Dynamic(t *testing.T) {
+	t.Run("PadOnDynamicAxis", func(t *testing.T) {
+		// Padding on a dynamic axis should be an error if padding is non-zero.
+		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		_, err := Pad(s, PadAxis{Start: 1, End: 1})
+		if err == nil {
+			t.Fatalf("Expected error when padding on dynamic axis, but got nil")
+		}
+		if !strings.Contains(err.Error(), "padding on a dynamic axis") {
+			t.Errorf("Expected error message to mention padding on dynamic axis, got: %v", err)
+		}
+	})
+
+	t.Run("ZeroPadOnDynamicAxis", func(t *testing.T) {
+		// Zero padding on a dynamic axis should be allowed.
+		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := Pad(s, PadAxis{Start: 0, End: 0})
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, 512}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, 512}, output.Dimensions)
+		}
+	})
+}
+
+func TestGatherOp_Dynamic(t *testing.T) {
+	t.Run("PropagatesBatchNames", func(t *testing.T) {
+		operand := S(F32, 10, 20)
+		startIndices := SD(I32, []int{-1, 1}, []string{"batch", ""})
+		output, err := Gather(
+			operand, startIndices, 1,
+			[]int{1}, []int{0}, []int{0}, []int{1, 20}, false,
+		)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected axis names %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
+	})
+}
+
+func TestReduceOp_Dynamic(t *testing.T) {
+	t.Run("PreservesOtherDynamicAxes", func(t *testing.T) {
+		s := SD(F32, []int{-1, 10, -1}, []string{"batch", "", "seq"})
+		output, err := Reduce(s, []int{1}) // Reduce middle axis
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, -1}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, -1}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "seq"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "seq"}, output.AxisNames)
+		}
+	})
+}
+
+func TestArgMinMaxOp_Dynamic(t *testing.T) {
+	t.Run("PreservesOtherDynamicAxes", func(t *testing.T) {
+		s := SD(F32, []int{-1, 10, -1}, []string{"batch", "", "seq"})
+		output, err := ArgMinMax(s, 1, dtypes.Int32)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, -1}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, -1}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "seq"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "seq"}, output.AxisNames)
+		}
+	})
+}
+
+func TestScatterOp_Dynamic(t *testing.T) {
+	t.Run("AllowsDynamicOperandAndUpdates", func(t *testing.T) {
+		operand := SD(F32, []int{-1, 10}, []string{"batch", ""})
+		indices := S(I32, 5, 1)
+		updates := SD(F32, []int{5, 10}, []string{"", ""})
+		// Scatter 5 updates to the dynamic batch axis
+		output, err := Scatter(
+			operand, indices, updates, 1,
+			[]int{1}, []int{0}, []int{0},
+		)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !output.Equal(operand) {
+			t.Fatalf("Expected output to be equal to operand")
 		}
 	})
 }

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -4,6 +4,7 @@ package shapeinference
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/gomlx/compute"
@@ -11,8 +12,6 @@ import (
 	"github.com/gomlx/compute/shapes"
 	"github.com/gomlx/compute/support/sets"
 	"github.com/gomlx/compute/support/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Aliases
@@ -35,73 +34,121 @@ func TestBinaryOp(t *testing.T) {
 	// Invalid data types check.
 	var err error
 	_, err = BinaryOp(OpTypeLogicalAnd, S(I8), S(I8))
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 	_, err = BinaryOp(OpTypeMul, S(Bool, 1), S(Bool, 1))
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 	_, err = BinaryOp(OpTypeMul, S(Bool, 1), S(Bool, 1))
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 	_, err = BinaryOp(OpTypeBitwiseXor, S(F32, 1), S(F32, 1))
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Invalid operation type (not binary op).
 	_, err = BinaryOp(OpTypeExp, S(F32), S(F32))
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// The same shape should be ok.
 	var output shapes.Shape
 	intMatrixShape := S(I8, 3, 3)
 	output, err = BinaryOp(OpTypeBitwiseOr, intMatrixShape, intMatrixShape)
-	require.NoError(t, err)
-	require.True(t, intMatrixShape.Equal(output))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(intMatrixShape.Equal(output)) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	// Scalar with matrix.
 	scalarShape := S(F32)
 	matrixShape := S(F32, 2, 3)
 	expectedShape := S(F32, 2, 3)
 	output, err = BinaryOp(OpTypeAdd, scalarShape, scalarShape)
-	require.NoError(t, err)
-	require.True(t, scalarShape.Equal(output))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(scalarShape.Equal(output)) {
+		t.Fatalf("Condition expected to be true")
+	}
 	output, err = BinaryOp(OpTypeAdd, scalarShape, matrixShape)
-	require.NoError(t, err)
-	require.True(t, expectedShape.Equal(output))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expectedShape.Equal(output)) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	// Broadcasting on both sides.
 	shape1 := S(F32, 2, 1, 3)
 	shape2 := S(F32, 1, 4, 3)
 	expectedBroadcastShape := S(F32, 2, 4, 3)
-	require.True(t, expectedBroadcastShape.Equal(must1(BinaryOp(OpTypeMul, shape1, shape2))))
+	if !(expectedBroadcastShape.Equal(must1(BinaryOp(OpTypeMul, shape1, shape2)))) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	// Matrix with scalar.
-	require.True(t, expectedShape.Equal(must1(BinaryOp(OpTypeAdd, matrixShape, scalarShape))))
+	if !(expectedShape.Equal(must1(BinaryOp(OpTypeAdd, matrixShape, scalarShape)))) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	// Invalid broadcasting shapes.
 	invalidShape1 := S(F32, 2, 3)
 	invalidShape2 := S(F32, 3, 2)
 	_, err = BinaryOp(OpTypeAdd, invalidShape1, invalidShape2)
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 }
 
 func TestUnaryOp(t *testing.T) {
 	// Invalid data types check.
-	require.Panics(t, func() { must1(UnaryOp(OpTypeLogicalNot, S(F32))) })
-	require.Panics(t, func() { must1(UnaryOp(OpTypeLogicalNot, S(I8))) })
-	require.Panics(t, func() { must1(UnaryOp(OpTypeBitwiseNot, S(F32))) })
-	require.Panics(t, func() { must1(UnaryOp(OpTypeNeg, S(Bool))) })
+	if panicked, _ := testutil.Try(func() { must1(UnaryOp(OpTypeLogicalNot, S(F32))) }); !panicked {
+		t.Fatalf("Expected panic")
+	}
+	if panicked, _ := testutil.Try(func() { must1(UnaryOp(OpTypeLogicalNot, S(I8))) }); !panicked {
+		t.Fatalf("Expected panic")
+	}
+	if panicked, _ := testutil.Try(func() { must1(UnaryOp(OpTypeBitwiseNot, S(F32))) }); !panicked {
+		t.Fatalf("Expected panic")
+	}
+	if panicked, _ := testutil.Try(func() { must1(UnaryOp(OpTypeNeg, S(Bool))) }); !panicked {
+		t.Fatalf("Expected panic")
+	}
 
 	// Invalid operation type (not unary op).
-	require.Panics(t, func() { must1(UnaryOp(OpTypeAdd, S(F32))) })
-	require.Panics(t, func() { must1(UnaryOp(OpTypeNeg, S(U64))) })
+	if panicked, _ := testutil.Try(func() { must1(UnaryOp(OpTypeAdd, S(F32))) }); !panicked {
+		t.Fatalf("Expected panic")
+	}
+	if panicked, _ := testutil.Try(func() { must1(UnaryOp(OpTypeNeg, S(U64))) }); !panicked {
+		t.Fatalf("Expected panic")
+	}
 
 	// Valid operations
 	boolShape := S(Bool, 2, 3)
-	require.True(t, boolShape.Equal(must1(UnaryOp(OpTypeLogicalNot, boolShape))))
+	if !(boolShape.Equal(must1(UnaryOp(OpTypeLogicalNot, boolShape)))) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	intShape := S(I8, 3, 3)
-	require.True(t, intShape.Equal(must1(UnaryOp(OpTypeBitwiseNot, intShape))))
+	if !(intShape.Equal(must1(UnaryOp(OpTypeBitwiseNot, intShape)))) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	floatShape := S(F32, 2, 3)
-	require.True(t, floatShape.Equal(must1(UnaryOp(OpTypeExp, floatShape))))
-	require.True(t, floatShape.Equal(must1(UnaryOp(OpTypeNeg, floatShape))))
+	if !(floatShape.Equal(must1(UnaryOp(OpTypeExp, floatShape)))) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if !(floatShape.Equal(must1(UnaryOp(OpTypeNeg, floatShape)))) {
+		t.Fatalf("Condition expected to be true")
+	}
 }
 
 func TestGatherOp(t *testing.T) {
@@ -115,9 +162,13 @@ func TestGatherOp(t *testing.T) {
 	sliceSizes := []int{1, 3, 1, 1}
 	output, err := Gather(operand, startIndices, indexVectorAxis,
 		offsetOutputAxes, collapsedSliceAxes, startIndexMap, sliceSizes, false)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 	fmt.Printf("\tTest 1: outputShape=%s\n", output)
-	require.NoError(t, output.Check(F32, 3, 3, 2, 1))
+	if output.Check(F32, 3, 3, 2, 1) != nil {
+		t.Fatalf("Expected no error, got %v", output.Check(F32, 3, 3, 2, 1))
+	}
 
 	// Test 2:
 	operand = S(F32, 3, 4, 5, 6)
@@ -128,9 +179,13 @@ func TestGatherOp(t *testing.T) {
 	startIndexMap = []int{1, 2, 3}
 	sliceSizes = []int{3, 1, 1, 1}
 	output, err = Gather(operand, startIndices, indexVectorAxis, offsetOutputAxes, collapsedSliceAxes, startIndexMap, sliceSizes, true)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 	fmt.Printf("\tTest 2: outputShape=%s\n", output)
-	require.NoError(t, output.Check(F32, 7, 3, 1, 8))
+	if output.Check(F32, 7, 3, 1, 8) != nil {
+		t.Fatalf("Expected no error, got %v", output.Check(F32, 7, 3, 1, 8))
+	}
 
 	// Test 3:
 	operand = S(F32, 8, 16)
@@ -141,9 +196,13 @@ func TestGatherOp(t *testing.T) {
 	startIndexMap = []int{0}
 	sliceSizes = []int{1, 16}
 	output, err = Gather(operand, startIndices, indexVectorAxis, offsetOutputAxes, collapsedSliceAxes, startIndexMap, sliceSizes, true)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 	fmt.Printf("\tTest 3: outputShape=%s\n", output)
-	require.NoError(t, output.Check(F32, 8, 16))
+	if output.Check(F32, 8, 16) != nil {
+		t.Fatalf("Expected no error, got %v", output.Check(F32, 8, 16))
+	}
 }
 
 func TestScatterOp(t *testing.T) {
@@ -161,8 +220,12 @@ func TestScatterOp(t *testing.T) {
 	scatterAxesToOperandAxes1 := []int{0} // Index coordinate vector element 0 maps to operand axis 0
 	expected1 := operand1
 	output1, err := Scatter(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1)
-	require.NoError(t, err)
-	require.True(t, expected1.Equal(output1), "Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected1.Equal(output1)) {
+		t.Fatalf("Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
+	}
 
 	// Case 2: Scattering into a higher-rank tensor
 	// Scatter updates of shape [4] into operand[i, j, :], where [i, j] comes from indices.
@@ -178,8 +241,12 @@ func TestScatterOp(t *testing.T) {
 	scatterAxesToOperandAxes2 := []int{0, 1} // index coord 0 -> operand axis 0, index coord 1 -> operand axis 1
 	expected2 := operand2
 	output2, err := Scatter(operand2, indices2, updates2, indexVectorAxis2, updateWindowAxes2, insertedWindowAxes2, scatterAxesToOperandAxes2)
-	require.NoError(t, err)
-	require.True(t, expected2.Equal(output2), "Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected2.Equal(output2)) {
+		t.Fatalf("Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
+	}
 
 	// Case 3: Different indexVectorAxis
 	// Same as case 2, but indices are [2, 2, 3] -> indexVectorAxis is 1 and different order of axes in the operand.
@@ -192,8 +259,12 @@ func TestScatterOp(t *testing.T) {
 	scatterAxesToOperandAxes3 := []int{1, 2} // indices are used for different axes in the operand this time.
 	expected3 := operand2                    // Still expect operand shape
 	output3, err := Scatter(operand3, indices3, updates3, indexVectorAxis3, updateWindowAxes3, insertedWindowAxes3, scatterAxesToOperandAxes3)
-	require.NoError(t, err)
-	require.True(t, expected3.Equal(output3), "Valid Case 3 Failed (IndexVecAxis=1): Expected %s, got %s", expected3, output3)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected3.Equal(output3)) {
+		t.Fatalf("Valid Case 3 Failed (IndexVecAxis=1): Expected %s, got %s", expected3, output3)
+	}
 
 	// Case 4: No insertedWindowAxes (scattering full slices)
 	// Scatter updates of shape [9] into operand [10, 9]
@@ -206,8 +277,12 @@ func TestScatterOp(t *testing.T) {
 	scatterAxesToOperandAxes4 := []int{0} // Index coord 0 -> operand axis 0
 	expected4 := operand4
 	output4, err := Scatter(operand4, indices4, updates4, indexVectorAxis4, updateWindowAxes4, insertedWindowAxes4, scatterAxesToOperandAxes4)
-	require.NoError(t, err)
-	require.True(t, expected4.Equal(output4), "Valid Case 4 Failed (No Window): Expected %s, got %s", expected4, output4)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected4.Equal(output4)) {
+		t.Fatalf("Valid Case 4 Failed (No Window): Expected %s, got %s", expected4, output4)
+	}
 
 	// Case 5: rearranging the output axes:
 	operand5 := S(F32, 2, 5, 2)
@@ -218,51 +293,77 @@ func TestScatterOp(t *testing.T) {
 	insertedWindowAxes5 := []int{0, 2}
 	scatterAxesToOperandAxes5 := []int{0, 2}
 	output5, err := Scatter(operand5, indices5, updates5, indexVectorAxis5, updateWindowAxes5, insertedWindowAxes5, scatterAxesToOperandAxes5)
-	require.NoError(t, err)
-	require.True(t, operand5.Equal(output5), "Valid Case 5 Failed (No Window): Expected %s, got %s", operand5, output5)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(operand5.Equal(output5)) {
+		t.Fatalf("Valid Case 5 Failed (No Window): Expected %s, got %s", operand5, output5)
+	}
 
 	// --- Error Cases ---
 
 	// Error Case 1: Mismatched DType (Operand vs Updates) - unchanged
 	_, err = Scatter(S(F32, 4, 5), S(I8, 2, 1), S(I8, 2, 5), 1, []int{1}, []int{1}, []int{0})
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error Case 2: Invalid DType for indices - unchanged
 	_, err = Scatter(S(F32, 4, 5), S(F32, 2, 1), S(F32, 2, 5), 1, []int{1}, []int{1}, []int{0})
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error Case 3: indexVectorAxis out of bounds
 	_, err = Scatter(operand1, indices1, updates1, 2, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1) // indices1 rank 2, axis 2 invalid
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	_, err = Scatter(operand1, indices1, updates1, -1, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1) // Negative axis
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error Case 4: len(updateWindowAxes) != len(insertedWindowAxes)
 	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, []int{1}, []int{1, 0}, scatterAxesToOperandAxes1) // inserted has len 2, update has len 1
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error Case 5: len(scatterAxesToOperandAxes) != size of index vector dimension
 	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, []int{0, 1}) // scatterAxes has len 2, expected 1
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 	_, err = Scatter(operand2, indices2, updates2, indexVectorAxis2, updateWindowAxes2, insertedWindowAxes2, []int{0}) // scatterAxes has len 1, expected 2
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error Case 6: Invalid axis index in updateWindowAxes
 	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, []int{2}, insertedWindowAxes1, scatterAxesToOperandAxes1) // axis 2 invalid for rank 2 updates
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error Case 7: Invalid axis index in insertedWindowAxes
 	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, []int{2}, scatterAxesToOperandAxes1) // axis 2 invalid for rank 2 operand
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error Case 8: Invalid axis index in scatterAxesToOperandAxes
 	_, err = Scatter(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, []int{2}) // axis 2 invalid for rank 2 operand
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error Case 9: Update dimension is larger than the corresponding dimension in the operand:
 	_, err = Scatter(operand5, indices5, updates5, indexVectorAxis5, updateWindowAxes5, []int{0, 1}, scatterAxesToOperandAxes5) // axis 2 invalid for rank 2 operand
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 }
 
 func TestSliceOp(t *testing.T) {
@@ -276,8 +377,12 @@ func TestSliceOp(t *testing.T) {
 	strides1 := []int{1}
 	expected1 := S(F32, 6)
 	output1, err := Slice(operand1, starts1, limits1, strides1)
-	require.NoError(t, err)
-	require.True(t, expected1.Equal(output1), "%s Valid Case 1 Failed: Expected %s, got %s", opName, expected1, output1)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected1.Equal(output1)) {
+		t.Fatalf("%s Valid Case 1 Failed: Expected %s, got %s", opName, expected1, output1)
+	}
 
 	// Case 2: 2D slice with stride 1
 	operand2 := S(I32, 5, 6)
@@ -286,8 +391,12 @@ func TestSliceOp(t *testing.T) {
 	strides2 := []int{1, 1}
 	expected2 := S(I32, 3, 3)
 	output2, err := Slice(operand2, starts2, limits2, strides2)
-	require.NoError(t, err)
-	require.True(t, expected2.Equal(output2), "%s Valid Case 2 Failed: Expected %s, got %s", opName, expected2, output2)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected2.Equal(output2)) {
+		t.Fatalf("%s Valid Case 2 Failed: Expected %s, got %s", opName, expected2, output2)
+	}
 
 	// Case 3: 3D slice with different strides
 	operand3 := S(Bool, 10, 8, 6)
@@ -299,8 +408,12 @@ func TestSliceOp(t *testing.T) {
 	// Dim 2: (6-1)/1 = 5 -> 5 elements (indices 1, 2, 3, 4, 5)
 	expected3 := S(Bool, 5, 3, 5)
 	output3, err := Slice(operand3, starts3, limits3, strides3)
-	require.NoError(t, err)
-	require.True(t, expected3.Equal(output3), "%s Valid Case 3 Failed: Expected %s, got %s", opName, expected3, output3)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected3.Equal(output3)) {
+		t.Fatalf("%s Valid Case 3 Failed: Expected %s, got %s", opName, expected3, output3)
+	}
 
 	// Case 4: Slice resulting in size 1 dimension
 	operand4 := S(F32, 10)
@@ -309,8 +422,12 @@ func TestSliceOp(t *testing.T) {
 	strides4 := []int{1}
 	expected4 := S(F32, 1)
 	output4, err := Slice(operand4, starts4, limits4, strides4)
-	require.NoError(t, err)
-	require.True(t, expected4.Equal(output4), "%s Valid Case 4 Failed: Expected %s, got %s", opName, expected4, output4)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected4.Equal(output4)) {
+		t.Fatalf("%s Valid Case 4 Failed: Expected %s, got %s", opName, expected4, output4)
+	}
 
 	// Case 5: Slice taking full dimension with stride > 1
 	operand5 := S(I8, 7)
@@ -320,8 +437,12 @@ func TestSliceOp(t *testing.T) {
 	// Dim 0: (7-0)/2 = 3.5 -> 4 elements (indices 0, 2, 4, 6)
 	expected5 := S(I8, 4)
 	output5, err := Slice(operand5, starts5, limits5, strides5)
-	require.NoError(t, err)
-	require.True(t, expected5.Equal(output5), "%s Valid Case 5 Failed: Expected %s, got %s", opName, expected5, output5)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(expected5.Equal(output5)) {
+		t.Fatalf("%s Valid Case 5 Failed: Expected %s, got %s", opName, expected5, output5)
+	}
 
 	// --- Error Cases ---
 	operand := S(F32, 10, 5) // Rank 2
@@ -331,43 +452,63 @@ func TestSliceOp(t *testing.T) {
 
 	// Error 1: Invalid operand DType
 	_, err = Slice(shapes.Shape{DType: dtypes.InvalidDType, Dimensions: []int{10}}, []int{0}, []int{5}, []int{1})
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 2: Incorrect length for starts
 	_, err = Slice(operand, []int{1}, validLimits, validStrides)
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 3: Incorrect length for limits
 	_, err = Slice(operand, validStarts, []int{8}, validStrides)
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 4: Incorrect length for strides
 	_, err = Slice(operand, validStarts, validLimits, []int{1})
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 5: Zero stride
 	_, err = Slice(operand, validStarts, validLimits, []int{1, 0})
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 6: Negative stride
 	_, err = Slice(operand, validStarts, validLimits, []int{-1, 1})
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 7: Start index < 0
 	_, err = Slice(operand, []int{-1, 1}, validLimits, validStrides)
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 8: Start index >= dimSize
 	_, err = Slice(operand, []int{10, 1}, validLimits, validStrides)
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 9: Limit index < start index
 	_, err = Slice(operand, validStarts, []int{0, 4}, validStrides) // limit[0]=0 < start[0]=1
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Error 10: Limit index > dimSize
 	_, err = Slice(operand, validStarts, []int{8, 6}, validStrides) // limit[1]=6 > dimSize[1]=5
-	require.Error(t, err)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 }
 
 func TestArgMinMaxOp(t *testing.T) {
@@ -377,36 +518,48 @@ func TestArgMinMaxOp(t *testing.T) {
 	operand1 := S(F32, 10)
 	expected1 := S(I32)
 	output1 := must1(ArgMinMax(operand1, 0, I32))
-	require.True(t, expected1.Equal(output1), "Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
+	if !(expected1.Equal(output1)) {
+		t.Fatalf("Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
+	}
 
 	// Case 2: 2D tensor, single axis
 	operand2 := S(F32, 5, 6)
 	expected2 := S(I8, 5)
 	output2 := must1(ArgMinMax(operand2, 1, expected2.DType))
-	require.True(t, expected2.Equal(output2), "Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
+	if !(expected2.Equal(output2)) {
+		t.Fatalf("Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
+	}
 
 	// Case 3: 3D tensor, multiple axes
 	operand3 := S(F32, 4, 5, 6)
 	expected3 := S(U64, 5, 6)
 	output3 := must1(ArgMinMax(operand3, 0, expected3.DType))
-	require.True(t, expected3.Equal(output3), "Valid Case 3 Failed: Expected %s, got %s", expected3, output3)
+	if !(expected3.Equal(output3)) {
+		t.Fatalf("Valid Case 3 Failed: Expected %s, got %s", expected3, output3)
+	}
 
 	// --- Error Cases ---
 
 	// Error 1: Invalid operand DType
-	require.Panics(t, func() {
+	if panicked, _ := testutil.Try(func() {
 		must1(ArgMinMax(shapes.Make(dtypes.InvalidDType, 10), 0, I32))
-	})
+	}); !panicked {
+		t.Fatalf("Expected panic")
+	}
 
 	// Error 2: Invalid axis (out of bounds)
-	require.Panics(t, func() {
+	if panicked, _ := testutil.Try(func() {
 		must1(ArgMinMax(operand1, 1, I32)) // operand1 is rank 1, axis 1 invalid
-	})
+	}); !panicked {
+		t.Fatalf("Expected panic")
+	}
 
 	// Error 3: Negative axis
-	require.Panics(t, func() {
+	if panicked, _ := testutil.Try(func() {
 		must1(ArgMinMax(operand2, -1, I32))
-	})
+	}); !panicked {
+		t.Fatalf("Expected panic")
+	}
 }
 
 func TestReduceWindowOp(t *testing.T) {
@@ -651,15 +804,21 @@ func TestReduceWindowOp(t *testing.T) {
 			)
 
 			if tc.expectError {
-				require.Error(t, err, "Expected an error for test case: %s", tc.name)
+				if err == nil {
+					t.Fatalf("Expected an error for test case: %s", tc.name)
+				}
 				if tc.errorMessageContains != "" {
-					assert.Contains(t, err.Error(), tc.errorMessageContains, "Error message mismatch for: %s", tc.name)
+					if !strings.Contains(err.Error(), tc.errorMessageContains) {
+						t.Errorf("Error message mismatch for: %s", tc.name)
+					}
 				}
 			} else {
-				require.NoError(t, err, "Did not expect an error for test case: %s (error was: %v)", tc.name, err)
-				assert.True(t, tc.expectedShape.Equal(outputShape),
-					"Mismatch in output shape for test case: %s. Expected %s, Got %s",
-					tc.name, tc.expectedShape, outputShape)
+				if err != nil {
+					t.Fatalf("Did not expect an error for test case: %s (error was: %v)", tc.name, err)
+				}
+				if !(tc.expectedShape.Equal(outputShape)) {
+					t.Errorf("Mismatch in output shape for test case: %s. Expected %s, Got %s", tc.name, tc.expectedShape, outputShape)
+				}
 			}
 		})
 	}
@@ -679,8 +838,12 @@ func TestGather(t *testing.T) {
 			[]int{1, 4},  // sliceSizes
 			false,        // indicesAreSorted
 		)
-		require.NoError(t, err)
-		assert.True(t, S(F32, 2, 4).Equal(output), "expected F32[2, 4], got %s", output)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !(S(F32, 2, 4).Equal(output)) {
+			t.Errorf("expected F32[2, 4], got %s", output)
+		}
 	})
 
 	t.Run("HighIndexVectorAxisLowRankOperand", func(t *testing.T) {
@@ -701,8 +864,12 @@ func TestGather(t *testing.T) {
 			[]int{1, 1},            // sliceSizes
 			false,                  // indicesAreSorted
 		)
-		require.NoError(t, err)
-		assert.True(t, S(Bool, 1, 1, 12, 1).Equal(output), "expected Bool[1, 1, 12, 1], got %s", output)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !(S(Bool, 1, 1, 12, 1).Equal(output)) {
+			t.Errorf("expected Bool[1, 1, 12, 1], got %s", output)
+		}
 	})
 
 	t.Run("IndexVectorAxisOutOfRange", func(t *testing.T) {
@@ -717,8 +884,12 @@ func TestGather(t *testing.T) {
 			[]int{1, 4},  // sliceSizes
 			false,        // indicesAreSorted
 		)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "indexVectorAxis=3 is out of range")
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "indexVectorAxis=3 is out of range") {
+			t.Errorf("Expected %v to contain %v", err.Error(), "indexVectorAxis=3 is out of range")
+		}
 	})
 }
 
@@ -730,10 +901,14 @@ func TestPad(t *testing.T) {
 			PadAxis{Start: 1, End: 0, Interior: 0}, // prefix axis 0
 			PadAxis{Start: 0, End: 2, Interior: 1}, // infix / suffix axis 1
 		)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 		// Axis 0: dim=2, start=1, end=0, interior=0 => 2 + 1 + 0 + (2-1)*0 = 3
 		// Axis 1: dim=3, start=0, end=2, interior=1 => 3 + 0 + 2 + (3-1)*1 = 7
-		assert.True(t, S(F32, 3, 7).Equal(output), "expected F32[3, 7], got %s", output)
+		if !(S(F32, 3, 7).Equal(output)) {
+			t.Errorf("expected F32[3, 7], got %s", output)
+		}
 	})
 
 	// 2. Check that padding works when it is on the last axis, and when the last axis is untouched.
@@ -745,11 +920,15 @@ func TestPad(t *testing.T) {
 			PadAxis{Start: 1, End: 1, Interior: 0}, // padding on middle axis
 			// last axis untouched (omitted)
 		)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 		// Axis 0: 4
 		// Axis 1: 5 + 1 + 1 = 7
 		// Axis 2: 2
-		assert.True(t, S(F32, 4, 7, 2).Equal(output), "expected F32[4, 7, 2], got %s", output)
+		if !(S(F32, 4, 7, 2).Equal(output)) {
+			t.Errorf("expected F32[4, 7, 2], got %s", output)
+		}
 	})
 
 	t.Run("LastAxisPadding", func(t *testing.T) {
@@ -759,11 +938,15 @@ func TestPad(t *testing.T) {
 			PadAxis{Start: 0, End: 0, Interior: 0}, // untouched
 			PadAxis{Start: 0, End: 0, Interior: 2}, // padding on the last axis
 		)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 		// Axis 0: 2
 		// Axis 1: 2
 		// Axis 2: 2 + 0 + 0 + (2-1)*2 = 4
-		assert.True(t, S(F32, 2, 2, 4).Equal(output), "expected F32[2, 2, 4], got %s", output)
+		if !(S(F32, 2, 2, 4).Equal(output)) {
+			t.Errorf("expected F32[2, 2, 4], got %s", output)
+		}
 	})
 
 	t.Run("MissingAxes", func(t *testing.T) {
@@ -772,10 +955,14 @@ func TestPad(t *testing.T) {
 			PadAxis{Start: 2, End: 2, Interior: 0},
 			// missing axis
 		)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 		// Axis 0: 5 + 4 = 9
 		// Axis 1: 3
-		assert.True(t, S(F32, 9, 3).Equal(output), "expected F32[9, 3], got %s", output)
+		if !(S(F32, 9, 3).Equal(output)) {
+			t.Errorf("expected F32[9, 3], got %s", output)
+		}
 	})
 }
 
@@ -786,10 +973,16 @@ func TestBinaryOp_AxisNames(t *testing.T) {
 		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		rhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
-		require.NoError(t, err)
-		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
 		// Dynamic dim propagates.
-		require.Equal(t, []int{-1, 512}, output.Dimensions)
+		if ok, diff := testutil.IsEqual([]int{-1, 512}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, 512}, output.Dimensions)
+		}
 	})
 
 	t.Run("OneNamed", func(t *testing.T) {
@@ -797,24 +990,36 @@ func TestBinaryOp_AxisNames(t *testing.T) {
 		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		rhs := S(F32, 1, 512)
 		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
-		require.NoError(t, err)
-		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
 	})
 
 	t.Run("BothUnnamed", func(t *testing.T) {
 		lhs := S(F32, 2, 3)
 		rhs := S(F32, 2, 3)
 		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
-		require.NoError(t, err)
-		require.Nil(t, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if output.AxisNames != nil {
+			t.Fatalf("Expected nil, got %v", output.AxisNames)
+		}
 	})
 
 	t.Run("ConflictingNames", func(t *testing.T) {
 		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		rhs := SD(F32, []int{-1, 512}, []string{"time", ""})
 		_, err := BinaryOp(OpTypeAdd, lhs, rhs)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "different axis names")
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "different axis names") {
+			t.Fatalf("Expected %v to contain %v", err.Error(), "different axis names")
+		}
 	})
 
 	t.Run("DynamicBroadcast", func(t *testing.T) {
@@ -822,9 +1027,15 @@ func TestBinaryOp_AxisNames(t *testing.T) {
 		lhs := SD(F32, []int{-1, 1}, []string{"batch", ""})
 		rhs := S(F32, 1, 512)
 		output, err := BinaryOp(OpTypeMul, lhs, rhs)
-		require.NoError(t, err)
-		require.Equal(t, []int{-1, 512}, output.Dimensions)
-		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, 512}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, 512}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
 	})
 
 	t.Run("BothDynamic", func(t *testing.T) {
@@ -832,8 +1043,12 @@ func TestBinaryOp_AxisNames(t *testing.T) {
 		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		rhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
-		require.NoError(t, err)
-		require.Equal(t, shapes.DynamicDim, output.Dimensions[0])
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual(shapes.DynamicDim, output.Dimensions[0]); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, shapes.DynamicDim, output.Dimensions[0])
+		}
 	})
 
 	t.Run("ScalarWithNamed", func(t *testing.T) {
@@ -841,8 +1056,12 @@ func TestBinaryOp_AxisNames(t *testing.T) {
 		scalar := S(F32)
 		named := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		output, err := BinaryOp(OpTypeAdd, scalar, named)
-		require.NoError(t, err)
-		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
 	})
 }
 
@@ -850,33 +1069,53 @@ func TestComparisonOp_AxisNames(t *testing.T) {
 	lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 	rhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 	output, err := ComparisonOp(OpTypeEqual, lhs, rhs)
-	require.NoError(t, err)
-	require.Equal(t, dtypes.Bool, output.DType)
-	require.Equal(t, []string{"batch", ""}, output.AxisNames)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if ok, diff := testutil.IsEqual(dtypes.Bool, output.DType); !ok {
+		t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, dtypes.Bool, output.DType)
+	}
+	if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+		t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+	}
 }
 
 func TestUnaryOp_AxisNames(t *testing.T) {
 	named := SD(F32, []int{-1, 512}, []string{"batch", ""})
 	output, err := UnaryOp(OpTypeExp, named)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 	// UnaryOp returns operand directly, so names are preserved.
-	require.Equal(t, []string{"batch", ""}, output.AxisNames)
+	if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+		t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+	}
 }
 
 func TestTransposeOp_AxisNames(t *testing.T) {
 	t.Run("PermutesNames", func(t *testing.T) {
 		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
 		output, err := Transpose(s, []int{1, 0, 2})
-		require.NoError(t, err)
-		require.Equal(t, []int{-1, -1, 768}, output.Dimensions)
-		require.Equal(t, []string{"seq_len", "batch", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, -1, 768}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, -1, 768}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"seq_len", "batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"seq_len", "batch", ""}, output.AxisNames)
+		}
 	})
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 2, 3)
 		output, err := Transpose(s, []int{1, 0})
-		require.NoError(t, err)
-		require.Nil(t, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if output.AxisNames != nil {
+			t.Fatalf("Expected nil, got %v", output.AxisNames)
+		}
 	})
 }
 
@@ -885,7 +1124,9 @@ func TestBroadcastInDim(t *testing.T) {
 		operand := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		outputShape := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		err := BroadcastInDim(operand, outputShape, []int{0, 1}, nil)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 	})
 
 	t.Run("DynamicDimMismatch", func(t *testing.T) {
@@ -893,8 +1134,12 @@ func TestBroadcastInDim(t *testing.T) {
 		operand := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		outputShape := S(F32, 32, 512)
 		err := BroadcastInDim(operand, outputShape, []int{0, 1}, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "must be preserved as dynamic in output shape")
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "must be preserved as dynamic in output shape") {
+			t.Fatalf("Expected %v to contain %v", err.Error(), "must be preserved as dynamic in output shape")
+		}
 	})
 
 	t.Run("BroadcastToUnknownDynamicAxis", func(t *testing.T) {
@@ -902,8 +1147,12 @@ func TestBroadcastInDim(t *testing.T) {
 		operand := S(F32, 1, 512)
 		outputShape := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		err := BroadcastInDim(operand, outputShape, []int{0, 1}, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "cannot introduce an unknown dynamic axis name -- the dynamic axis must be known from the input parameters")
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot introduce an unknown dynamic axis name -- the dynamic axis must be known from the input parameters") {
+			t.Fatalf("Expected %v to contain %v", err.Error(), "cannot introduce an unknown dynamic axis name -- the dynamic axis must be known from the input parameters")
+		}
 	})
 
 	t.Run("BroadcastToKnownDynamicAxis", func(t *testing.T) {
@@ -911,7 +1160,9 @@ func TestBroadcastInDim(t *testing.T) {
 		operand := SD(F32, []int{-1, 512}, []string{"seqLen", ""})
 		outputShape := SD(F32, []int{-1, -1, 512}, []string{"batch", "seqLen", ""})
 		err := BroadcastInDim(operand, outputShape, []int{1, 2}, sets.MakeWith("batch"))
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 	})
 }
 
@@ -920,23 +1171,37 @@ func TestReduceOp_AxisNames(t *testing.T) {
 		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
 		// Reduce last axis → names for remaining axes preserved.
 		output, err := Reduce(s, []int{2})
-		require.NoError(t, err)
-		require.Equal(t, []int{-1, -1}, output.Dimensions)
-		require.Equal(t, []string{"batch", "seq_len"}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, -1}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, -1}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "seq_len"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "seq_len"}, output.AxisNames)
+		}
 	})
 
 	t.Run("ReduceToScalar", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		output, err := Reduce(s, []int{0, 1})
-		require.NoError(t, err)
-		require.True(t, output.IsScalar())
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !(output.IsScalar()) {
+			t.Fatalf("Condition expected to be true")
+		}
 	})
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 4, 5, 6)
 		output, err := Reduce(s, []int{1})
-		require.NoError(t, err)
-		require.Nil(t, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if output.AxisNames != nil {
+			t.Fatalf("Expected nil, got %v", output.AxisNames)
+		}
 	})
 }
 
@@ -945,8 +1210,12 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 		s1 := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		s2 := SD(F32, []int{-1, 256}, []string{"batch", ""})
 		output, err := Concatenate([]shapes.Shape{s1, s2}, 1)
-		require.NoError(t, err)
-		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
 	})
 
 	t.Run("ConcatAxisNameConflictDrops", func(t *testing.T) {
@@ -954,25 +1223,39 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 		s1 := SD(F32, []int{-1, -1}, []string{"batch", "a"})
 		s2 := SD(F32, []int{-1, -1}, []string{"batch", "b"})
 		output, err := Concatenate([]shapes.Shape{s1, s2}, 1) // concat on axis 1
-		require.NoError(t, err)
-		require.Equal(t, "batch", output.AxisNames[0])
-		require.Equal(t, "", output.AxisNames[1]) // dropped due to conflict
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual("batch", output.AxisNames[0]); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, "batch", output.AxisNames[0])
+		}
+		if ok, diff := testutil.IsEqual("", output.AxisNames[1]); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, "", output.AxisNames[1])
+		} // dropped due to conflict
 	})
 
 	t.Run("NonConcatAxisNameConflictErrors", func(t *testing.T) {
 		s1 := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		s2 := SD(F32, []int{-1, 512}, []string{"time", ""})
 		_, err := Concatenate([]shapes.Shape{s1, s2}, 1) // concat on axis 1, conflict on axis 0
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "axis name conflict")
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "axis name conflict") {
+			t.Fatalf("Expected %v to contain %v", err.Error(), "axis name conflict")
+		}
 	})
 
 	t.Run("DynamicConcatAxis", func(t *testing.T) {
 		s1 := SD(F32, []int{-1, -1}, []string{"batch", "seq"})
 		s2 := SD(F32, []int{-1, 128}, []string{"batch", ""})
 		output, err := Concatenate([]shapes.Shape{s1, s2}, 1)
-		require.NoError(t, err)
-		require.Equal(t, shapes.DynamicDim, output.Dimensions[1])
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual(shapes.DynamicDim, output.Dimensions[1]); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, shapes.DynamicDim, output.Dimensions[1])
+		}
 	})
 }
 
@@ -980,24 +1263,40 @@ func TestSliceOp_AxisNames(t *testing.T) {
 	t.Run("PreservesNames", func(t *testing.T) {
 		s := S(F32, 10, 20).WithAxisNames("height", "width")
 		output, err := Slice(s, []int{2, 5}, []int{8, 15}, []int{1, 1})
-		require.NoError(t, err)
-		require.Equal(t, []string{"height", "width"}, output.AxisNames)
-		require.Equal(t, []int{6, 10}, output.Dimensions)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]string{"height", "width"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"height", "width"}, output.AxisNames)
+		}
+		if ok, diff := testutil.IsEqual([]int{6, 10}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{6, 10}, output.Dimensions)
+		}
 	})
 
 	t.Run("DynamicAxis", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		output, err := Slice(s, []int{0, 0}, []int{0, 256}, []int{1, 1})
-		require.NoError(t, err)
-		require.Equal(t, shapes.DynamicDim, output.Dimensions[0])
-		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual(shapes.DynamicDim, output.Dimensions[0]); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, shapes.DynamicDim, output.Dimensions[0])
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
 	})
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 10, 20)
 		output, err := Slice(s, []int{0, 0}, []int{5, 10}, []int{1, 1})
-		require.NoError(t, err)
-		require.Nil(t, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if output.AxisNames != nil {
+			t.Fatalf("Expected nil, got %v", output.AxisNames)
+		}
 	})
 }
 
@@ -1005,24 +1304,40 @@ func TestArgMinMaxOp_AxisNames(t *testing.T) {
 	t.Run("RemovesAxisName", func(t *testing.T) {
 		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
 		output, err := ArgMinMax(s, 2, I32)
-		require.NoError(t, err)
-		require.Equal(t, []int{-1, -1}, output.Dimensions)
-		require.Equal(t, []string{"batch", "seq_len"}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, -1}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, -1}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "seq_len"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "seq_len"}, output.AxisNames)
+		}
 	})
 
 	t.Run("RemovesFirstAxis", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		output, err := ArgMinMax(s, 0, I32)
-		require.NoError(t, err)
-		require.Equal(t, []int{512}, output.Dimensions)
-		require.Equal(t, []string{""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{512}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{512}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{""}, output.AxisNames)
+		}
 	})
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 5, 6)
 		output, err := ArgMinMax(s, 1, I32)
-		require.NoError(t, err)
-		require.Nil(t, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if output.AxisNames != nil {
+			t.Fatalf("Expected nil, got %v", output.AxisNames)
+		}
 	})
 }
 
@@ -1030,24 +1345,40 @@ func TestReduceWindowOp_AxisNames(t *testing.T) {
 	t.Run("PreservesNames", func(t *testing.T) {
 		s := S(F32, 1, 20, 22, 3).WithAxisNames("batch", "height", "width", "channels")
 		output, err := ReduceWindow(s, []int{1, 3, 3, 1}, []int{1, 2, 2, 1}, nil, nil, nil)
-		require.NoError(t, err)
-		require.Equal(t, []string{"batch", "height", "width", "channels"}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "height", "width", "channels"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "height", "width", "channels"}, output.AxisNames)
+		}
 	})
 
 	t.Run("DynamicDim", func(t *testing.T) {
 		s := SD(F32, []int{-1, 10}, []string{"batch", "seq"})
 		output, err := ReduceWindow(s, []int{1, 3}, []int{1, 1}, nil, nil, nil)
-		require.NoError(t, err)
-		require.Equal(t, shapes.DynamicDim, output.Dimensions[0])
-		require.Equal(t, 8, output.Dimensions[1])
-		require.Equal(t, []string{"batch", "seq"}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual(shapes.DynamicDim, output.Dimensions[0]); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, shapes.DynamicDim, output.Dimensions[0])
+		}
+		if ok, diff := testutil.IsEqual(8, output.Dimensions[1]); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, 8, output.Dimensions[1])
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "seq"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "seq"}, output.AxisNames)
+		}
 	})
 
 	t.Run("NoNames", func(t *testing.T) {
 		s := S(F32, 10)
 		output, err := ReduceWindow(s, []int{3}, nil, nil, nil, nil)
-		require.NoError(t, err)
-		require.Nil(t, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if output.AxisNames != nil {
+			t.Fatalf("Expected nil, got %v", output.AxisNames)
+		}
 	})
 }
 
@@ -1056,17 +1387,27 @@ func TestDotGeneral_DynamicAndNames(t *testing.T) {
 		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		rhs := SD(F32, []int{-1, 512, 256}, []string{"batch", "", ""})
 		output, err := DotGeneral(lhs, []int{1}, []int{0}, rhs, []int{1}, []int{0}, DotGeneralConfig{})
-		require.NoError(t, err)
-		require.Equal(t, []int{-1, 256}, output.Dimensions)
-		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, 256}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, 256}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		}
 	})
 
 	t.Run("AxisNameConflict", func(t *testing.T) {
 		lhs := SD(F32, []int{-1, 512}, []string{"batch1", ""})
 		rhs := SD(F32, []int{-1, 512}, []string{"batch2", ""})
 		_, err := DotGeneral(lhs, []int{1}, []int{0}, rhs, []int{1}, []int{0}, DotGeneralConfig{})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "axis name conflict")
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "axis name conflict") {
+			t.Fatalf("Expected %v to contain %v", err.Error(), "axis name conflict")
+		}
 	})
 }
 
@@ -1074,23 +1415,39 @@ func TestReshapeOp_Dynamic(t *testing.T) {
 	t.Run("PropagatesDynamicDim", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		output, err := Reshape(s, []int{-1, 8, 64})
-		require.NoError(t, err)
-		require.Equal(t, []int{-1, 8, 64}, output.Dimensions)
-		require.Equal(t, []string{"batch", "", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, 8, 64}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, 8, 64}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "", ""}, output.AxisNames)
+		}
 	})
 
 	t.Run("MultipleDynamicDims", func(t *testing.T) {
 		s := SD(F32, []int{10, -1, 512, -1}, []string{"", "batch", "", "seq"})
 		output, err := Reshape(s, []int{-1, -1, 8, 640})
-		require.NoError(t, err)
-		require.Equal(t, []int{-1, -1, 8, 640}, output.Dimensions)
-		require.Equal(t, []string{"batch", "seq", "", ""}, output.AxisNames)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]int{-1, -1, 8, 640}, output.Dimensions); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, -1, 8, 640}, output.Dimensions)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "seq", "", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "seq", "", ""}, output.AxisNames)
+		}
 	})
 
 	t.Run("MismatchedDynamicDims", func(t *testing.T) {
 		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		_, err := Reshape(s, []int{-1, -1, 64})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "requires the number of dynamic dimensions in the input (1) to match the target dims (2)")
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "requires the number of dynamic dimensions in the input (1) to match the target dims (2)") {
+			t.Fatalf("Expected %v to contain %v", err.Error(), "requires the number of dynamic dimensions in the input (1) to match the target dims (2)")
+		}
 	})
 }

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -4,13 +4,14 @@ package shapeinference
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	. "github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes"
 	"github.com/gomlx/compute/shapes"
 	"github.com/gomlx/compute/support/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Aliases
@@ -21,130 +22,85 @@ var (
 	F32  = dtypes.Float32
 	U64  = dtypes.Uint64
 
-	S = shapes.Make
+	S  = shapes.Make
+	SD = shapes.MakeDynamic
 )
 
 func must1[T any](value T, err error) T {
 	return testutil.Must1(value, err)
 }
 
-func assertPanics(t *testing.T, f func()) {
-	t.Helper()
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("expected panic, but did not panic")
-		}
-	}()
-	f()
-}
-
 func TestBinaryOp(t *testing.T) {
 	// Invalid data types check.
 	var err error
 	_, err = BinaryOp(OpTypeLogicalAnd, S(I8), S(I8))
-	if err == nil {
-		t.Error("expected error for BinaryOp(OpTypeLogicalAnd, I8, I8)")
-	}
+	require.Error(t, err)
 	_, err = BinaryOp(OpTypeMul, S(Bool, 1), S(Bool, 1))
-	if err == nil {
-		t.Error("expected error for BinaryOp(OpTypeMul, Bool, Bool)")
-	}
+	require.Error(t, err)
 	_, err = BinaryOp(OpTypeMul, S(Bool, 1), S(Bool, 1))
-	if err == nil {
-		t.Error("expected error for BinaryOp(OpTypeMul, Bool, Bool)")
-	}
+	require.Error(t, err)
 	_, err = BinaryOp(OpTypeBitwiseXor, S(F32, 1), S(F32, 1))
-	if err == nil {
-		t.Error("expected error for BinaryOp(OpTypeBitwiseXor, F32, F32)")
-	}
+	require.Error(t, err)
 
 	// Invalid operation type (not binary op).
 	_, err = BinaryOp(OpTypeExp, S(F32), S(F32))
-	if err == nil {
-		t.Error("expected error for BinaryOp(OpTypeExp, F32, F32)")
-	}
+	require.Error(t, err)
 
 	// The same shape should be ok.
 	var output shapes.Shape
 	intMatrixShape := S(I8, 3, 3)
 	output, err = BinaryOp(OpTypeBitwiseOr, intMatrixShape, intMatrixShape)
-	if err != nil {
-		t.Errorf("BinaryOp failed: %+v", err)
-	}
-	if !intMatrixShape.Equal(output) {
-		t.Errorf("expected %s, got %s", intMatrixShape, output)
-	}
+	require.NoError(t, err)
+	require.True(t, intMatrixShape.Equal(output))
 
 	// Scalar with matrix.
 	scalarShape := S(F32)
 	matrixShape := S(F32, 2, 3)
 	expectedShape := S(F32, 2, 3)
 	output, err = BinaryOp(OpTypeAdd, scalarShape, scalarShape)
-	if err != nil {
-		t.Errorf("BinaryOp failed: %+v", err)
-	}
-	if !scalarShape.Equal(output) {
-		t.Errorf("expected %s, got %s", scalarShape, output)
-	}
+	require.NoError(t, err)
+	require.True(t, scalarShape.Equal(output))
 	output, err = BinaryOp(OpTypeAdd, scalarShape, matrixShape)
-	if err != nil {
-		t.Errorf("BinaryOp failed: %+v", err)
-	}
-	if !expectedShape.Equal(output) {
-		t.Errorf("expected %s, got %s", expectedShape, output)
-	}
+	require.NoError(t, err)
+	require.True(t, expectedShape.Equal(output))
 
 	// Broadcasting on both sides.
 	shape1 := S(F32, 2, 1, 3)
 	shape2 := S(F32, 1, 4, 3)
 	expectedBroadcastShape := S(F32, 2, 4, 3)
-	if !expectedBroadcastShape.Equal(must1(BinaryOp(OpTypeMul, shape1, shape2))) {
-		t.Errorf("expected %s, got something else", expectedBroadcastShape)
-	}
+	require.True(t, expectedBroadcastShape.Equal(must1(BinaryOp(OpTypeMul, shape1, shape2))))
 
 	// Matrix with scalar.
-	if !expectedShape.Equal(must1(BinaryOp(OpTypeAdd, matrixShape, scalarShape))) {
-		t.Errorf("expected %s, got something else", expectedShape)
-	}
+	require.True(t, expectedShape.Equal(must1(BinaryOp(OpTypeAdd, matrixShape, scalarShape))))
 
 	// Invalid broadcasting shapes.
 	invalidShape1 := S(F32, 2, 3)
 	invalidShape2 := S(F32, 3, 2)
 	_, err = BinaryOp(OpTypeAdd, invalidShape1, invalidShape2)
-	if err == nil {
-		t.Error("expected error for invalid broadcasting shapes")
-	}
+	require.Error(t, err)
 }
 
 func TestUnaryOp(t *testing.T) {
 	// Invalid data types check.
-	assertPanics(t, func() { must1(UnaryOp(OpTypeLogicalNot, S(F32))) })
-	assertPanics(t, func() { must1(UnaryOp(OpTypeLogicalNot, S(I8))) })
-	assertPanics(t, func() { must1(UnaryOp(OpTypeBitwiseNot, S(F32))) })
-	assertPanics(t, func() { must1(UnaryOp(OpTypeNeg, S(Bool))) })
+	require.Panics(t, func() { must1(UnaryOp(OpTypeLogicalNot, S(F32))) })
+	require.Panics(t, func() { must1(UnaryOp(OpTypeLogicalNot, S(I8))) })
+	require.Panics(t, func() { must1(UnaryOp(OpTypeBitwiseNot, S(F32))) })
+	require.Panics(t, func() { must1(UnaryOp(OpTypeNeg, S(Bool))) })
 
 	// Invalid operation type (not unary op).
-	assertPanics(t, func() { must1(UnaryOp(OpTypeAdd, S(F32))) })
-	assertPanics(t, func() { must1(UnaryOp(OpTypeNeg, S(U64))) })
+	require.Panics(t, func() { must1(UnaryOp(OpTypeAdd, S(F32))) })
+	require.Panics(t, func() { must1(UnaryOp(OpTypeNeg, S(U64))) })
 
 	// Valid operations
 	boolShape := S(Bool, 2, 3)
-	if !boolShape.Equal(must1(UnaryOp(OpTypeLogicalNot, boolShape))) {
-		t.Errorf("expected %s, got something else", boolShape)
-	}
+	require.True(t, boolShape.Equal(must1(UnaryOp(OpTypeLogicalNot, boolShape))))
 
 	intShape := S(I8, 3, 3)
-	if !intShape.Equal(must1(UnaryOp(OpTypeBitwiseNot, intShape))) {
-		t.Errorf("expected %s, got something else", intShape)
-	}
+	require.True(t, intShape.Equal(must1(UnaryOp(OpTypeBitwiseNot, intShape))))
 
 	floatShape := S(F32, 2, 3)
-	if !floatShape.Equal(must1(UnaryOp(OpTypeExp, floatShape))) {
-		t.Errorf("expected %s, got something else", floatShape)
-	}
-	if !floatShape.Equal(must1(UnaryOp(OpTypeNeg, floatShape))) {
-		t.Errorf("expected %s, got something else", floatShape)
-	}
+	require.True(t, floatShape.Equal(must1(UnaryOp(OpTypeExp, floatShape))))
+	require.True(t, floatShape.Equal(must1(UnaryOp(OpTypeNeg, floatShape))))
 }
 
 func TestGatherOp(t *testing.T) {
@@ -158,13 +114,9 @@ func TestGatherOp(t *testing.T) {
 	sliceSizes := []int{1, 3, 1, 1}
 	output, err := Gather(operand, startIndices, indexVectorAxis,
 		offsetOutputAxes, collapsedSliceAxes, startIndexMap, sliceSizes, false)
-	if err != nil {
-		t.Errorf("Gather failed: %+v", err)
-	}
+	require.NoError(t, err)
 	fmt.Printf("\tTest 1: outputShape=%s\n", output)
-	if err := output.Check(F32, 3, 3, 2, 1); err != nil {
-		t.Errorf("output shape check failed: %+v", err)
-	}
+	require.NoError(t, output.Check(F32, 3, 3, 2, 1))
 
 	// Test 2:
 	operand = S(F32, 3, 4, 5, 6)
@@ -175,13 +127,9 @@ func TestGatherOp(t *testing.T) {
 	startIndexMap = []int{1, 2, 3}
 	sliceSizes = []int{3, 1, 1, 1}
 	output, err = Gather(operand, startIndices, indexVectorAxis, offsetOutputAxes, collapsedSliceAxes, startIndexMap, sliceSizes, true)
-	if err != nil {
-		t.Errorf("Gather failed: %+v", err)
-	}
+	require.NoError(t, err)
 	fmt.Printf("\tTest 2: outputShape=%s\n", output)
-	if err := output.Check(F32, 7, 3, 1, 8); err != nil {
-		t.Errorf("output shape check failed: %+v", err)
-	}
+	require.NoError(t, output.Check(F32, 7, 3, 1, 8))
 
 	// Test 3:
 	operand = S(F32, 8, 16)
@@ -192,13 +140,9 @@ func TestGatherOp(t *testing.T) {
 	startIndexMap = []int{0}
 	sliceSizes = []int{1, 16}
 	output, err = Gather(operand, startIndices, indexVectorAxis, offsetOutputAxes, collapsedSliceAxes, startIndexMap, sliceSizes, true)
-	if err != nil {
-		t.Errorf("Gather failed: %+v", err)
-	}
+	require.NoError(t, err)
 	fmt.Printf("\tTest 3: outputShape=%s\n", output)
-	if err := output.Check(F32, 8, 16); err != nil {
-		t.Errorf("output shape check failed: %+v", err)
-	}
+	require.NoError(t, output.Check(F32, 8, 16))
 }
 
 func TestScatterOp(t *testing.T) {
@@ -216,12 +160,8 @@ func TestScatterOp(t *testing.T) {
 	scatterAxesToOperandAxes1 := []int{0} // Index coordinate vector element 0 maps to operand axis 0
 	expected1 := operand1
 	output1, err := ScatterOp(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1)
-	if err != nil {
-		t.Errorf("ScatterOp failed: %+v", err)
-	}
-	if !expected1.Equal(output1) {
-		t.Errorf("Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
-	}
+	require.NoError(t, err)
+	require.True(t, expected1.Equal(output1), "Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
 
 	// Case 2: Scattering into a higher-rank tensor
 	// Scatter updates of shape [4] into operand[i, j, :], where [i, j] comes from indices.
@@ -237,12 +177,8 @@ func TestScatterOp(t *testing.T) {
 	scatterAxesToOperandAxes2 := []int{0, 1} // index coord 0 -> operand axis 0, index coord 1 -> operand axis 1
 	expected2 := operand2
 	output2, err := ScatterOp(operand2, indices2, updates2, indexVectorAxis2, updateWindowAxes2, insertedWindowAxes2, scatterAxesToOperandAxes2)
-	if err != nil {
-		t.Errorf("ScatterOp failed: %+v", err)
-	}
-	if !expected2.Equal(output2) {
-		t.Errorf("Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
-	}
+	require.NoError(t, err)
+	require.True(t, expected2.Equal(output2), "Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
 
 	// Case 3: Different indexVectorAxis
 	// Same as case 2, but indices are [2, 2, 3] -> indexVectorAxis is 1 and different order of axes in the operand.
@@ -255,12 +191,8 @@ func TestScatterOp(t *testing.T) {
 	scatterAxesToOperandAxes3 := []int{1, 2} // indices are used for different axes in the operand this time.
 	expected3 := operand2                    // Still expect operand shape
 	output3, err := ScatterOp(operand3, indices3, updates3, indexVectorAxis3, updateWindowAxes3, insertedWindowAxes3, scatterAxesToOperandAxes3)
-	if err != nil {
-		t.Errorf("ScatterOp failed: %+v", err)
-	}
-	if !expected3.Equal(output3) {
-		t.Errorf("Valid Case 3 Failed (IndexVecAxis=1): Expected %s, got %s", expected3, output3)
-	}
+	require.NoError(t, err)
+	require.True(t, expected3.Equal(output3), "Valid Case 3 Failed (IndexVecAxis=1): Expected %s, got %s", expected3, output3)
 
 	// Case 4: No insertedWindowAxes (scattering full slices)
 	// Scatter updates of shape [9] into operand [10, 9]
@@ -273,12 +205,8 @@ func TestScatterOp(t *testing.T) {
 	scatterAxesToOperandAxes4 := []int{0} // Index coord 0 -> operand axis 0
 	expected4 := operand4
 	output4, err := ScatterOp(operand4, indices4, updates4, indexVectorAxis4, updateWindowAxes4, insertedWindowAxes4, scatterAxesToOperandAxes4)
-	if err != nil {
-		t.Errorf("ScatterOp failed: %+v", err)
-	}
-	if !expected4.Equal(output4) {
-		t.Errorf("Valid Case 4 Failed (No Window): Expected %s, got %s", expected4, output4)
-	}
+	require.NoError(t, err)
+	require.True(t, expected4.Equal(output4), "Valid Case 4 Failed (No Window): Expected %s, got %s", expected4, output4)
 
 	// Case 5: rearranging the output axes:
 	operand5 := S(F32, 2, 5, 2)
@@ -289,77 +217,51 @@ func TestScatterOp(t *testing.T) {
 	insertedWindowAxes5 := []int{0, 2}
 	scatterAxesToOperandAxes5 := []int{0, 2}
 	output5, err := ScatterOp(operand5, indices5, updates5, indexVectorAxis5, updateWindowAxes5, insertedWindowAxes5, scatterAxesToOperandAxes5)
-	if err != nil {
-		t.Errorf("ScatterOp failed: %+v", err)
-	}
-	if !operand5.Equal(output5) {
-		t.Errorf("Valid Case 5 Failed (No Window): Expected %s, got %s", operand5, output5)
-	}
+	require.NoError(t, err)
+	require.True(t, operand5.Equal(output5), "Valid Case 5 Failed (No Window): Expected %s, got %s", operand5, output5)
 
 	// --- Error Cases ---
 
 	// Error Case 1: Mismatched DType (Operand vs Updates) - unchanged
 	_, err = ScatterOp(S(F32, 4, 5), S(I8, 2, 1), S(I8, 2, 5), 1, []int{1}, []int{1}, []int{0})
-	if err == nil {
-		t.Error("Error Case 1 Failed: Mismatched operand/updates DType")
-	}
+	require.Error(t, err)
 
 	// Error Case 2: Invalid DType for indices - unchanged
 	_, err = ScatterOp(S(F32, 4, 5), S(F32, 2, 1), S(F32, 2, 5), 1, []int{1}, []int{1}, []int{0})
-	if err == nil {
-		t.Error("Error Case 2 Failed: Invalid indices DType")
-	}
+	require.Error(t, err)
 
 	// Error Case 3: indexVectorAxis out of bounds
 	_, err = ScatterOp(operand1, indices1, updates1, 2, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1) // indices1 rank 2, axis 2 invalid
-	if err == nil {
-		t.Error("Error Case 3 Failed: indexVectorAxis out of bounds")
-	}
+	require.Error(t, err)
 
 	_, err = ScatterOp(operand1, indices1, updates1, -1, updateWindowAxes1, insertedWindowAxes1, scatterAxesToOperandAxes1) // Negative axis
-	if err == nil {
-		t.Error("Error Case 3 Failed: negative indexVectorAxis")
-	}
+	require.Error(t, err)
 
 	// Error Case 4: len(updateWindowAxes) != len(insertedWindowAxes)
 	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, []int{1}, []int{1, 0}, scatterAxesToOperandAxes1) // inserted has len 2, update has len 1
-	if err == nil {
-		t.Error("Error Case 4 Failed: len(updateWindowAxes) != len(insertedWindowAxes)")
-	}
+	require.Error(t, err)
 
 	// Error Case 5: len(scatterAxesToOperandAxes) != size of index vector dimension
 	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, []int{0, 1}) // scatterAxes has len 2, expected 1
-	if err == nil {
-		t.Error("Error Case 5 Failed: len(scatterAxesToOperandAxes) mismatch")
-	}
+	require.Error(t, err)
 	_, err = ScatterOp(operand2, indices2, updates2, indexVectorAxis2, updateWindowAxes2, insertedWindowAxes2, []int{0}) // scatterAxes has len 1, expected 2
-	if err == nil {
-		t.Error("Error Case 5 Failed: len(scatterAxesToOperandAxes) mismatch")
-	}
+	require.Error(t, err)
 
 	// Error Case 6: Invalid axis index in updateWindowAxes
 	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, []int{2}, insertedWindowAxes1, scatterAxesToOperandAxes1) // axis 2 invalid for rank 2 updates
-	if err == nil {
-		t.Error("Error Case 6 Failed: Invalid axis in updateWindowAxes")
-	}
+	require.Error(t, err)
 
 	// Error Case 7: Invalid axis index in insertedWindowAxes
 	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, []int{2}, scatterAxesToOperandAxes1) // axis 2 invalid for rank 2 operand
-	if err == nil {
-		t.Error("Error Case 7 Failed: Invalid axis in insertedWindowAxes")
-	}
+	require.Error(t, err)
 
 	// Error Case 8: Invalid axis index in scatterAxesToOperandAxes
 	_, err = ScatterOp(operand1, indices1, updates1, indexVectorAxis1, updateWindowAxes1, insertedWindowAxes1, []int{2}) // axis 2 invalid for rank 2 operand
-	if err == nil {
-		t.Error("Error Case 8 Failed: Invalid axis in scatterAxesToOperandAxes")
-	}
+	require.Error(t, err)
 
 	// Error Case 9: Update dimension is larger than the corresponding dimension in the operand:
 	_, err = ScatterOp(operand5, indices5, updates5, indexVectorAxis5, updateWindowAxes5, []int{0, 1}, scatterAxesToOperandAxes5) // axis 2 invalid for rank 2 operand
-	if err == nil {
-		t.Error("Error Case 9 Failed: Update dimension is larger than the corresponding dimension in the operand")
-	}
+	require.Error(t, err)
 }
 
 func TestSliceOp(t *testing.T) {
@@ -373,12 +275,8 @@ func TestSliceOp(t *testing.T) {
 	strides1 := []int{1}
 	expected1 := S(F32, 6)
 	output1, err := SliceOp(operand1, starts1, limits1, strides1)
-	if err != nil {
-		t.Errorf("%s failed: %+v", opName, err)
-	}
-	if !expected1.Equal(output1) {
-		t.Errorf("%s Valid Case 1 Failed: Expected %s, got %s", opName, expected1, output1)
-	}
+	require.NoError(t, err)
+	require.True(t, expected1.Equal(output1), "%s Valid Case 1 Failed: Expected %s, got %s", opName, expected1, output1)
 
 	// Case 2: 2D slice with stride 1
 	operand2 := S(I32, 5, 6)
@@ -387,12 +285,8 @@ func TestSliceOp(t *testing.T) {
 	strides2 := []int{1, 1}
 	expected2 := S(I32, 3, 3)
 	output2, err := SliceOp(operand2, starts2, limits2, strides2)
-	if err != nil {
-		t.Errorf("%s failed: %+v", opName, err)
-	}
-	if !expected2.Equal(output2) {
-		t.Errorf("%s Valid Case 2 Failed: Expected %s, got %s", opName, expected2, output2)
-	}
+	require.NoError(t, err)
+	require.True(t, expected2.Equal(output2), "%s Valid Case 2 Failed: Expected %s, got %s", opName, expected2, output2)
 
 	// Case 3: 3D slice with different strides
 	operand3 := S(Bool, 10, 8, 6)
@@ -404,12 +298,8 @@ func TestSliceOp(t *testing.T) {
 	// Dim 2: (6-1)/1 = 5 -> 5 elements (indices 1, 2, 3, 4, 5)
 	expected3 := S(Bool, 5, 3, 5)
 	output3, err := SliceOp(operand3, starts3, limits3, strides3)
-	if err != nil {
-		t.Errorf("%s failed: %+v", opName, err)
-	}
-	if !expected3.Equal(output3) {
-		t.Errorf("%s Valid Case 3 Failed: Expected %s, got %s", opName, expected3, output3)
-	}
+	require.NoError(t, err)
+	require.True(t, expected3.Equal(output3), "%s Valid Case 3 Failed: Expected %s, got %s", opName, expected3, output3)
 
 	// Case 4: Slice resulting in size 1 dimension
 	operand4 := S(F32, 10)
@@ -418,12 +308,8 @@ func TestSliceOp(t *testing.T) {
 	strides4 := []int{1}
 	expected4 := S(F32, 1)
 	output4, err := SliceOp(operand4, starts4, limits4, strides4)
-	if err != nil {
-		t.Errorf("%s failed: %+v", opName, err)
-	}
-	if !expected4.Equal(output4) {
-		t.Errorf("%s Valid Case 4 Failed: Expected %s, got %s", opName, expected4, output4)
-	}
+	require.NoError(t, err)
+	require.True(t, expected4.Equal(output4), "%s Valid Case 4 Failed: Expected %s, got %s", opName, expected4, output4)
 
 	// Case 5: Slice taking full dimension with stride > 1
 	operand5 := S(I8, 7)
@@ -433,12 +319,8 @@ func TestSliceOp(t *testing.T) {
 	// Dim 0: (7-0)/2 = 3.5 -> 4 elements (indices 0, 2, 4, 6)
 	expected5 := S(I8, 4)
 	output5, err := SliceOp(operand5, starts5, limits5, strides5)
-	if err != nil {
-		t.Errorf("%s failed: %+v", opName, err)
-	}
-	if !expected5.Equal(output5) {
-		t.Errorf("%s Valid Case 5 Failed: Expected %s, got %s", opName, expected5, output5)
-	}
+	require.NoError(t, err)
+	require.True(t, expected5.Equal(output5), "%s Valid Case 5 Failed: Expected %s, got %s", opName, expected5, output5)
 
 	// --- Error Cases ---
 	operand := S(F32, 10, 5) // Rank 2
@@ -448,63 +330,43 @@ func TestSliceOp(t *testing.T) {
 
 	// Error 1: Invalid operand DType
 	_, err = SliceOp(shapes.Shape{DType: dtypes.InvalidDType, Dimensions: []int{10}}, []int{0}, []int{5}, []int{1})
-	if err == nil {
-		t.Errorf("%s Error Case 1 Failed: Invalid operand DType", opName)
-	}
+	require.Error(t, err)
 
 	// Error 2: Incorrect length for starts
 	_, err = SliceOp(operand, []int{1}, validLimits, validStrides)
-	if err == nil {
-		t.Errorf("%s Error Case 2 Failed: len(starts) != rank", opName)
-	}
+	require.Error(t, err)
 
 	// Error 3: Incorrect length for limits
 	_, err = SliceOp(operand, validStarts, []int{8}, validStrides)
-	if err == nil {
-		t.Errorf("%s Error Case 3 Failed: len(limits) != rank", opName)
-	}
+	require.Error(t, err)
 
 	// Error 4: Incorrect length for strides
 	_, err = SliceOp(operand, validStarts, validLimits, []int{1})
-	if err == nil {
-		t.Errorf("%s Error Case 4 Failed: len(strides) != rank", opName)
-	}
+	require.Error(t, err)
 
 	// Error 5: Zero stride
 	_, err = SliceOp(operand, validStarts, validLimits, []int{1, 0})
-	if err == nil {
-		t.Errorf("%s Error Case 5 Failed: Zero stride", opName)
-	}
+	require.Error(t, err)
 
 	// Error 6: Negative stride
 	_, err = SliceOp(operand, validStarts, validLimits, []int{-1, 1})
-	if err == nil {
-		t.Errorf("%s Error Case 6 Failed: Negative stride", opName)
-	}
+	require.Error(t, err)
 
 	// Error 7: Start index < 0
 	_, err = SliceOp(operand, []int{-1, 1}, validLimits, validStrides)
-	if err == nil {
-		t.Errorf("%s Error Case 7 Failed: Start < 0", opName)
-	}
+	require.Error(t, err)
 
 	// Error 8: Start index >= dimSize
 	_, err = SliceOp(operand, []int{10, 1}, validLimits, validStrides)
-	if err == nil {
-		t.Errorf("%s Error Case 8 Failed: Start >= dimSize", opName)
-	}
+	require.Error(t, err)
 
 	// Error 9: Limit index < start index
 	_, err = SliceOp(operand, validStarts, []int{0, 4}, validStrides) // limit[0]=0 < start[0]=1
-	if err == nil {
-		t.Errorf("%s Error Case 9 Failed: Limit < Start", opName)
-	}
+	require.Error(t, err)
 
 	// Error 10: Limit index > dimSize
 	_, err = SliceOp(operand, validStarts, []int{8, 6}, validStrides) // limit[1]=6 > dimSize[1]=5
-	if err == nil {
-		t.Errorf("%s Error Case 10 Failed: Limit > dimSize", opName)
-	}
+	require.Error(t, err)
 }
 
 func TestArgMinMaxOp(t *testing.T) {
@@ -514,40 +376,34 @@ func TestArgMinMaxOp(t *testing.T) {
 	operand1 := S(F32, 10)
 	expected1 := S(I32)
 	output1 := must1(ArgMinMaxOp(operand1, 0, I32))
-	if !expected1.Equal(output1) {
-		t.Errorf("Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
-	}
+	require.True(t, expected1.Equal(output1), "Valid Case 1 Failed: Expected %s, got %s", expected1, output1)
 
 	// Case 2: 2D tensor, single axis
 	operand2 := S(F32, 5, 6)
 	expected2 := S(I8, 5)
 	output2 := must1(ArgMinMaxOp(operand2, 1, expected2.DType))
-	if !expected2.Equal(output2) {
-		t.Errorf("Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
-	}
+	require.True(t, expected2.Equal(output2), "Valid Case 2 Failed: Expected %s, got %s", expected2, output2)
 
 	// Case 3: 3D tensor, multiple axes
 	operand3 := S(F32, 4, 5, 6)
 	expected3 := S(U64, 5, 6)
 	output3 := must1(ArgMinMaxOp(operand3, 0, expected3.DType))
-	if !expected3.Equal(output3) {
-		t.Errorf("Valid Case 3 Failed: Expected %s, got %s", expected3, output3)
-	}
+	require.True(t, expected3.Equal(output3), "Valid Case 3 Failed: Expected %s, got %s", expected3, output3)
 
 	// --- Error Cases ---
 
 	// Error 1: Invalid operand DType
-	assertPanics(t, func() {
+	require.Panics(t, func() {
 		must1(ArgMinMaxOp(shapes.Make(dtypes.InvalidDType, 10), 0, I32))
 	})
 
 	// Error 2: Invalid axis (out of bounds)
-	assertPanics(t, func() {
+	require.Panics(t, func() {
 		must1(ArgMinMaxOp(operand1, 1, I32)) // operand1 is rank 1, axis 1 invalid
 	})
 
 	// Error 3: Negative axis
-	assertPanics(t, func() {
+	require.Panics(t, func() {
 		must1(ArgMinMaxOp(operand2, -1, I32))
 	})
 }
@@ -558,7 +414,7 @@ func TestReduceWindowOp(t *testing.T) {
 		operandShape         shapes.Shape
 		windowDimensions     []int
 		strides              []int
-		inputDilations       []int
+		baseDilations        []int
 		windowDilations      []int
 		paddings             [][2]int
 		expectedShape        shapes.Shape
@@ -572,7 +428,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Float32), // Rank 0
 			windowDimensions: nil,                         // Should be handled as empty for rank 0
 			strides:          nil,                         // Should be handled as empty for rank 0
-			inputDilations:   nil,
+			baseDilations:    nil,
 			windowDilations:  nil,
 			paddings:         nil, // Should be handled as empty for rank 0
 			expectedShape:    shapes.Make(dtypes.Float32),
@@ -583,7 +439,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Float32, 10),
 			windowDimensions: nil, // Defaults to {1}
 			strides:          nil, // Defaults to windowDimensions, in this case {1}
-			inputDilations:   nil, // Defaults to {1}
+			baseDilations:    nil, // Defaults to {1}
 			windowDilations:  nil, // Defaults to {1}
 			paddings:         nil, // Defaults to {{0,0}}
 			// Calculation: EffIn=10, EffWin=1. PaddedEffIn=10. Num=10-1=9. Out=(9/1)+1=10.
@@ -595,7 +451,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Float32, 10),
 			windowDimensions: []int{3}, // EffWin=3
 			strides:          nil,      // Default to windowDimensions, in this case {3}
-			inputDilations:   nil,      // Default {1}
+			baseDilations:    nil,      // Default {1}
 			windowDilations:  nil,      // Default {1}
 			paddings:         nil,      // Default {{0,0}}
 			// Calculation: EffIn=10, EffWin=3. PaddedEffIn=10. Num=10-3=7. Out=(7/3)+1=3.
@@ -607,7 +463,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Float32, 10),
 			windowDimensions: nil, // Default {1} => EffWin=1
 			strides:          []int{2},
-			inputDilations:   nil,
+			baseDilations:    nil,
 			windowDilations:  nil,
 			paddings:         nil,
 			// Calculation: EffIn=10, EffWin=1. PaddedEffIn=10. Num=10-1=9. Out=(9/2)+1=4+1=5.
@@ -619,7 +475,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Float32, 10),
 			windowDimensions: nil, // Default {1} => EffWin=1
 			strides:          nil, // Default {1}
-			inputDilations:   nil,
+			baseDilations:    nil,
 			windowDilations:  nil,
 			paddings:         [][2]int{{1, 1}},
 			// Calculation: EffIn=10, EffWin=1. PaddedEffIn=10+1+1=12. Num=12-1=11. Out=(11/1)+1=12.
@@ -631,7 +487,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Float32, 5),
 			windowDimensions: []int{3}, // EffWin=3
 			strides:          []int{1},
-			inputDilations:   []int{2}, // EffIn=(5-1)*2+1 = 9
+			baseDilations:    []int{2}, // EffIn=(5-1)*2+1 = 9
 			windowDilations:  nil,
 			paddings:         nil,
 			// Calculation: PaddedEffIn=9. Num=9-3=6. Out=(6/1)+1=7.
@@ -643,7 +499,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Float32, 10),
 			windowDimensions: []int{3},
 			strides:          []int{1},
-			inputDilations:   nil,
+			baseDilations:    nil,
 			windowDilations:  []int{2}, // EffWin=(3-1)*2+1=5
 			paddings:         nil,
 			// Calculation: EffIn=10. PaddedEffIn=10. Num=10-5=5. Out=(5/1)+1=6.
@@ -655,7 +511,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Int32, 10, 12),
 			windowDimensions: []int{3, 4},
 			strides:          []int{2, 3},
-			inputDilations:   []int{2, 1},
+			baseDilations:    []int{2, 1},
 			windowDilations:  []int{1, 2},
 			paddings:         [][2]int{{1, 1}, {0, 2}},
 			// Dim0: In=10,Win=3,Str=2,Pad=[1,1],BD=2,WD=1. EffIn=(10-1)*2+1=19. EffWin=(3-1)*1+1=3. PaddedEffIn=19+1+1=21. Num=21-3=18. Out=18/2+1=10.
@@ -668,7 +524,7 @@ func TestReduceWindowOp(t *testing.T) {
 			operandShape:     shapes.Make(dtypes.Float32, 1, 20, 22, 3), // N, H, W, C
 			windowDimensions: []int{1, 3, 3, 1},                         // Window on H, W
 			strides:          []int{1, 2, 2, 1},                         // Stride on H, W
-			inputDilations:   nil,                                       // Default {1,1,1,1}
+			baseDilations:    nil,                                       // Default {1,1,1,1}
 			windowDilations:  nil,                                       // Default {1,1,1,1}
 			paddings:         [][2]int{{0, 0}, {1, 0}, {0, 1}, {0, 0}},  // Padding H (low), W (high)
 			// Dim0(N): In=1,Win=1,Str=1,Pad0,BD1,WD1. EffIn=1,EffWin=1.Padded=1.Num=0.Out=1.
@@ -713,13 +569,13 @@ func TestReduceWindowOp(t *testing.T) {
 			errorMessageContains: "paddings[0]=[-1, 0] must be non-negative",
 		},
 		{
-			name:                 "Error_InvalidInputDilationZero",
+			name:                 "Error_InvalidBaseDilationZero",
 			operandShape:         shapes.Make(dtypes.Float32, 5),
 			windowDimensions:     []int{2},
 			strides:              []int{1},
-			inputDilations:       []int{0},
+			baseDilations:        []int{0},
 			expectError:          true,
-			errorMessageContains: "inputDilations[0]=0 must be >= 1",
+			errorMessageContains: "baseDilations[0]=0 must be >= 1",
 		},
 		{
 			name:                 "Error_InvalidWindowDilationZero",
@@ -756,11 +612,11 @@ func TestReduceWindowOp(t *testing.T) {
 			errorMessageContains: "len(paddings)=1, but operand rank is 2",
 		},
 		{
-			name:                 "Error_InputDilationsNotNil_WrongLength",
+			name:                 "Error_BaseDilationsNotNil_WrongLength",
 			operandShape:         shapes.Make(dtypes.Float32, 5, 5), // Rank 2
-			inputDilations:       []int{1},                          // Error: len 1, rank 2
+			baseDilations:        []int{1},                          // Error: len 1, rank 2
 			expectError:          true,
-			errorMessageContains: "inputDilations is not nil and len(inputDilations)=1, but operand rank is 2",
+			errorMessageContains: "baseDilations is not nil and len(baseDilations)=1, but operand rank is 2",
 		},
 		{
 			name:                 "Error_WindowDilationsNotNil_WrongLength",
@@ -788,28 +644,21 @@ func TestReduceWindowOp(t *testing.T) {
 				tc.operandShape,
 				tc.windowDimensions,
 				tc.strides,
-				tc.inputDilations,
+				tc.baseDilations,
 				tc.windowDilations,
 				tc.paddings,
 			)
 
 			if tc.expectError {
-				if err == nil {
-					t.Fatalf("Expected an error for test case: %s", tc.name)
-				}
+				require.Error(t, err, "Expected an error for test case: %s", tc.name)
 				if tc.errorMessageContains != "" {
-					if !strings.Contains(err.Error(), tc.errorMessageContains) {
-						t.Errorf("Error message mismatch for: %s. Expected to contain %q, got %q", tc.name, tc.errorMessageContains, err.Error())
-					}
+					assert.Contains(t, err.Error(), tc.errorMessageContains, "Error message mismatch for: %s", tc.name)
 				}
 			} else {
-				if err != nil {
-					t.Fatalf("Did not expect an error for test case: %s (error was: %+v)", tc.name, err)
-				}
-				if !tc.expectedShape.Equal(outputShape) {
-					t.Errorf("Mismatch in output shape for test case: %s. Expected %s, Got %s",
-						tc.name, tc.expectedShape, outputShape)
-				}
+				require.NoError(t, err, "Did not expect an error for test case: %s (error was: %v)", tc.name, err)
+				assert.True(t, tc.expectedShape.Equal(outputShape),
+					"Mismatch in output shape for test case: %s. Expected %s, Got %s",
+					tc.name, tc.expectedShape, outputShape)
 			}
 		})
 	}
@@ -829,12 +678,8 @@ func TestGather(t *testing.T) {
 			[]int{1, 4},  // sliceSizes
 			false,        // indicesAreSorted
 		)
-		if err != nil {
-			t.Fatalf("Gather failed: %+v", err)
-		}
-		if !S(F32, 2, 4).Equal(output) {
-			t.Errorf("expected F32[2, 4], got %s", output)
-		}
+		require.NoError(t, err)
+		assert.True(t, S(F32, 2, 4).Equal(output), "expected F32[2, 4], got %s", output)
 	})
 
 	t.Run("HighIndexVectorAxisLowRankOperand", func(t *testing.T) {
@@ -855,12 +700,8 @@ func TestGather(t *testing.T) {
 			[]int{1, 1},            // sliceSizes
 			false,                  // indicesAreSorted
 		)
-		if err != nil {
-			t.Fatalf("Gather failed: %+v", err)
-		}
-		if !S(Bool, 1, 1, 12, 1).Equal(output) {
-			t.Errorf("expected Bool[1, 1, 12, 1], got %s", output)
-		}
+		require.NoError(t, err)
+		assert.True(t, S(Bool, 1, 1, 12, 1).Equal(output), "expected Bool[1, 1, 12, 1], got %s", output)
 	})
 
 	t.Run("IndexVectorAxisOutOfRange", func(t *testing.T) {
@@ -875,12 +716,8 @@ func TestGather(t *testing.T) {
 			[]int{1, 4},  // sliceSizes
 			false,        // indicesAreSorted
 		)
-		if err == nil {
-			t.Fatal("expected error for indexVectorAxis out of range")
-		}
-		if !strings.Contains(err.Error(), "indexVectorAxis=3 is out of range") {
-			t.Errorf("expected error to contain %q, got %q", "indexVectorAxis=3 is out of range", err.Error())
-		}
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "indexVectorAxis=3 is out of range")
 	})
 }
 
@@ -892,14 +729,10 @@ func TestPad(t *testing.T) {
 			PadAxis{Start: 1, End: 0, Interior: 0}, // prefix axis 0
 			PadAxis{Start: 0, End: 2, Interior: 1}, // infix / suffix axis 1
 		)
-		if err != nil {
-			t.Fatalf("PadOp failed: %+v", err)
-		}
+		require.NoError(t, err)
 		// Axis 0: dim=2, start=1, end=0, interior=0 => 2 + 1 + 0 + (2-1)*0 = 3
 		// Axis 1: dim=3, start=0, end=2, interior=1 => 3 + 0 + 2 + (3-1)*1 = 7
-		if !S(F32, 3, 7).Equal(output) {
-			t.Errorf("expected F32[3, 7], got %s", output)
-		}
+		assert.True(t, S(F32, 3, 7).Equal(output), "expected F32[3, 7], got %s", output)
 	})
 
 	// 2. Check that padding works when it is on the last axis, and when the last axis is untouched.
@@ -911,15 +744,11 @@ func TestPad(t *testing.T) {
 			PadAxis{Start: 1, End: 1, Interior: 0}, // padding on middle axis
 			// last axis untouched (omitted)
 		)
-		if err != nil {
-			t.Fatalf("PadOp failed: %+v", err)
-		}
+		require.NoError(t, err)
 		// Axis 0: 4
 		// Axis 1: 5 + 1 + 1 = 7
 		// Axis 2: 2
-		if !S(F32, 4, 7, 2).Equal(output) {
-			t.Errorf("expected F32[4, 7, 2], got %s", output)
-		}
+		assert.True(t, S(F32, 4, 7, 2).Equal(output), "expected F32[4, 7, 2], got %s", output)
 	})
 
 	t.Run("LastAxisPadding", func(t *testing.T) {
@@ -929,15 +758,11 @@ func TestPad(t *testing.T) {
 			PadAxis{Start: 0, End: 0, Interior: 0}, // untouched
 			PadAxis{Start: 0, End: 0, Interior: 2}, // padding on the last axis
 		)
-		if err != nil {
-			t.Fatalf("PadOp failed: %+v", err)
-		}
+		require.NoError(t, err)
 		// Axis 0: 2
 		// Axis 1: 2
 		// Axis 2: 2 + 0 + 0 + (2-1)*2 = 4
-		if !S(F32, 2, 2, 4).Equal(output) {
-			t.Errorf("expected F32, 2, 2, 4, got %s", output)
-		}
+		assert.True(t, S(F32, 2, 2, 4).Equal(output), "expected F32[2, 2, 4], got %s", output)
 	})
 
 	t.Run("MissingAxes", func(t *testing.T) {
@@ -946,13 +771,293 @@ func TestPad(t *testing.T) {
 			PadAxis{Start: 2, End: 2, Interior: 0},
 			// missing axis
 		)
-		if err != nil {
-			t.Fatalf("PadOp failed: %+v", err)
-		}
+		require.NoError(t, err)
 		// Axis 0: 5 + 4 = 9
 		// Axis 1: 3
-		if !S(F32, 9, 3).Equal(output) {
-			t.Errorf("expected F32[9, 3], got %s", output)
-		}
+		assert.True(t, S(F32, 9, 3).Equal(output), "expected F32[9, 3], got %s", output)
 	})
 }
+
+// --- Axis Name Propagation Tests ---
+
+func TestBinaryOp_AxisNames(t *testing.T) {
+	t.Run("MatchingNames", func(t *testing.T) {
+		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		rhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
+		require.NoError(t, err)
+		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+		// Dynamic dim propagates.
+		require.Equal(t, []int{-1, 512}, output.Dimensions)
+	})
+
+	t.Run("OneNamed", func(t *testing.T) {
+		// lhs has names, rhs does not → adopt lhs names.
+		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		rhs := S(F32, 32, 512)
+		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
+		require.NoError(t, err)
+		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+	})
+
+	t.Run("BothUnnamed", func(t *testing.T) {
+		lhs := S(F32, 2, 3)
+		rhs := S(F32, 2, 3)
+		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
+		require.NoError(t, err)
+		require.Nil(t, output.AxisNames)
+	})
+
+	t.Run("ConflictingNames", func(t *testing.T) {
+		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		rhs := SD(F32, []int{-1, 512}, []string{"time", ""})
+		_, err := BinaryOp(OpTypeAdd, lhs, rhs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "axis name conflict")
+	})
+
+	t.Run("DynamicBroadcast", func(t *testing.T) {
+		// lhs: [batch=-1, 1], rhs: [1, 512] → output: [batch=-1, 512]
+		lhs := SD(F32, []int{-1, 1}, []string{"batch", ""})
+		rhs := S(F32, 1, 512)
+		output, err := BinaryOp(OpTypeMul, lhs, rhs)
+		require.NoError(t, err)
+		require.Equal(t, []int{-1, 512}, output.Dimensions)
+		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+	})
+
+	t.Run("BothDynamic", func(t *testing.T) {
+		// Both sides dynamic non-broadcast → output is dynamic.
+		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		rhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := BinaryOp(OpTypeAdd, lhs, rhs)
+		require.NoError(t, err)
+		require.Equal(t, shapes.DynamicDim, output.Dimensions[0])
+	})
+
+	t.Run("ScalarWithNamed", func(t *testing.T) {
+		// Scalar + named tensor → named tensor (scalar path returns rhs directly).
+		scalar := S(F32)
+		named := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := BinaryOp(OpTypeAdd, scalar, named)
+		require.NoError(t, err)
+		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+	})
+}
+
+func TestComparisonOp_AxisNames(t *testing.T) {
+	lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+	rhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+	output, err := ComparisonOp(OpTypeEqual, lhs, rhs)
+	require.NoError(t, err)
+	require.Equal(t, dtypes.Bool, output.DType)
+	require.Equal(t, []string{"batch", ""}, output.AxisNames)
+}
+
+func TestUnaryOp_AxisNames(t *testing.T) {
+	named := SD(F32, []int{-1, 512}, []string{"batch", ""})
+	output, err := UnaryOp(OpTypeExp, named)
+	require.NoError(t, err)
+	// UnaryOp returns operand directly, so names are preserved.
+	require.Equal(t, []string{"batch", ""}, output.AxisNames)
+}
+
+func TestTransposeOp_AxisNames(t *testing.T) {
+	t.Run("PermutesNames", func(t *testing.T) {
+		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+		output, err := TransposeOp(s, []int{1, 0, 2})
+		require.NoError(t, err)
+		require.Equal(t, []int{-1, -1, 768}, output.Dimensions)
+		require.Equal(t, []string{"seq_len", "batch", ""}, output.AxisNames)
+	})
+
+	t.Run("NoNames", func(t *testing.T) {
+		s := S(F32, 2, 3)
+		output, err := TransposeOp(s, []int{1, 0})
+		require.NoError(t, err)
+		require.Nil(t, output.AxisNames)
+	})
+}
+
+func TestBroadcastInDimOp_AxisNames(t *testing.T) {
+	t.Run("DynamicDimMatch", func(t *testing.T) {
+		operand := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		outputShape := S(F32, 32, 512)
+		err := BroadcastInDimOp(operand, outputShape, []int{0, 1})
+		require.NoError(t, err)
+	})
+
+	t.Run("DynamicDimMismatch", func(t *testing.T) {
+		// Static 32 cannot be broadcast to static 64, but dynamic is assumed OK.
+		// Wait, if output is static, it must match or be 1.
+		operand := S(F32, 32, 512)
+		outputShape := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		err := BroadcastInDimOp(operand, outputShape, []int{0, 1})
+		require.NoError(t, err)
+	})
+}
+
+func TestReduceOp_AxisNames(t *testing.T) {
+	t.Run("RemovesReducedAxis", func(t *testing.T) {
+		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+		// Reduce last axis → names for remaining axes preserved.
+		output, err := ReduceOp(s, []int{2})
+		require.NoError(t, err)
+		require.Equal(t, []int{-1, -1}, output.Dimensions)
+		require.Equal(t, []string{"batch", "seq_len"}, output.AxisNames)
+	})
+
+	t.Run("ReduceToScalar", func(t *testing.T) {
+		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := ReduceOp(s, []int{0, 1})
+		require.NoError(t, err)
+		require.True(t, output.IsScalar())
+	})
+
+	t.Run("NoNames", func(t *testing.T) {
+		s := S(F32, 4, 5, 6)
+		output, err := ReduceOp(s, []int{1})
+		require.NoError(t, err)
+		require.Nil(t, output.AxisNames)
+	})
+}
+
+func TestConcatenateOp_AxisNames(t *testing.T) {
+	t.Run("UnifiesNames", func(t *testing.T) {
+		s1 := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		s2 := SD(F32, []int{-1, 256}, []string{"batch", ""})
+		output, err := ConcatenateOp([]shapes.Shape{s1, s2}, 1)
+		require.NoError(t, err)
+		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+	})
+
+	t.Run("ConcatAxisNameConflictDrops", func(t *testing.T) {
+		// Different names on the concat axis → name is dropped for that axis.
+		s1 := SD(F32, []int{-1, -1}, []string{"batch", "a"})
+		s2 := SD(F32, []int{-1, -1}, []string{"batch", "b"})
+		output, err := ConcatenateOp([]shapes.Shape{s1, s2}, 1) // concat on axis 1
+		require.NoError(t, err)
+		require.Equal(t, "batch", output.AxisNames[0])
+		require.Equal(t, "", output.AxisNames[1]) // dropped due to conflict
+	})
+
+	t.Run("NonConcatAxisNameConflictErrors", func(t *testing.T) {
+		s1 := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		s2 := SD(F32, []int{-1, 512}, []string{"time", ""})
+		_, err := ConcatenateOp([]shapes.Shape{s1, s2}, 1) // concat on axis 1, conflict on axis 0
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "axis name conflict")
+	})
+
+	t.Run("DynamicConcatAxis", func(t *testing.T) {
+		s1 := SD(F32, []int{-1, -1}, []string{"batch", "seq"})
+		s2 := SD(F32, []int{-1, 128}, []string{"batch", ""})
+		output, err := ConcatenateOp([]shapes.Shape{s1, s2}, 1)
+		require.NoError(t, err)
+		require.Equal(t, shapes.DynamicDim, output.Dimensions[1])
+	})
+}
+
+func TestSliceOp_AxisNames(t *testing.T) {
+	t.Run("PreservesNames", func(t *testing.T) {
+		s := S(F32, 10, 20).WithAxisNames("height", "width")
+		output, err := SliceOp(s, []int{2, 5}, []int{8, 15}, []int{1, 1})
+		require.NoError(t, err)
+		require.Equal(t, []string{"height", "width"}, output.AxisNames)
+		require.Equal(t, []int{6, 10}, output.Dimensions)
+	})
+
+	t.Run("DynamicAxis", func(t *testing.T) {
+		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := SliceOp(s, []int{0, 0}, []int{0, 256}, []int{1, 1})
+		require.NoError(t, err)
+		require.Equal(t, shapes.DynamicDim, output.Dimensions[0])
+		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+	})
+
+	t.Run("NoNames", func(t *testing.T) {
+		s := S(F32, 10, 20)
+		output, err := SliceOp(s, []int{0, 0}, []int{5, 10}, []int{1, 1})
+		require.NoError(t, err)
+		require.Nil(t, output.AxisNames)
+	})
+}
+
+func TestArgMinMaxOp_AxisNames(t *testing.T) {
+	t.Run("RemovesAxisName", func(t *testing.T) {
+		s := SD(F32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+		output, err := ArgMinMaxOp(s, 2, I32)
+		require.NoError(t, err)
+		require.Equal(t, []int{-1, -1}, output.Dimensions)
+		require.Equal(t, []string{"batch", "seq_len"}, output.AxisNames)
+	})
+
+	t.Run("RemovesFirstAxis", func(t *testing.T) {
+		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := ArgMinMaxOp(s, 0, I32)
+		require.NoError(t, err)
+		require.Equal(t, []int{512}, output.Dimensions)
+		require.Equal(t, []string{""}, output.AxisNames)
+	})
+
+	t.Run("NoNames", func(t *testing.T) {
+		s := S(F32, 5, 6)
+		output, err := ArgMinMaxOp(s, 1, I32)
+		require.NoError(t, err)
+		require.Nil(t, output.AxisNames)
+	})
+}
+
+func TestReduceWindowOp_AxisNames(t *testing.T) {
+	t.Run("PreservesNames", func(t *testing.T) {
+		s := S(F32, 1, 20, 22, 3).WithAxisNames("batch", "height", "width", "channels")
+		output, err := ReduceWindowOp(s, []int{1, 3, 3, 1}, []int{1, 2, 2, 1}, nil, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, []string{"batch", "height", "width", "channels"}, output.AxisNames)
+	})
+
+	t.Run("DynamicDim", func(t *testing.T) {
+		s := SD(F32, []int{-1, 10}, []string{"batch", "seq"})
+		output, err := ReduceWindowOp(s, []int{1, 3}, []int{1, 1}, nil, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, shapes.DynamicDim, output.Dimensions[0])
+		require.Equal(t, 8, output.Dimensions[1])
+		require.Equal(t, []string{"batch", "seq"}, output.AxisNames)
+	})
+
+	t.Run("NoNames", func(t *testing.T) {
+		s := S(F32, 10)
+		output, err := ReduceWindowOp(s, []int{3}, nil, nil, nil, nil)
+		require.NoError(t, err)
+		require.Nil(t, output.AxisNames)
+	})
+}
+
+func TestDotGeneral_DynamicAndNames(t *testing.T) {
+	t.Run("DynamicBatchDim", func(t *testing.T) {
+		lhs := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		rhs := SD(F32, []int{-1, 512, 256}, []string{"batch", "", ""})
+		output, err := DotGeneral(lhs, []int{1}, []int{0}, rhs, []int{1}, []int{0}, DotGeneralConfig{})
+		require.NoError(t, err)
+		require.Equal(t, []int{-1, 256}, output.Dimensions)
+		require.Equal(t, []string{"batch", ""}, output.AxisNames)
+	})
+
+	t.Run("AxisNameConflict", func(t *testing.T) {
+		lhs := SD(F32, []int{-1, 512}, []string{"batch1", ""})
+		rhs := SD(F32, []int{-1, 512}, []string{"batch2", ""})
+		_, err := DotGeneral(lhs, []int{1}, []int{0}, rhs, []int{1}, []int{0}, DotGeneralConfig{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "axis name conflict")
+	})
+}
+
+func TestReshapeOp_Dynamic(t *testing.T) {
+	t.Run("PropagatesDynamicDim", func(t *testing.T) {
+		s := SD(F32, []int{-1, 512}, []string{"batch", ""})
+		output, err := ReshapeOp(s, []int{-1, 8, 64})
+		require.NoError(t, err)
+		require.Equal(t, []int{-1, 8, 64}, output.Dimensions)
+	})
+}
+

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -1,0 +1,169 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package shapes
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// AxisBindings maps named axis names to their concrete dimension values.
+// Used at execution time to resolve dynamic shapes.
+type AxisBindings map[string]int
+
+// Key returns a deterministic string key suitable for use as a map key.
+// Axis names are sorted alphabetically and formatted as "name=value,name=value".
+func (b AxisBindings) Key() string {
+	if len(b) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(b))
+	for name := range b {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	parts := make([]string, len(names))
+	for i, name := range names {
+		parts[i] = fmt.Sprintf("%s=%d", name, b[name])
+	}
+	return strings.Join(parts, ",")
+}
+
+// Resolve returns a new Shape with all dynamic dimensions replaced by their bound values.
+// The resolved shape retains its AxisNames for provenance/debugging.
+//
+// Panics if a named dynamic axis has no corresponding binding, or if the binding is non-positive.
+func (s Shape) Resolve(bindings AxisBindings) Shape {
+	if !s.HasDynamicDims() {
+		return s
+	}
+	resolved := s.Clone()
+	for i, dim := range resolved.Dimensions {
+		if dim != DynamicDim {
+			continue
+		}
+		name := resolved.AxisName(i)
+		if name == "" {
+			panic(errors.Errorf("Shape.Resolve: dynamic axis %d has no name and cannot be resolved: %s", i, s))
+		}
+		val, ok := bindings[name]
+		if !ok {
+			panic(errors.Errorf("Shape.Resolve: no binding for axis %q in shape %s", name, s))
+		}
+		if val <= 0 {
+			panic(errors.Errorf("Shape.Resolve: binding for axis %q must be positive, got %d", name, val))
+		}
+		resolved.Dimensions[i] = val
+	}
+	return resolved
+}
+
+// ExtractBindings extracts axis bindings by comparing a template shape (with named dynamic axes)
+// against a concrete shape (with all dimensions known).
+//
+// Returns an error if the shapes are incompatible: different ranks, different static dimensions,
+// or inconsistent bindings where the same axis name maps to different concrete values.
+func ExtractBindings(template, concrete Shape) (AxisBindings, error) {
+	if template.Rank() != concrete.Rank() {
+		return nil, errors.Errorf("ExtractBindings: rank mismatch: template %s has rank %d, concrete %s has rank %d",
+			template, template.Rank(), concrete, concrete.Rank())
+	}
+	bindings := make(AxisBindings)
+	for i := range template.Dimensions {
+		templateDim := template.Dimensions[i]
+		concreteDim := concrete.Dimensions[i]
+
+		if concreteDim == DynamicDim {
+			return nil, errors.Errorf("ExtractBindings: concrete shape %s has dynamic dimension at axis %d", concrete, i)
+		}
+
+		if templateDim == DynamicDim {
+			name := template.AxisName(i)
+			if name == "" {
+				return nil, errors.Errorf("ExtractBindings: template %s has dynamic dimension at axis %d but no axis name", template, i)
+			}
+			if existing, ok := bindings[name]; ok && existing != concreteDim {
+				return nil, errors.Errorf("ExtractBindings: axis %q has conflicting values: %d vs %d", name, existing, concreteDim)
+			}
+			bindings[name] = concreteDim
+		} else if templateDim != concreteDim {
+			return nil, errors.Errorf("ExtractBindings: dimension %d mismatch: template has %d, concrete has %d",
+				i, templateDim, concreteDim)
+		}
+	}
+	return bindings, nil
+}
+
+// MergeBindings merges multiple AxisBindings into one. Returns an error if any axis name
+// has conflicting values across the inputs.
+func MergeBindings(all ...AxisBindings) (AxisBindings, error) {
+	merged := make(AxisBindings)
+	for _, b := range all {
+		for name, val := range b {
+			if existing, ok := merged[name]; ok && existing != val {
+				return nil, errors.Errorf("MergeBindings: axis %q has conflicting values: %d vs %d", name, existing, val)
+			}
+			merged[name] = val
+		}
+	}
+	return merged, nil
+}
+
+// UnifyAxisName resolves the output axis name when combining two axes from different shapes.
+//
+// Rules:
+//   - "" + "" = "" (both unnamed → unnamed)
+//   - "name" + "" = "name" (one named → keep the name)
+//   - "" + "name" = "name" (one named → keep the name)
+//   - "name" + "name" = "name" (same name → keep it)
+//   - "a" + "b" = error (different names → conflict)
+func UnifyAxisName(name1, name2 string) (string, error) {
+	if name1 == "" {
+		return name2, nil
+	}
+	if name2 == "" {
+		return name1, nil
+	}
+	if name1 == name2 {
+		return name1, nil
+	}
+	return "", errors.Errorf("incompatible axis names: %q vs %q", name1, name2)
+}
+
+// UnifyAxisNames unifies axis names from two shapes of the same rank.
+// Returns the unified axis names, or error on name conflicts.
+// Returns nil if neither shape has axis names.
+func UnifyAxisNames(s1, s2 Shape) ([]string, error) {
+	if s1.AxisNames == nil && s2.AxisNames == nil {
+		return nil, nil
+	}
+	if s1.Rank() != s2.Rank() {
+		return nil, errors.Errorf("UnifyAxisNames: rank mismatch: %d vs %d", s1.Rank(), s2.Rank())
+	}
+	result := make([]string, s1.Rank())
+	for i := range result {
+		name1 := ""
+		if s1.AxisNames != nil {
+			name1 = s1.AxisNames[i]
+		}
+		name2 := ""
+		if s2.AxisNames != nil {
+			name2 = s2.AxisNames[i]
+		}
+		unified, err := UnifyAxisName(name1, name2)
+		if err != nil {
+			return nil, errors.Wrapf(err, "axis %d", i)
+		}
+		result[i] = unified
+	}
+
+	// If all names are empty, return nil for consistency.
+	if slices.IndexFunc(result, func(s string) bool { return s != "" }) == -1 {
+		return nil, nil
+	}
+	return result, nil
+}

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -60,55 +60,45 @@ func (s Shape) Resolve(bindings AxisBindings) (Shape, error) {
 	return resolved, nil
 }
 
-// ExtractBindings extracts axis bindings by comparing a template shape (with named dynamic axes)
-// against a concrete shape (with all dimensions known).
+// Extract axis bindings by comparing a template shape (with named dynamic axes)
+// against a concrete shape with all dimensions known (presumably given during execution, when the concrete inputs
+// are given).
 //
 // Returns an error if the shapes are incompatible: different ranks, different static dimensions,
 // or inconsistent bindings where the same axis name maps to different concrete values.
-func ExtractBindings(template, concrete Shape) (AxisBindings, error) {
+func (b AxisBindings) Extract(template, concrete Shape) error {
 	if template.Rank() != concrete.Rank() {
-		return nil, errors.Errorf("ExtractBindings: rank mismatch: template %s has rank %d, concrete %s has rank %d",
+		return errors.Errorf("ExtractBindings: rank mismatch: template %s has rank %d, concrete %s has rank %d",
 			template, template.Rank(), concrete, concrete.Rank())
 	}
-	bindings := make(AxisBindings)
 	for i := range template.Dimensions {
 		templateDim := template.Dimensions[i]
 		concreteDim := concrete.Dimensions[i]
 
 		if concreteDim == DynamicDim {
-			return nil, errors.Errorf("ExtractBindings: concrete shape %s has dynamic dimension at axis %d", concrete, i)
+			return errors.Errorf("ExtractBindings: concrete shape %s has a dynamic dimension at axis %d",
+				concrete, i)
 		}
 
 		if templateDim == DynamicDim {
 			name := template.AxisName(i)
 			if name == "" {
-				return nil, errors.Errorf("ExtractBindings: template %s has dynamic dimension at axis %d but no axis name", template, i)
+				return errors.Errorf(
+					"ExtractBindings: template %s has dynamic dimension at axis %d but no axis name",
+					template, i)
 			}
-			if existing, ok := bindings[name]; ok && existing != concreteDim {
-				return nil, errors.Errorf("ExtractBindings: axis %q has conflicting values: %d vs %d", name, existing, concreteDim)
+			if existing, ok := b[name]; ok && existing != concreteDim {
+				return errors.Errorf("ExtractBindings: axis %q has conflicting values: %d vs %d",
+					name, existing, concreteDim)
 			}
-			bindings[name] = concreteDim
+			b[name] = concreteDim
 		} else if templateDim != concreteDim {
-			return nil, errors.Errorf("ExtractBindings: dimension %d mismatch: template has %d, concrete has %d",
+			return errors.Errorf(
+				"ExtractBindings: dimension %d mismatch: template has %d, concrete has %d",
 				i, templateDim, concreteDim)
 		}
 	}
-	return bindings, nil
-}
-
-// MergeBindings merges multiple AxisBindings into one. Returns an error if any axis name
-// has conflicting values across the inputs.
-func MergeBindings(all ...AxisBindings) (AxisBindings, error) {
-	merged := make(AxisBindings)
-	for _, b := range all {
-		for name, val := range b {
-			if existing, ok := merged[name]; ok && existing != val {
-				return nil, errors.Errorf("MergeBindings: axis %q has conflicting values: %d vs %d", name, existing, val)
-			}
-			merged[name] = val
-		}
-	}
-	return merged, nil
+	return nil
 }
 
 // UnifyAxisName resolves the output axis name when combining two axes from different shapes.

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gomlx/gomlx/pkg/support/xslices"
+	"github.com/gomlx/compute/support/xslices"
 	"github.com/pkg/errors"
 )
 

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -38,7 +38,7 @@ func (b AxisBindings) Key() string {
 //
 // Panics if a named dynamic axis has no corresponding binding, or if the binding is non-positive.
 func (s Shape) Resolve(bindings AxisBindings) Shape {
-	if !s.HasDynamicDims() {
+	if !s.IsDynamic() {
 		return s
 	}
 	resolved := s.Clone()

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -29,13 +29,15 @@ func (b AxisBindings) Key() string {
 	return strings.Join(parts, ",")
 }
 
-// Resolve returns a new Shape with all dynamic dimensions replaced by their bound values.
+// Resolve returns a new Shape with all dynamic dimensions replaced by their bound values --
+// except if the original shape was not dynamic, then it is returned as is (not a copy).
+//
 // The resolved shape retains its AxisNames for provenance/debugging.
 //
-// Panics if a named dynamic axis has no corresponding binding, or if the binding is non-positive.
-func (s Shape) Resolve(bindings AxisBindings) Shape {
+// Returns an error a named dynamic axis has no corresponding binding, or if the binding is non-positive.
+func (s Shape) Resolve(bindings AxisBindings) (Shape, error) {
 	if !s.IsDynamic() {
-		return s
+		return s, nil
 	}
 	resolved := s.Clone()
 	for i, dim := range resolved.Dimensions {
@@ -44,18 +46,18 @@ func (s Shape) Resolve(bindings AxisBindings) Shape {
 		}
 		name := resolved.AxisName(i)
 		if name == "" {
-			panic(errors.Errorf("Shape.Resolve: dynamic axis %d has no name and cannot be resolved: %s", i, s))
+			return Shape{}, errors.Errorf("Shape.Resolve: dynamic axis %d has no name and cannot be resolved: %s", i, s)
 		}
 		val, ok := bindings[name]
 		if !ok {
-			panic(errors.Errorf("Shape.Resolve: no binding for axis %q in shape %s", name, s))
+			return Shape{}, errors.Errorf("Shape.Resolve: no binding for axis %q in shape %s", name, s)
 		}
 		if val <= 0 {
-			panic(errors.Errorf("Shape.Resolve: binding for axis %q must be positive, got %d", name, val))
+			return Shape{}, errors.Errorf("Shape.Resolve: binding for axis %q must be positive, got %d", name, val)
 		}
 		resolved.Dimensions[i] = val
 	}
-	return resolved
+	return resolved, nil
 }
 
 // ExtractBindings extracts axis bindings by comparing a template shape (with named dynamic axes)

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -132,19 +132,17 @@ func UnifyAxisNames(s1, s2 Shape) ([]string, error) {
 	if s1.Rank() != s2.Rank() {
 		return nil, errors.Errorf("UnifyAxisNames: rank mismatch: %d vs %d", s1.Rank(), s2.Rank())
 	}
+	if s1.AxisNames == nil {
+		return s2.AxisNames, nil
+	}
+	if s2.AxisNames == nil {
+		return s1.AxisNames, nil
+	}
 	result := make([]string, s1.Rank())
 	for i := range result {
-		name1 := ""
-		if s1.AxisNames != nil {
-			name1 = s1.AxisNames[i]
-		}
-		name2 := ""
-		if s2.AxisNames != nil {
-			name2 = s2.AxisNames[i]
-		}
-		unified, err := UnifyAxisName(name1, name2)
+		unified, err := UnifyAxisName(s1.AxisNames[i], s2.AxisNames[i])
 		if err != nil {
-			return nil, errors.Wrapf(err, "axis %d", i)
+			return nil, errors.WithMessagef(err, "axis %d", i)
 		}
 		result[i] = unified
 	}

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -5,9 +5,9 @@ package shapes
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
+	"github.com/gomlx/gomlx/pkg/support/xslices"
 	"github.com/pkg/errors"
 )
 
@@ -21,11 +21,7 @@ func (b AxisBindings) Key() string {
 	if len(b) == 0 {
 		return ""
 	}
-	names := make([]string, 0, len(b))
-	for name := range b {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := xslices.SortedKeys(b)
 	parts := make([]string, len(names))
 	for i, name := range names {
 		parts[i] = fmt.Sprintf("%s=%d", name, b[name])

--- a/shapes/bindings_test.go
+++ b/shapes/bindings_test.go
@@ -9,205 +9,185 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAxisBindings_Key(t *testing.T) {
-	b := AxisBindings{"batch": 32, "seq_len": 128}
-	require.Equal(t, "batch=32,seq_len=128", b.Key())
+func TestBindings(t *testing.T) {
+	t.Run("AxisBindings_Key", func(t *testing.T) {
+		b := AxisBindings{"batch": 32, "seq_len": 128}
+		require.Equal(t, "batch=32,seq_len=128", b.Key())
 
-	// Deterministic ordering.
-	b2 := AxisBindings{"seq_len": 128, "batch": 32}
-	require.Equal(t, b.Key(), b2.Key())
+		// Deterministic ordering.
+		b2 := AxisBindings{"seq_len": 128, "batch": 32}
+		require.Equal(t, b.Key(), b2.Key())
 
-	// Empty.
-	require.Equal(t, "", AxisBindings{}.Key())
-}
+		// Empty.
+		require.Equal(t, "", AxisBindings{}.Key())
+	})
 
-func TestResolve(t *testing.T) {
-	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	bindings := AxisBindings{"batch": 32}
-	resolved, err := s.Resolve(bindings)
-	require.NoError(t, err)
+	t.Run("Resolve", func(t *testing.T) {
+		s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+		bindings := AxisBindings{"batch": 32}
+		resolved, err := s.Resolve(bindings)
+		require.NoError(t, err)
 
-	require.Equal(t, []int{32, 512}, resolved.Dimensions)
-	require.Equal(t, []string{"batch", ""}, resolved.AxisNames)
-	require.False(t, resolved.IsDynamic())
-}
+		require.Equal(t, []int{32, 512}, resolved.Dimensions)
+		require.Equal(t, []string{"batch", ""}, resolved.AxisNames)
+		require.False(t, resolved.IsDynamic())
+	})
 
-func TestResolve_MultipleAxes(t *testing.T) {
-	s := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
-	bindings := AxisBindings{"batch": 8, "seq_len": 256}
-	resolved, err := s.Resolve(bindings)
-	require.NoError(t, err)
+	t.Run("Resolve_MultipleAxes", func(t *testing.T) {
+		s := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+		bindings := AxisBindings{"batch": 8, "seq_len": 256}
+		resolved, err := s.Resolve(bindings)
+		require.NoError(t, err)
 
-	require.Equal(t, []int{8, 256, 768}, resolved.Dimensions)
-}
+		require.Equal(t, []int{8, 256, 768}, resolved.Dimensions)
+	})
 
-func TestResolve_StaticShape(t *testing.T) {
-	s := Make(dtypes.Float32, 32, 512)
-	// Resolve on static shape returns same shape (no-op).
-	resolved, err := s.Resolve(AxisBindings{"batch": 64})
-	require.NoError(t, err)
-	require.True(t, s.Equal(resolved))
-}
+	t.Run("Resolve_StaticShape", func(t *testing.T) {
+		s := Make(dtypes.Float32, 32, 512)
+		// Resolve on static shape returns same shape (no-op).
+		resolved, err := s.Resolve(AxisBindings{"batch": 64})
+		require.NoError(t, err)
+		require.True(t, s.Equal(resolved))
+	})
 
-func TestResolve_MissingBinding(t *testing.T) {
-	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	_, err := s.Resolve(AxisBindings{})
-	require.Error(t, err)
-}
+	t.Run("Resolve_MissingBinding", func(t *testing.T) {
+		s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+		_, err := s.Resolve(AxisBindings{})
+		require.Error(t, err)
+	})
 
-func TestResolve_NonPositiveBinding(t *testing.T) {
-	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	_, err := s.Resolve(AxisBindings{"batch": 0})
-	require.Error(t, err)
-	_, err = s.Resolve(AxisBindings{"batch": -5})
-	require.Error(t, err)
-}
+	t.Run("Resolve_NonPositiveBinding", func(t *testing.T) {
+		s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+		_, err := s.Resolve(AxisBindings{"batch": 0})
+		require.Error(t, err)
+		_, err = s.Resolve(AxisBindings{"batch": -5})
+		require.Error(t, err)
+	})
 
-func TestExtractBindings(t *testing.T) {
-	template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	concrete := Make(dtypes.Float32, 32, 512)
+	t.Run("Extract", func(t *testing.T) {
+		t.Run("Basic", func(t *testing.T) {
+			bindings := make(AxisBindings)
+			template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+			concrete := Make(dtypes.Float32, 32, 512)
+			err := bindings.Extract(template, concrete)
+			require.NoError(t, err)
+			require.Equal(t, AxisBindings{"batch": 32}, bindings)
+		})
 
-	bindings, err := ExtractBindings(template, concrete)
-	require.NoError(t, err)
-	require.Equal(t, AxisBindings{"batch": 32}, bindings)
-}
+		t.Run("MultipleAxes", func(t *testing.T) {
+			template := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+			concrete := Make(dtypes.Float32, 8, 128, 768)
+			bindings := make(AxisBindings)
+			err := bindings.Extract(template, concrete)
+			require.NoError(t, err)
+			require.Equal(t, AxisBindings{"batch": 8, "seq_len": 128}, bindings)
+		})
 
-func TestExtractBindings_MultipleAxes(t *testing.T) {
-	template := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
-	concrete := Make(dtypes.Float32, 8, 128, 768)
+		t.Run("ConsistencyCheck", func(t *testing.T) {
+			// Same axis name appears multiple times with different values.
+			template := MakeDynamic(dtypes.Float32, []int{-1, -1}, []string{"n", "n"})
+			concrete := Make(dtypes.Float32, 5, 5)
 
-	bindings, err := ExtractBindings(template, concrete)
-	require.NoError(t, err)
-	require.Equal(t, AxisBindings{"batch": 8, "seq_len": 128}, bindings)
-}
+			// Same value → OK.
+			bindings := make(AxisBindings)
+			err := bindings.Extract(template, concrete)
+			require.NoError(t, err)
+			require.Equal(t, AxisBindings{"n": 5}, bindings)
 
-func TestExtractBindings_ConsistencyCheck(t *testing.T) {
-	// Same axis name appears multiple times with different values.
-	template := MakeDynamic(dtypes.Float32, []int{-1, -1}, []string{"n", "n"})
-	concrete := Make(dtypes.Float32, 5, 5)
+			// Different values → error.
+			concrete2 := Make(dtypes.Float32, 5, 10)
+			bindings2 := make(AxisBindings)
+			err = bindings2.Extract(template, concrete2)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "conflicting")
+		})
 
-	// Same value → OK.
-	bindings, err := ExtractBindings(template, concrete)
-	require.NoError(t, err)
-	require.Equal(t, AxisBindings{"n": 5}, bindings)
+		t.Run("RankMismatch", func(t *testing.T) {
+			template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+			concrete := Make(dtypes.Float32, 32, 512, 3)
+			bindings := make(AxisBindings)
+			err := bindings.Extract(template, concrete)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "rank")
+		})
 
-	// Different values → error.
-	concrete2 := Make(dtypes.Float32, 5, 10)
-	_, err = ExtractBindings(template, concrete2)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "conflicting")
-}
+		t.Run("StaticDimMismatch", func(t *testing.T) {
+			template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+			concrete := Make(dtypes.Float32, 32, 256)
+			b := make(AxisBindings)
+			err := b.Extract(template, concrete)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "mismatch")
+		})
+	})
 
-func TestExtractBindings_RankMismatch(t *testing.T) {
-	template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	concrete := Make(dtypes.Float32, 32, 512, 3)
+	t.Run("UnifyAxisName", func(t *testing.T) {
+		// Both empty.
+		name, err := UnifyAxisName("", "")
+		require.NoError(t, err)
+		require.Equal(t, "", name)
 
-	_, err := ExtractBindings(template, concrete)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "rank")
-}
+		// One named.
+		name, err = UnifyAxisName("batch", "")
+		require.NoError(t, err)
+		require.Equal(t, "batch", name)
 
-func TestExtractBindings_StaticDimMismatch(t *testing.T) {
-	template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	concrete := Make(dtypes.Float32, 32, 256)
+		name, err = UnifyAxisName("", "batch")
+		require.NoError(t, err)
+		require.Equal(t, "batch", name)
 
-	_, err := ExtractBindings(template, concrete)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "mismatch")
-}
+		// Same name.
+		name, err = UnifyAxisName("batch", "batch")
+		require.NoError(t, err)
+		require.Equal(t, "batch", name)
 
-func TestMergeBindings(t *testing.T) {
-	b1 := AxisBindings{"batch": 32}
-	b2 := AxisBindings{"seq_len": 128}
+		// Different names.
+		_, err = UnifyAxisName("batch", "time")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "incompatible")
+	})
 
-	merged, err := MergeBindings(b1, b2)
-	require.NoError(t, err)
-	require.Equal(t, AxisBindings{"batch": 32, "seq_len": 128}, merged)
-}
+	t.Run("UnifyAxisNames", func(t *testing.T) {
+		s1 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+		s2 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 
-func TestMergeBindings_SameValue(t *testing.T) {
-	b1 := AxisBindings{"batch": 32}
-	b2 := AxisBindings{"batch": 32}
+		names, err := UnifyAxisNames(s1, s2)
+		require.NoError(t, err)
+		require.Equal(t, []string{"batch", ""}, names)
 
-	merged, err := MergeBindings(b1, b2)
-	require.NoError(t, err)
-	require.Equal(t, AxisBindings{"batch": 32}, merged)
-}
+		// One unnamed adopts.
+		s3 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+		s4 := Make(dtypes.Float32, 32, 512) // no AxisNames
+		names, err = UnifyAxisNames(s3, s4)
+		require.NoError(t, err)
+		require.Equal(t, []string{"batch", ""}, names)
 
-func TestMergeBindings_Conflict(t *testing.T) {
-	b1 := AxisBindings{"batch": 32}
-	b2 := AxisBindings{"batch": 64}
+		// Both nil.
+		s5 := Make(dtypes.Float32, 32, 512)
+		s6 := Make(dtypes.Float32, 32, 512)
+		names, err = UnifyAxisNames(s5, s6)
+		require.NoError(t, err)
+		require.Nil(t, names)
 
-	_, err := MergeBindings(b1, b2)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "conflicting")
-}
+		// Conflict.
+		s7 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+		s8 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"time", ""})
+		_, err = UnifyAxisNames(s7, s8)
+		require.Error(t, err)
+	})
 
-func TestUnifyAxisName(t *testing.T) {
-	// Both empty.
-	name, err := UnifyAxisName("", "")
-	require.NoError(t, err)
-	require.Equal(t, "", name)
+	t.Run("RoundTrip_ExtractAndResolve", func(t *testing.T) {
+		// Extract bindings from concrete shape, then resolve template with those bindings.
+		template := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+		concrete := Make(dtypes.Float32, 16, 64, 768)
 
-	// One named.
-	name, err = UnifyAxisName("batch", "")
-	require.NoError(t, err)
-	require.Equal(t, "batch", name)
+		b := make(AxisBindings)
+		err := b.Extract(template, concrete)
+		require.NoError(t, err)
 
-	name, err = UnifyAxisName("", "batch")
-	require.NoError(t, err)
-	require.Equal(t, "batch", name)
-
-	// Same name.
-	name, err = UnifyAxisName("batch", "batch")
-	require.NoError(t, err)
-	require.Equal(t, "batch", name)
-
-	// Different names.
-	_, err = UnifyAxisName("batch", "time")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "incompatible")
-}
-
-func TestUnifyAxisNames(t *testing.T) {
-	s1 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	s2 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-
-	names, err := UnifyAxisNames(s1, s2)
-	require.NoError(t, err)
-	require.Equal(t, []string{"batch", ""}, names)
-
-	// One unnamed adopts.
-	s3 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	s4 := Make(dtypes.Float32, 32, 512) // no AxisNames
-	names, err = UnifyAxisNames(s3, s4)
-	require.NoError(t, err)
-	require.Equal(t, []string{"batch", ""}, names)
-
-	// Both nil.
-	s5 := Make(dtypes.Float32, 32, 512)
-	s6 := Make(dtypes.Float32, 32, 512)
-	names, err = UnifyAxisNames(s5, s6)
-	require.NoError(t, err)
-	require.Nil(t, names)
-
-	// Conflict.
-	s7 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	s8 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"time", ""})
-	_, err = UnifyAxisNames(s7, s8)
-	require.Error(t, err)
-}
-
-func TestRoundTrip_ExtractAndResolve(t *testing.T) {
-	// Extract bindings from concrete shape, then resolve template with those bindings.
-	template := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
-	concrete := Make(dtypes.Float32, 16, 64, 768)
-
-	bindings, err := ExtractBindings(template, concrete)
-	require.NoError(t, err)
-
-	resolved, err := template.Resolve(bindings)
-	require.NoError(t, err)
-	require.Equal(t, concrete.Dimensions, resolved.Dimensions)
-	require.False(t, resolved.IsDynamic())
+		resolved, err := template.Resolve(b)
+		require.NoError(t, err)
+		require.Equal(t, concrete.Dimensions, resolved.Dimensions)
+		require.False(t, resolved.IsDynamic())
+	})
 }

--- a/shapes/bindings_test.go
+++ b/shapes/bindings_test.go
@@ -3,65 +3,94 @@
 package shapes
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gomlx/compute/dtypes"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBindings(t *testing.T) {
 	t.Run("AxisBindings_Key", func(t *testing.T) {
 		b := AxisBindings{"batch": 32, "seq_len": 128}
-		require.Equal(t, "batch=32,seq_len=128", b.Key())
+		if !reflect.DeepEqual("batch=32,seq_len=128", b.Key()) {
+			t.Fatalf("Expected %v, got %v", "batch=32,seq_len=128", b.Key())
+		}
 
 		// Deterministic ordering.
 		b2 := AxisBindings{"seq_len": 128, "batch": 32}
-		require.Equal(t, b.Key(), b2.Key())
+		if !reflect.DeepEqual(b.Key(), b2.Key()) {
+			t.Fatalf("Expected %v, got %v", b.Key(), b2.Key())
+		}
 
 		// Empty.
-		require.Equal(t, "", AxisBindings{}.Key())
+		if !reflect.DeepEqual("", AxisBindings{}.Key()) {
+			t.Fatalf("Expected %v, got %v", "", AxisBindings{}.Key())
+		}
 	})
 
 	t.Run("Resolve", func(t *testing.T) {
 		s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 		bindings := AxisBindings{"batch": 32}
 		resolved, err := s.Resolve(bindings)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 
-		require.Equal(t, []int{32, 512}, resolved.Dimensions)
-		require.Equal(t, []string{"batch", ""}, resolved.AxisNames)
-		require.False(t, resolved.IsDynamic())
+		if !reflect.DeepEqual([]int{32, 512}, resolved.Dimensions) {
+			t.Fatalf("Expected %v, got %v", []int{32, 512}, resolved.Dimensions)
+		}
+		if !reflect.DeepEqual([]string{"batch", ""}, resolved.AxisNames) {
+			t.Fatalf("Expected %v, got %v", []string{"batch", ""}, resolved.AxisNames)
+		}
+		if resolved.IsDynamic() {
+			t.Fatalf("Condition expected to be false")
+		}
 	})
 
 	t.Run("Resolve_MultipleAxes", func(t *testing.T) {
 		s := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
 		bindings := AxisBindings{"batch": 8, "seq_len": 256}
 		resolved, err := s.Resolve(bindings)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 
-		require.Equal(t, []int{8, 256, 768}, resolved.Dimensions)
+		if !reflect.DeepEqual([]int{8, 256, 768}, resolved.Dimensions) {
+			t.Fatalf("Expected %v, got %v", []int{8, 256, 768}, resolved.Dimensions)
+		}
 	})
 
 	t.Run("Resolve_StaticShape", func(t *testing.T) {
 		s := Make(dtypes.Float32, 32, 512)
 		// Resolve on static shape returns same shape (no-op).
 		resolved, err := s.Resolve(AxisBindings{"batch": 64})
-		require.NoError(t, err)
-		require.True(t, s.Equal(resolved))
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !(s.Equal(resolved)) {
+			t.Fatalf("Condition expected to be true")
+		}
 	})
 
 	t.Run("Resolve_MissingBinding", func(t *testing.T) {
 		s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 		_, err := s.Resolve(AxisBindings{})
-		require.Error(t, err)
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
 	})
 
 	t.Run("Resolve_NonPositiveBinding", func(t *testing.T) {
 		s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 		_, err := s.Resolve(AxisBindings{"batch": 0})
-		require.Error(t, err)
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
 		_, err = s.Resolve(AxisBindings{"batch": -5})
-		require.Error(t, err)
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
 	})
 
 	t.Run("Extract", func(t *testing.T) {
@@ -70,8 +99,12 @@ func TestBindings(t *testing.T) {
 			template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 			concrete := Make(dtypes.Float32, 32, 512)
 			err := bindings.Extract(template, concrete)
-			require.NoError(t, err)
-			require.Equal(t, AxisBindings{"batch": 32}, bindings)
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			if !reflect.DeepEqual(AxisBindings{"batch": 32}, bindings) {
+				t.Fatalf("Expected %v, got %v", AxisBindings{"batch": 32}, bindings)
+			}
 		})
 
 		t.Run("MultipleAxes", func(t *testing.T) {
@@ -79,8 +112,12 @@ func TestBindings(t *testing.T) {
 			concrete := Make(dtypes.Float32, 8, 128, 768)
 			bindings := make(AxisBindings)
 			err := bindings.Extract(template, concrete)
-			require.NoError(t, err)
-			require.Equal(t, AxisBindings{"batch": 8, "seq_len": 128}, bindings)
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			if !reflect.DeepEqual(AxisBindings{"batch": 8, "seq_len": 128}, bindings) {
+				t.Fatalf("Expected %v, got %v", AxisBindings{"batch": 8, "seq_len": 128}, bindings)
+			}
 		})
 
 		t.Run("ConsistencyCheck", func(t *testing.T) {
@@ -91,15 +128,23 @@ func TestBindings(t *testing.T) {
 			// Same value → OK.
 			bindings := make(AxisBindings)
 			err := bindings.Extract(template, concrete)
-			require.NoError(t, err)
-			require.Equal(t, AxisBindings{"n": 5}, bindings)
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			if !reflect.DeepEqual(AxisBindings{"n": 5}, bindings) {
+				t.Fatalf("Expected %v, got %v", AxisBindings{"n": 5}, bindings)
+			}
 
 			// Different values → error.
 			concrete2 := Make(dtypes.Float32, 5, 10)
 			bindings2 := make(AxisBindings)
 			err = bindings2.Extract(template, concrete2)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "conflicting")
+			if err == nil {
+				t.Fatalf("Expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "conflicting") {
+				t.Fatalf("Expected %v to contain %v", err.Error(), "conflicting")
+			}
 		})
 
 		t.Run("RankMismatch", func(t *testing.T) {
@@ -107,8 +152,12 @@ func TestBindings(t *testing.T) {
 			concrete := Make(dtypes.Float32, 32, 512, 3)
 			bindings := make(AxisBindings)
 			err := bindings.Extract(template, concrete)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "rank")
+			if err == nil {
+				t.Fatalf("Expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "rank") {
+				t.Fatalf("Expected %v to contain %v", err.Error(), "rank")
+			}
 		})
 
 		t.Run("StaticDimMismatch", func(t *testing.T) {
@@ -116,35 +165,59 @@ func TestBindings(t *testing.T) {
 			concrete := Make(dtypes.Float32, 32, 256)
 			b := make(AxisBindings)
 			err := b.Extract(template, concrete)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "mismatch")
+			if err == nil {
+				t.Fatalf("Expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "mismatch") {
+				t.Fatalf("Expected %v to contain %v", err.Error(), "mismatch")
+			}
 		})
 	})
 
 	t.Run("UnifyAxisName", func(t *testing.T) {
 		// Both empty.
 		name, err := UnifyAxisName("", "")
-		require.NoError(t, err)
-		require.Equal(t, "", name)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual("", name) {
+			t.Fatalf("Expected %v, got %v", "", name)
+		}
 
 		// One named.
 		name, err = UnifyAxisName("batch", "")
-		require.NoError(t, err)
-		require.Equal(t, "batch", name)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual("batch", name) {
+			t.Fatalf("Expected %v, got %v", "batch", name)
+		}
 
 		name, err = UnifyAxisName("", "batch")
-		require.NoError(t, err)
-		require.Equal(t, "batch", name)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual("batch", name) {
+			t.Fatalf("Expected %v, got %v", "batch", name)
+		}
 
 		// Same name.
 		name, err = UnifyAxisName("batch", "batch")
-		require.NoError(t, err)
-		require.Equal(t, "batch", name)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual("batch", name) {
+			t.Fatalf("Expected %v, got %v", "batch", name)
+		}
 
 		// Different names.
 		_, err = UnifyAxisName("batch", "time")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "incompatible")
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "incompatible") {
+			t.Fatalf("Expected %v to contain %v", err.Error(), "incompatible")
+		}
 	})
 
 	t.Run("UnifyAxisNames", func(t *testing.T) {
@@ -152,28 +225,42 @@ func TestBindings(t *testing.T) {
 		s2 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 
 		names, err := UnifyAxisNames(s1, s2)
-		require.NoError(t, err)
-		require.Equal(t, []string{"batch", ""}, names)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual([]string{"batch", ""}, names) {
+			t.Fatalf("Expected %v, got %v", []string{"batch", ""}, names)
+		}
 
 		// One unnamed adopts.
 		s3 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 		s4 := Make(dtypes.Float32, 32, 512) // no AxisNames
 		names, err = UnifyAxisNames(s3, s4)
-		require.NoError(t, err)
-		require.Equal(t, []string{"batch", ""}, names)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual([]string{"batch", ""}, names) {
+			t.Fatalf("Expected %v, got %v", []string{"batch", ""}, names)
+		}
 
 		// Both nil.
 		s5 := Make(dtypes.Float32, 32, 512)
 		s6 := Make(dtypes.Float32, 32, 512)
 		names, err = UnifyAxisNames(s5, s6)
-		require.NoError(t, err)
-		require.Nil(t, names)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if names != nil {
+			t.Fatalf("Expected nil, got %v", names)
+		}
 
 		// Conflict.
 		s7 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 		s8 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"time", ""})
 		_, err = UnifyAxisNames(s7, s8)
-		require.Error(t, err)
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
 	})
 
 	t.Run("RoundTrip_ExtractAndResolve", func(t *testing.T) {
@@ -183,11 +270,19 @@ func TestBindings(t *testing.T) {
 
 		b := make(AxisBindings)
 		err := b.Extract(template, concrete)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 
 		resolved, err := template.Resolve(b)
-		require.NoError(t, err)
-		require.Equal(t, concrete.Dimensions, resolved.Dimensions)
-		require.False(t, resolved.IsDynamic())
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual(concrete.Dimensions, resolved.Dimensions) {
+			t.Fatalf("Expected %v, got %v", concrete.Dimensions, resolved.Dimensions)
+		}
+		if resolved.IsDynamic() {
+			t.Fatalf("Condition expected to be false")
+		}
 	})
 }

--- a/shapes/bindings_test.go
+++ b/shapes/bindings_test.go
@@ -1,0 +1,206 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package shapes
+
+import (
+	"testing"
+
+	"github.com/gomlx/compute/dtypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAxisBindings_Key(t *testing.T) {
+	b := AxisBindings{"batch": 32, "seq_len": 128}
+	require.Equal(t, "batch=32,seq_len=128", b.Key())
+
+	// Deterministic ordering.
+	b2 := AxisBindings{"seq_len": 128, "batch": 32}
+	require.Equal(t, b.Key(), b2.Key())
+
+	// Empty.
+	require.Equal(t, "", AxisBindings{}.Key())
+}
+
+func TestResolve(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	bindings := AxisBindings{"batch": 32}
+	resolved := s.Resolve(bindings)
+
+	require.Equal(t, []int{32, 512}, resolved.Dimensions)
+	require.Equal(t, []string{"batch", ""}, resolved.AxisNames)
+	require.False(t, resolved.HasDynamicDims())
+}
+
+func TestResolve_MultipleAxes(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+	bindings := AxisBindings{"batch": 8, "seq_len": 256}
+	resolved := s.Resolve(bindings)
+
+	require.Equal(t, []int{8, 256, 768}, resolved.Dimensions)
+}
+
+func TestResolve_StaticShape(t *testing.T) {
+	s := Make(dtypes.Float32, 32, 512)
+	// Resolve on static shape returns same shape (no-op).
+	resolved := s.Resolve(AxisBindings{"batch": 64})
+	require.True(t, s.Equal(resolved))
+}
+
+func TestResolve_MissingBinding(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.Panics(t, func() { s.Resolve(AxisBindings{}) })
+}
+
+func TestResolve_NonPositiveBinding(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.Panics(t, func() { s.Resolve(AxisBindings{"batch": 0}) })
+	require.Panics(t, func() { s.Resolve(AxisBindings{"batch": -5}) })
+}
+
+func TestExtractBindings(t *testing.T) {
+	template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	concrete := Make(dtypes.Float32, 32, 512)
+
+	bindings, err := ExtractBindings(template, concrete)
+	require.NoError(t, err)
+	require.Equal(t, AxisBindings{"batch": 32}, bindings)
+}
+
+func TestExtractBindings_MultipleAxes(t *testing.T) {
+	template := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+	concrete := Make(dtypes.Float32, 8, 128, 768)
+
+	bindings, err := ExtractBindings(template, concrete)
+	require.NoError(t, err)
+	require.Equal(t, AxisBindings{"batch": 8, "seq_len": 128}, bindings)
+}
+
+func TestExtractBindings_ConsistencyCheck(t *testing.T) {
+	// Same axis name appears multiple times with different values.
+	template := MakeDynamic(dtypes.Float32, []int{-1, -1}, []string{"n", "n"})
+	concrete := Make(dtypes.Float32, 5, 5)
+
+	// Same value → OK.
+	bindings, err := ExtractBindings(template, concrete)
+	require.NoError(t, err)
+	require.Equal(t, AxisBindings{"n": 5}, bindings)
+
+	// Different values → error.
+	concrete2 := Make(dtypes.Float32, 5, 10)
+	_, err = ExtractBindings(template, concrete2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflicting")
+}
+
+func TestExtractBindings_RankMismatch(t *testing.T) {
+	template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	concrete := Make(dtypes.Float32, 32, 512, 3)
+
+	_, err := ExtractBindings(template, concrete)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rank")
+}
+
+func TestExtractBindings_StaticDimMismatch(t *testing.T) {
+	template := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	concrete := Make(dtypes.Float32, 32, 256)
+
+	_, err := ExtractBindings(template, concrete)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mismatch")
+}
+
+func TestMergeBindings(t *testing.T) {
+	b1 := AxisBindings{"batch": 32}
+	b2 := AxisBindings{"seq_len": 128}
+
+	merged, err := MergeBindings(b1, b2)
+	require.NoError(t, err)
+	require.Equal(t, AxisBindings{"batch": 32, "seq_len": 128}, merged)
+}
+
+func TestMergeBindings_SameValue(t *testing.T) {
+	b1 := AxisBindings{"batch": 32}
+	b2 := AxisBindings{"batch": 32}
+
+	merged, err := MergeBindings(b1, b2)
+	require.NoError(t, err)
+	require.Equal(t, AxisBindings{"batch": 32}, merged)
+}
+
+func TestMergeBindings_Conflict(t *testing.T) {
+	b1 := AxisBindings{"batch": 32}
+	b2 := AxisBindings{"batch": 64}
+
+	_, err := MergeBindings(b1, b2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflicting")
+}
+
+func TestUnifyAxisName(t *testing.T) {
+	// Both empty.
+	name, err := UnifyAxisName("", "")
+	require.NoError(t, err)
+	require.Equal(t, "", name)
+
+	// One named.
+	name, err = UnifyAxisName("batch", "")
+	require.NoError(t, err)
+	require.Equal(t, "batch", name)
+
+	name, err = UnifyAxisName("", "batch")
+	require.NoError(t, err)
+	require.Equal(t, "batch", name)
+
+	// Same name.
+	name, err = UnifyAxisName("batch", "batch")
+	require.NoError(t, err)
+	require.Equal(t, "batch", name)
+
+	// Different names.
+	_, err = UnifyAxisName("batch", "time")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "incompatible")
+}
+
+func TestUnifyAxisNames(t *testing.T) {
+	s1 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	s2 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+
+	names, err := UnifyAxisNames(s1, s2)
+	require.NoError(t, err)
+	require.Equal(t, []string{"batch", ""}, names)
+
+	// One unnamed adopts.
+	s3 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	s4 := Make(dtypes.Float32, 32, 512) // no AxisNames
+	names, err = UnifyAxisNames(s3, s4)
+	require.NoError(t, err)
+	require.Equal(t, []string{"batch", ""}, names)
+
+	// Both nil.
+	s5 := Make(dtypes.Float32, 32, 512)
+	s6 := Make(dtypes.Float32, 32, 512)
+	names, err = UnifyAxisNames(s5, s6)
+	require.NoError(t, err)
+	require.Nil(t, names)
+
+	// Conflict.
+	s7 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	s8 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"time", ""})
+	_, err = UnifyAxisNames(s7, s8)
+	require.Error(t, err)
+}
+
+func TestRoundTrip_ExtractAndResolve(t *testing.T) {
+	// Extract bindings from concrete shape, then resolve template with those bindings.
+	template := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+	concrete := Make(dtypes.Float32, 16, 64, 768)
+
+	bindings, err := ExtractBindings(template, concrete)
+	require.NoError(t, err)
+
+	resolved := template.Resolve(bindings)
+	require.Equal(t, concrete.Dimensions, resolved.Dimensions)
+	require.False(t, resolved.HasDynamicDims())
+}

--- a/shapes/bindings_test.go
+++ b/shapes/bindings_test.go
@@ -24,7 +24,8 @@ func TestAxisBindings_Key(t *testing.T) {
 func TestResolve(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 	bindings := AxisBindings{"batch": 32}
-	resolved := s.Resolve(bindings)
+	resolved, err := s.Resolve(bindings)
+	require.NoError(t, err)
 
 	require.Equal(t, []int{32, 512}, resolved.Dimensions)
 	require.Equal(t, []string{"batch", ""}, resolved.AxisNames)
@@ -34,7 +35,8 @@ func TestResolve(t *testing.T) {
 func TestResolve_MultipleAxes(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
 	bindings := AxisBindings{"batch": 8, "seq_len": 256}
-	resolved := s.Resolve(bindings)
+	resolved, err := s.Resolve(bindings)
+	require.NoError(t, err)
 
 	require.Equal(t, []int{8, 256, 768}, resolved.Dimensions)
 }
@@ -42,19 +44,23 @@ func TestResolve_MultipleAxes(t *testing.T) {
 func TestResolve_StaticShape(t *testing.T) {
 	s := Make(dtypes.Float32, 32, 512)
 	// Resolve on static shape returns same shape (no-op).
-	resolved := s.Resolve(AxisBindings{"batch": 64})
+	resolved, err := s.Resolve(AxisBindings{"batch": 64})
+	require.NoError(t, err)
 	require.True(t, s.Equal(resolved))
 }
 
 func TestResolve_MissingBinding(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.Panics(t, func() { s.Resolve(AxisBindings{}) })
+	_, err := s.Resolve(AxisBindings{})
+	require.Error(t, err)
 }
 
 func TestResolve_NonPositiveBinding(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.Panics(t, func() { s.Resolve(AxisBindings{"batch": 0}) })
-	require.Panics(t, func() { s.Resolve(AxisBindings{"batch": -5}) })
+	_, err := s.Resolve(AxisBindings{"batch": 0})
+	require.Error(t, err)
+	_, err = s.Resolve(AxisBindings{"batch": -5})
+	require.Error(t, err)
 }
 
 func TestExtractBindings(t *testing.T) {
@@ -200,7 +206,8 @@ func TestRoundTrip_ExtractAndResolve(t *testing.T) {
 	bindings, err := ExtractBindings(template, concrete)
 	require.NoError(t, err)
 
-	resolved := template.Resolve(bindings)
+	resolved, err := template.Resolve(bindings)
+	require.NoError(t, err)
 	require.Equal(t, concrete.Dimensions, resolved.Dimensions)
 	require.False(t, resolved.IsDynamic())
 }

--- a/shapes/bindings_test.go
+++ b/shapes/bindings_test.go
@@ -28,7 +28,7 @@ func TestResolve(t *testing.T) {
 
 	require.Equal(t, []int{32, 512}, resolved.Dimensions)
 	require.Equal(t, []string{"batch", ""}, resolved.AxisNames)
-	require.False(t, resolved.HasDynamicDims())
+	require.False(t, resolved.IsDynamic())
 }
 
 func TestResolve_MultipleAxes(t *testing.T) {
@@ -202,5 +202,5 @@ func TestRoundTrip_ExtractAndResolve(t *testing.T) {
 
 	resolved := template.Resolve(bindings)
 	require.Equal(t, concrete.Dimensions, resolved.Dimensions)
-	require.False(t, resolved.HasDynamicDims())
+	require.False(t, resolved.IsDynamic())
 }

--- a/shapes/dynamic.go
+++ b/shapes/dynamic.go
@@ -1,0 +1,132 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package shapes
+
+import (
+	"slices"
+
+	"github.com/gomlx/compute/dtypes"
+	"github.com/pkg/errors"
+)
+
+// DynamicDim is the sentinel value used in Shape.Dimensions to indicate an axis whose
+// size is unknown at graph build time and will be resolved at execution time via AxisBindings.
+//
+// Note: this is the same numeric value as UncheckedAxis (-1), but used in a different context.
+// UncheckedAxis is used in assertion arguments (CheckDims, AssertDims) to mean "don't check this axis".
+// DynamicDim is used in Shape.Dimensions to mean "this axis has an unknown size".
+const DynamicDim = -1
+
+// MakeDynamic creates a Shape with named axes and optional dynamic dimensions.
+//
+// dimensions can contain DynamicDim (-1) for axes whose size is unknown at graph build time.
+// Dynamic axes must have a non-empty name in axisNames. Static axes (>= 0) may have names too.
+//
+// axisNames must have the same length as dimensions. Use "" for unnamed axes.
+//
+// Example:
+//
+//	shapes.MakeDynamic(dtypes.F32, []int{-1, 512}, []string{"batch", ""})
+//	// Creates shape (Float32)[batch=-1 512]
+func MakeDynamic(dtype dtypes.DType, dimensions []int, axisNames []string) Shape {
+	if len(dimensions) != len(axisNames) {
+		panic(errors.Errorf("shapes.MakeDynamic: len(dimensions)=%d must equal len(axisNames)=%d", len(dimensions), len(axisNames)))
+	}
+	for i, dim := range dimensions {
+		if dim == DynamicDim {
+			if axisNames[i] == "" {
+				panic(errors.Errorf("shapes.MakeDynamic: dynamic axis %d (dimension=-1) must have a non-empty axis name", i))
+			}
+		} else if dim < 0 {
+			panic(errors.Errorf("shapes.MakeDynamic: dimension %d has invalid value %d (must be >= 0 or DynamicDim)", i, dim))
+		}
+	}
+	return Shape{
+		DType:      dtype,
+		Dimensions: slices.Clone(dimensions),
+		AxisNames:  slices.Clone(axisNames),
+	}
+}
+
+// HasDynamicDims returns true if any dimension is dynamic (DynamicDim).
+func (s Shape) HasDynamicDims() bool {
+	for _, d := range s.Dimensions {
+		if d == DynamicDim {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDynamicDim returns true if the given axis has a dynamic dimension (DynamicDim).
+// axis supports negative indexing (e.g., -1 for the last axis).
+func (s Shape) IsDynamicDim(axis int) bool {
+	adjustedAxis := axis
+	if adjustedAxis < 0 {
+		adjustedAxis += s.Rank()
+	}
+	if adjustedAxis < 0 || adjustedAxis >= s.Rank() {
+		panic(errors.Errorf("Shape.IsDynamicDim(%d) out-of-bounds for rank %d (shape=%s)", axis, s.Rank(), s))
+	}
+	return s.Dimensions[adjustedAxis] == DynamicDim
+}
+
+// AxisName returns the name of the given axis, or "" if unnamed or if AxisNames is nil.
+// axis supports negative indexing.
+func (s Shape) AxisName(axis int) string {
+	if s.AxisNames == nil {
+		return ""
+	}
+	adjustedAxis := axis
+	if adjustedAxis < 0 {
+		adjustedAxis += s.Rank()
+	}
+	if adjustedAxis < 0 || adjustedAxis >= s.Rank() {
+		panic(errors.Errorf("Shape.AxisName(%d) out-of-bounds for rank %d (shape=%s)", axis, s.Rank(), s))
+	}
+	return s.AxisNames[adjustedAxis]
+}
+
+// WithAxisNames returns a copy of the shape with the given axis names set.
+// The number of names must equal the rank.
+func (s Shape) WithAxisNames(names ...string) Shape {
+	if len(names) != s.Rank() {
+		panic(errors.Errorf("Shape.WithAxisNames: len(names)=%d must equal rank=%d", len(names), s.Rank()))
+	}
+	s2 := s.Clone()
+	s2.AxisNames = slices.Clone(names)
+	return s2
+}
+
+// axisNamesEqual compares two axis name slices for equality.
+// nil is considered equal to a slice of all empty strings.
+func axisNamesEqual(a, b []string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	aLen := len(a)
+	bLen := len(b)
+	if a == nil {
+		aLen = bLen
+	}
+	if b == nil {
+		bLen = aLen
+	}
+	if aLen != bLen {
+		return false
+	}
+	for i := range aLen {
+		aName := ""
+		if a != nil {
+			aName = a[i]
+		}
+		bName := ""
+		if b != nil {
+			bName = b[i]
+		}
+		if aName != bName {
+			return false
+		}
+	}
+	return true
+}

--- a/shapes/dynamic.go
+++ b/shapes/dynamic.go
@@ -48,25 +48,20 @@ func MakeDynamic(dtype dtypes.DType, dimensions []int, axisNames []string) Shape
 	}
 }
 
-// HasDynamicDims returns true if any dimension is dynamic (DynamicDim).
-func (s Shape) HasDynamicDims() bool {
-	for _, d := range s.Dimensions {
-		if d == DynamicDim {
-			return true
-		}
-	}
-	return false
+// IsDynamic returns true if any dimension is dynamic (DynamicDim).
+func (s Shape) IsDynamic() bool {
+	return slices.Contains(s.Dimensions, DynamicDim)
 }
 
-// IsDynamicDim returns true if the given axis has a dynamic dimension (DynamicDim).
+// IsAxisDynamic returns true if the given axis has a dynamic dimension (DynamicDim).
 // axis supports negative indexing (e.g., -1 for the last axis).
-func (s Shape) IsDynamicDim(axis int) bool {
+func (s Shape) IsAxisDynamic(axis int) bool {
 	adjustedAxis := axis
 	if adjustedAxis < 0 {
 		adjustedAxis += s.Rank()
 	}
 	if adjustedAxis < 0 || adjustedAxis >= s.Rank() {
-		panic(errors.Errorf("Shape.IsDynamicDim(%d) out-of-bounds for rank %d (shape=%s)", axis, s.Rank(), s))
+		panic(errors.Errorf("Shape.IsAxisDynamic(%d) out-of-bounds for rank %d (shape=%s)", axis, s.Rank(), s))
 	}
 	return s.Dimensions[adjustedAxis] == DynamicDim
 }

--- a/shapes/dynamic.go
+++ b/shapes/dynamic.go
@@ -24,6 +24,9 @@ const DynamicDim = -1
 //
 // axisNames must have the same length as dimensions. Use "" for unnamed axes.
 //
+// Axis names starting with "=" or "#" are reserved for internal (backend implementation) use and shouldn't e
+// used by end users.
+//
 // Example:
 //
 //	shapes.MakeDynamic(dtypes.F32, []int{-1, 512}, []string{"batch", ""})

--- a/shapes/dynamic_test.go
+++ b/shapes/dynamic_test.go
@@ -5,87 +5,169 @@ package shapes
 import (
 	"bytes"
 	"encoding/gob"
+	"reflect"
 	"testing"
 
 	"github.com/gomlx/compute/dtypes"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMakeDynamic(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.Equal(t, dtypes.Float32, s.DType)
-	require.Equal(t, []int{-1, 512}, s.Dimensions)
-	require.Equal(t, []string{"batch", ""}, s.AxisNames)
-	require.Equal(t, 2, s.Rank())
+	if !reflect.DeepEqual(dtypes.Float32, s.DType) {
+		t.Fatalf("Expected %v, got %v", dtypes.Float32, s.DType)
+	}
+	if !reflect.DeepEqual([]int{-1, 512}, s.Dimensions) {
+		t.Fatalf("Expected %v, got %v", []int{-1, 512}, s.Dimensions)
+	}
+	if !reflect.DeepEqual([]string{"batch", ""}, s.AxisNames) {
+		t.Fatalf("Expected %v, got %v", []string{"batch", ""}, s.AxisNames)
+	}
+	if !reflect.DeepEqual(2, s.Rank()) {
+		t.Fatalf("Expected %v, got %v", 2, s.Rank())
+	}
 }
 
 func TestMakeDynamic_MultipleNamedAxes(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
-	require.Equal(t, []int{-1, -1, 768}, s.Dimensions)
-	require.Equal(t, []string{"batch", "seq_len", ""}, s.AxisNames)
+	if !reflect.DeepEqual([]int{-1, -1, 768}, s.Dimensions) {
+		t.Fatalf("Expected %v, got %v", []int{-1, -1, 768}, s.Dimensions)
+	}
+	if !reflect.DeepEqual([]string{"batch", "seq_len", ""}, s.AxisNames) {
+		t.Fatalf("Expected %v, got %v", []string{"batch", "seq_len", ""}, s.AxisNames)
+	}
 }
 
 func TestMakeDynamic_Panics(t *testing.T) {
 	// Mismatched lengths.
-	require.Panics(t, func() {
-		MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch"})
-	})
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() {
+			MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch"})
+		}()
+	}()
 
 	// Dynamic dim without name.
-	require.Panics(t, func() {
-		MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"", ""})
-	})
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() {
+			MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"", ""})
+		}()
+	}()
 
 	// Invalid negative dimension (not -1).
-	require.Panics(t, func() {
-		MakeDynamic(dtypes.Float32, []int{-2, 512}, []string{"batch", ""})
-	})
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() {
+			MakeDynamic(dtypes.Float32, []int{-2, 512}, []string{"batch", ""})
+		}()
+	}()
 }
 
 func TestHasDynamicDims(t *testing.T) {
 	static := Make(dtypes.Float32, 32, 512)
-	require.False(t, static.IsDynamic())
+	if static.IsDynamic() {
+		t.Fatalf("Condition expected to be false")
+	}
 
 	dynamic := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.True(t, dynamic.IsDynamic())
+	if !(dynamic.IsDynamic()) {
+		t.Fatalf("Condition expected to be true")
+	}
 }
 
 func TestIsDynamicDim(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.True(t, s.IsAxisDynamic(0))
-	require.False(t, s.IsAxisDynamic(1))
+	if !(s.IsAxisDynamic(0)) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if s.IsAxisDynamic(1) {
+		t.Fatalf("Condition expected to be false")
+	}
 
 	// Negative indexing.
-	require.False(t, s.IsAxisDynamic(-1))
-	require.True(t, s.IsAxisDynamic(-2))
+	if s.IsAxisDynamic(-1) {
+		t.Fatalf("Condition expected to be false")
+	}
+	if !(s.IsAxisDynamic(-2)) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	// Out of bounds.
-	require.Panics(t, func() { s.IsAxisDynamic(2) })
-	require.Panics(t, func() { s.IsAxisDynamic(-3) })
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() { s.IsAxisDynamic(2) }()
+	}()
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() { s.IsAxisDynamic(-3) }()
+	}()
 }
 
 func TestAxisName(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.Equal(t, "batch", s.AxisName(0))
-	require.Equal(t, "", s.AxisName(1))
-	require.Equal(t, "", s.AxisName(-1))
-	require.Equal(t, "batch", s.AxisName(-2))
+	if !reflect.DeepEqual("batch", s.AxisName(0)) {
+		t.Fatalf("Expected %v, got %v", "batch", s.AxisName(0))
+	}
+	if !reflect.DeepEqual("", s.AxisName(1)) {
+		t.Fatalf("Expected %v, got %v", "", s.AxisName(1))
+	}
+	if !reflect.DeepEqual("", s.AxisName(-1)) {
+		t.Fatalf("Expected %v, got %v", "", s.AxisName(-1))
+	}
+	if !reflect.DeepEqual("batch", s.AxisName(-2)) {
+		t.Fatalf("Expected %v, got %v", "batch", s.AxisName(-2))
+	}
 
 	// No axis names.
 	static := Make(dtypes.Float32, 32, 512)
-	require.Equal(t, "", static.AxisName(0))
-	require.Equal(t, "", static.AxisName(1))
+	if !reflect.DeepEqual("", static.AxisName(0)) {
+		t.Fatalf("Expected %v, got %v", "", static.AxisName(0))
+	}
+	if !reflect.DeepEqual("", static.AxisName(1)) {
+		t.Fatalf("Expected %v, got %v", "", static.AxisName(1))
+	}
 }
 
 func TestWithAxisNames(t *testing.T) {
 	s := Make(dtypes.Float32, 32, 512)
 	named := s.WithAxisNames("batch", "features")
-	require.Equal(t, []string{"batch", "features"}, named.AxisNames)
+	if !reflect.DeepEqual([]string{"batch", "features"}, named.AxisNames) {
+		t.Fatalf("Expected %v, got %v", []string{"batch", "features"}, named.AxisNames)
+	}
 	// Original unchanged.
-	require.Nil(t, s.AxisNames)
+	if s.AxisNames != nil {
+		t.Fatalf("Expected nil, got %v", s.AxisNames)
+	}
 
 	// Wrong number of names.
-	require.Panics(t, func() { s.WithAxisNames("batch") })
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() { s.WithAxisNames("batch") }()
+	}()
 }
 
 func TestShape_Equal_WithAxisNames(t *testing.T) {
@@ -94,16 +176,24 @@ func TestShape_Equal_WithAxisNames(t *testing.T) {
 	s3 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"time", ""})
 
 	// Same axis names → equal.
-	require.True(t, s1.Equal(s2))
+	if !(s1.Equal(s2)) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	// Different axis names → not equal.
-	require.False(t, s1.Equal(s3))
+	if s1.Equal(s3) {
+		t.Fatalf("Condition expected to be false")
+	}
 
 	// nil AxisNames equals all-empty AxisNames.
 	static := Make(dtypes.Float32, 32, 512)
 	staticNamed := Make(dtypes.Float32, 32, 512).WithAxisNames("", "")
-	require.True(t, static.Equal(staticNamed))
-	require.True(t, staticNamed.Equal(static))
+	if !(static.Equal(staticNamed)) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if !(staticNamed.Equal(static)) {
+		t.Fatalf("Condition expected to be true")
+	}
 }
 
 func TestShape_EqualDimensions_IgnoresAxisNames(t *testing.T) {
@@ -111,7 +201,9 @@ func TestShape_EqualDimensions_IgnoresAxisNames(t *testing.T) {
 	s2 := MakeDynamic(dtypes.Float64, []int{-1, 512}, []string{"time", ""})
 
 	// EqualDimensions ignores both DType and AxisNames.
-	require.True(t, s1.EqualDimensions(s2))
+	if !(s1.EqualDimensions(s2)) {
+		t.Fatalf("Condition expected to be true")
+	}
 }
 
 func TestShape_Clone_WithAxisNames(t *testing.T) {
@@ -119,46 +211,79 @@ func TestShape_Clone_WithAxisNames(t *testing.T) {
 	s2 := s.Clone()
 
 	// Equal.
-	require.True(t, s.Equal(s2))
+	if !(s.Equal(s2)) {
+		t.Fatalf("Condition expected to be true")
+	}
 
 	// Independent slices.
 	s2.AxisNames[0] = "modified"
-	require.Equal(t, "batch", s.AxisNames[0])
+	if !reflect.DeepEqual("batch", s.AxisNames[0]) {
+		t.Fatalf("Expected %v, got %v", "batch", s.AxisNames[0])
+	}
 }
 
 func TestShape_String_WithAxisNames(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 	str := s.String()
-	require.Equal(t, "(Float32)[batch=?, 512]", str)
+	if !reflect.DeepEqual("(Float32)[batch=?, 512]", str) {
+		t.Fatalf("Expected %v, got %v", "(Float32)[batch=?, 512]", str)
+	}
 
 	s2 := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
-	require.Equal(t, "(Float32)[batch=?, seq_len=?, 768]", s2.String())
+	if !reflect.DeepEqual("(Float32)[batch=?, seq_len=?, 768]", s2.String()) {
+		t.Fatalf("Expected %v, got %v", "(Float32)[batch=?, seq_len=?, 768]", s2.String())
+	}
 
 	// Named static axes.
 	s3 := Make(dtypes.Float32, 32, 512).WithAxisNames("batch", "features")
-	require.Equal(t, "(Float32)[batch=32, features=512]", s3.String())
+	if !reflect.DeepEqual("(Float32)[batch=32, features=512]", s3.String()) {
+		t.Fatalf("Expected %v, got %v", "(Float32)[batch=32, features=512]", s3.String())
+	}
 }
 
 func TestShape_Size_PanicsOnDynamic(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.Panics(t, func() { _ = s.Size() })
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() { _ = s.Size() }()
+	}()
 
 	// Static shapes still work.
 	static := Make(dtypes.Float32, 4, 3, 2)
-	require.Equal(t, 24, static.Size())
+	if !reflect.DeepEqual(24, static.Size()) {
+		t.Fatalf("Expected %v, got %v", 24, static.Size())
+	}
 }
 
 func TestShape_Strides_PanicsOnDynamic(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.Panics(t, func() { _ = s.Strides() })
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() { _ = s.Strides() }()
+	}()
 }
 
 func TestShape_Iter_PanicsOnDynamic(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.Panics(t, func() {
-		for range s.Iter() {
-		}
-	})
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("Expected panic")
+			}
+		}()
+		func() {
+			for range s.Iter() {
+			}
+		}()
+	}()
 }
 
 func TestGobSerialize_WithAxisNames(t *testing.T) {
@@ -167,13 +292,21 @@ func TestGobSerialize_WithAxisNames(t *testing.T) {
 	var buf bytes.Buffer
 	encoder := gob.NewEncoder(&buf)
 	err := original.GobSerialize(encoder)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 
 	decoder := gob.NewDecoder(&buf)
 	decoded, err := GobDeserialize(decoder)
-	require.NoError(t, err)
-	require.True(t, original.Equal(decoded))
-	require.Equal(t, original.AxisNames, decoded.AxisNames)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(original.Equal(decoded)) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if !reflect.DeepEqual(original.AxisNames, decoded.AxisNames) {
+		t.Fatalf("Expected %v, got %v", original.AxisNames, decoded.AxisNames)
+	}
 }
 
 func TestGobSerialize_WithoutAxisNames(t *testing.T) {
@@ -183,13 +316,21 @@ func TestGobSerialize_WithoutAxisNames(t *testing.T) {
 	var buf bytes.Buffer
 	encoder := gob.NewEncoder(&buf)
 	err := original.GobSerialize(encoder)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 
 	decoder := gob.NewDecoder(&buf)
 	decoded, err := GobDeserialize(decoder)
-	require.NoError(t, err)
-	require.True(t, original.Equal(decoded))
-	require.Nil(t, decoded.AxisNames)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !(original.Equal(decoded)) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if decoded.AxisNames != nil {
+		t.Fatalf("Expected nil, got %v", decoded.AxisNames)
+	}
 }
 
 func TestConcatenateDimensions_WithAxisNames(t *testing.T) {
@@ -197,29 +338,53 @@ func TestConcatenateDimensions_WithAxisNames(t *testing.T) {
 	s2 := Make(dtypes.Float32, 3, 4)
 
 	result := ConcatenateDimensions(s1, s2)
-	require.Equal(t, []int{-1, 512, 3, 4}, result.Dimensions)
-	require.Equal(t, []string{"batch", "", "", ""}, result.AxisNames)
+	if !reflect.DeepEqual([]int{-1, 512, 3, 4}, result.Dimensions) {
+		t.Fatalf("Expected %v, got %v", []int{-1, 512, 3, 4}, result.Dimensions)
+	}
+	if !reflect.DeepEqual([]string{"batch", "", "", ""}, result.AxisNames) {
+		t.Fatalf("Expected %v, got %v", []string{"batch", "", "", ""}, result.AxisNames)
+	}
 }
 
 func TestCheckDims_WithDynamic(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 
 	// Checking static dim works normally.
-	require.NoError(t, s.CheckDims(-1, 512)) // -1 in check args means unchecked
+	if s.CheckDims(-1, 512) != nil {
+		t.Fatalf("Expected no error, got %v", s.CheckDims(-1, 512))
+	} // -1 in check args means unchecked
 
 	// Checking dynamic dim against a concrete value fails (as expected, the dim is unknown).
-	require.Error(t, s.CheckDims(32, 512))
+	if s.CheckDims(32, 512) == nil {
+		t.Fatalf("Expected error, got nil")
+	}
 
 	// Checking dynamic dim with unchecked works.
-	require.NoError(t, s.CheckDims(-1, -1))
+	if s.CheckDims(-1, -1) != nil {
+		t.Fatalf("Expected no error, got %v", s.CheckDims(-1, -1))
+	}
 }
 
 func TestAxisNamesEqual(t *testing.T) {
-	require.True(t, axisNamesEqual(nil, nil))
-	require.True(t, axisNamesEqual(nil, []string{"", ""}))
-	require.True(t, axisNamesEqual([]string{"", ""}, nil))
-	require.True(t, axisNamesEqual([]string{"a", "b"}, []string{"a", "b"}))
-	require.False(t, axisNamesEqual([]string{"a", "b"}, []string{"a", "c"}))
-	require.False(t, axisNamesEqual(nil, []string{"a", ""}))
-	require.False(t, axisNamesEqual([]string{"a"}, []string{"a", "b"}))
+	if !(axisNamesEqual(nil, nil)) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if !(axisNamesEqual(nil, []string{"", ""})) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if !(axisNamesEqual([]string{"", ""}, nil)) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if !(axisNamesEqual([]string{"a", "b"}, []string{"a", "b"})) {
+		t.Fatalf("Condition expected to be true")
+	}
+	if axisNamesEqual([]string{"a", "b"}, []string{"a", "c"}) {
+		t.Fatalf("Condition expected to be false")
+	}
+	if axisNamesEqual(nil, []string{"a", ""}) {
+		t.Fatalf("Condition expected to be false")
+	}
+	if axisNamesEqual([]string{"a"}, []string{"a", "b"}) {
+		t.Fatalf("Condition expected to be false")
+	}
 }

--- a/shapes/dynamic_test.go
+++ b/shapes/dynamic_test.go
@@ -44,24 +44,24 @@ func TestMakeDynamic_Panics(t *testing.T) {
 
 func TestHasDynamicDims(t *testing.T) {
 	static := Make(dtypes.Float32, 32, 512)
-	require.False(t, static.HasDynamicDims())
+	require.False(t, static.IsDynamic())
 
 	dynamic := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.True(t, dynamic.HasDynamicDims())
+	require.True(t, dynamic.IsDynamic())
 }
 
 func TestIsDynamicDim(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
-	require.True(t, s.IsDynamicDim(0))
-	require.False(t, s.IsDynamicDim(1))
+	require.True(t, s.IsAxisDynamic(0))
+	require.False(t, s.IsAxisDynamic(1))
 
 	// Negative indexing.
-	require.False(t, s.IsDynamicDim(-1))
-	require.True(t, s.IsDynamicDim(-2))
+	require.False(t, s.IsAxisDynamic(-1))
+	require.True(t, s.IsAxisDynamic(-2))
 
 	// Out of bounds.
-	require.Panics(t, func() { s.IsDynamicDim(2) })
-	require.Panics(t, func() { s.IsDynamicDim(-3) })
+	require.Panics(t, func() { s.IsAxisDynamic(2) })
+	require.Panics(t, func() { s.IsAxisDynamic(-3) })
 }
 
 func TestAxisName(t *testing.T) {
@@ -129,14 +129,14 @@ func TestShape_Clone_WithAxisNames(t *testing.T) {
 func TestShape_String_WithAxisNames(t *testing.T) {
 	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
 	str := s.String()
-	require.Equal(t, "(Float32)[batch=-1 512]", str)
+	require.Equal(t, "(Float32)[batch=?, 512]", str)
 
 	s2 := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
-	require.Equal(t, "(Float32)[batch=-1 seq_len=-1 768]", s2.String())
+	require.Equal(t, "(Float32)[batch=?, seq_len=?, 768]", s2.String())
 
 	// Named static axes.
 	s3 := Make(dtypes.Float32, 32, 512).WithAxisNames("batch", "features")
-	require.Equal(t, "(Float32)[batch=32 features=512]", s3.String())
+	require.Equal(t, "(Float32)[batch=32, features=512]", s3.String())
 }
 
 func TestShape_Size_PanicsOnDynamic(t *testing.T) {

--- a/shapes/dynamic_test.go
+++ b/shapes/dynamic_test.go
@@ -1,0 +1,225 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package shapes
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+
+	"github.com/gomlx/compute/dtypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeDynamic(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.Equal(t, dtypes.Float32, s.DType)
+	require.Equal(t, []int{-1, 512}, s.Dimensions)
+	require.Equal(t, []string{"batch", ""}, s.AxisNames)
+	require.Equal(t, 2, s.Rank())
+}
+
+func TestMakeDynamic_MultipleNamedAxes(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+	require.Equal(t, []int{-1, -1, 768}, s.Dimensions)
+	require.Equal(t, []string{"batch", "seq_len", ""}, s.AxisNames)
+}
+
+func TestMakeDynamic_Panics(t *testing.T) {
+	// Mismatched lengths.
+	require.Panics(t, func() {
+		MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch"})
+	})
+
+	// Dynamic dim without name.
+	require.Panics(t, func() {
+		MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"", ""})
+	})
+
+	// Invalid negative dimension (not -1).
+	require.Panics(t, func() {
+		MakeDynamic(dtypes.Float32, []int{-2, 512}, []string{"batch", ""})
+	})
+}
+
+func TestHasDynamicDims(t *testing.T) {
+	static := Make(dtypes.Float32, 32, 512)
+	require.False(t, static.HasDynamicDims())
+
+	dynamic := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.True(t, dynamic.HasDynamicDims())
+}
+
+func TestIsDynamicDim(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.True(t, s.IsDynamicDim(0))
+	require.False(t, s.IsDynamicDim(1))
+
+	// Negative indexing.
+	require.False(t, s.IsDynamicDim(-1))
+	require.True(t, s.IsDynamicDim(-2))
+
+	// Out of bounds.
+	require.Panics(t, func() { s.IsDynamicDim(2) })
+	require.Panics(t, func() { s.IsDynamicDim(-3) })
+}
+
+func TestAxisName(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.Equal(t, "batch", s.AxisName(0))
+	require.Equal(t, "", s.AxisName(1))
+	require.Equal(t, "", s.AxisName(-1))
+	require.Equal(t, "batch", s.AxisName(-2))
+
+	// No axis names.
+	static := Make(dtypes.Float32, 32, 512)
+	require.Equal(t, "", static.AxisName(0))
+	require.Equal(t, "", static.AxisName(1))
+}
+
+func TestWithAxisNames(t *testing.T) {
+	s := Make(dtypes.Float32, 32, 512)
+	named := s.WithAxisNames("batch", "features")
+	require.Equal(t, []string{"batch", "features"}, named.AxisNames)
+	// Original unchanged.
+	require.Nil(t, s.AxisNames)
+
+	// Wrong number of names.
+	require.Panics(t, func() { s.WithAxisNames("batch") })
+}
+
+func TestShape_Equal_WithAxisNames(t *testing.T) {
+	s1 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	s2 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	s3 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"time", ""})
+
+	// Same axis names → equal.
+	require.True(t, s1.Equal(s2))
+
+	// Different axis names → not equal.
+	require.False(t, s1.Equal(s3))
+
+	// nil AxisNames equals all-empty AxisNames.
+	static := Make(dtypes.Float32, 32, 512)
+	staticNamed := Make(dtypes.Float32, 32, 512).WithAxisNames("", "")
+	require.True(t, static.Equal(staticNamed))
+	require.True(t, staticNamed.Equal(static))
+}
+
+func TestShape_EqualDimensions_IgnoresAxisNames(t *testing.T) {
+	s1 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	s2 := MakeDynamic(dtypes.Float64, []int{-1, 512}, []string{"time", ""})
+
+	// EqualDimensions ignores both DType and AxisNames.
+	require.True(t, s1.EqualDimensions(s2))
+}
+
+func TestShape_Clone_WithAxisNames(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	s2 := s.Clone()
+
+	// Equal.
+	require.True(t, s.Equal(s2))
+
+	// Independent slices.
+	s2.AxisNames[0] = "modified"
+	require.Equal(t, "batch", s.AxisNames[0])
+}
+
+func TestShape_String_WithAxisNames(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	str := s.String()
+	require.Equal(t, "(Float32)[batch=-1 512]", str)
+
+	s2 := MakeDynamic(dtypes.Float32, []int{-1, -1, 768}, []string{"batch", "seq_len", ""})
+	require.Equal(t, "(Float32)[batch=-1 seq_len=-1 768]", s2.String())
+
+	// Named static axes.
+	s3 := Make(dtypes.Float32, 32, 512).WithAxisNames("batch", "features")
+	require.Equal(t, "(Float32)[batch=32 features=512]", s3.String())
+}
+
+func TestShape_Size_PanicsOnDynamic(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.Panics(t, func() { _ = s.Size() })
+
+	// Static shapes still work.
+	static := Make(dtypes.Float32, 4, 3, 2)
+	require.Equal(t, 24, static.Size())
+}
+
+func TestShape_Strides_PanicsOnDynamic(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.Panics(t, func() { _ = s.Strides() })
+}
+
+func TestShape_Iter_PanicsOnDynamic(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	require.Panics(t, func() {
+		for range s.Iter() {
+		}
+	})
+}
+
+func TestGobSerialize_WithAxisNames(t *testing.T) {
+	original := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+
+	var buf bytes.Buffer
+	encoder := gob.NewEncoder(&buf)
+	err := original.GobSerialize(encoder)
+	require.NoError(t, err)
+
+	decoder := gob.NewDecoder(&buf)
+	decoded, err := GobDeserialize(decoder)
+	require.NoError(t, err)
+	require.True(t, original.Equal(decoded))
+	require.Equal(t, original.AxisNames, decoded.AxisNames)
+}
+
+func TestGobSerialize_WithoutAxisNames(t *testing.T) {
+	// Static shapes (no axis names) round-trip correctly.
+	original := Make(dtypes.Float32, 4, 3, 2)
+
+	var buf bytes.Buffer
+	encoder := gob.NewEncoder(&buf)
+	err := original.GobSerialize(encoder)
+	require.NoError(t, err)
+
+	decoder := gob.NewDecoder(&buf)
+	decoded, err := GobDeserialize(decoder)
+	require.NoError(t, err)
+	require.True(t, original.Equal(decoded))
+	require.Nil(t, decoded.AxisNames)
+}
+
+func TestConcatenateDimensions_WithAxisNames(t *testing.T) {
+	s1 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+	s2 := Make(dtypes.Float32, 3, 4)
+
+	result := ConcatenateDimensions(s1, s2)
+	require.Equal(t, []int{-1, 512, 3, 4}, result.Dimensions)
+	require.Equal(t, []string{"batch", "", "", ""}, result.AxisNames)
+}
+
+func TestCheckDims_WithDynamic(t *testing.T) {
+	s := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{"batch", ""})
+
+	// Checking static dim works normally.
+	require.NoError(t, s.CheckDims(-1, 512)) // -1 in check args means unchecked
+
+	// Checking dynamic dim against a concrete value fails (as expected, the dim is unknown).
+	require.Error(t, s.CheckDims(32, 512))
+
+	// Checking dynamic dim with unchecked works.
+	require.NoError(t, s.CheckDims(-1, -1))
+}
+
+func TestAxisNamesEqual(t *testing.T) {
+	require.True(t, axisNamesEqual(nil, nil))
+	require.True(t, axisNamesEqual(nil, []string{"", ""}))
+	require.True(t, axisNamesEqual([]string{"", ""}, nil))
+	require.True(t, axisNamesEqual([]string{"a", "b"}, []string{"a", "b"}))
+	require.False(t, axisNamesEqual([]string{"a", "b"}, []string{"a", "c"}))
+	require.False(t, axisNamesEqual(nil, []string{"a", ""}))
+	require.False(t, axisNamesEqual([]string{"a"}, []string{"a", "b"}))
+}

--- a/shapes/iter.go
+++ b/shapes/iter.go
@@ -13,10 +13,15 @@ import (
 // in memory, the one used everywhere in GoMLX.
 //
 // Notice the strides are **not in bytes**, but in indices.
+//
+// Panics if any dimension is dynamic (DynamicDim).
 func (s Shape) Strides() (strides []int) {
 	rank := s.Rank()
 	if rank == 0 {
 		return
+	}
+	if s.HasDynamicDims() {
+		panic(errors.Errorf("Shape.Strides() called on shape with dynamic dimensions: %s", s))
 	}
 	strides = make([]int, rank)
 	if s.IsZeroSize() {
@@ -35,9 +40,14 @@ func (s Shape) Strides() (strides []int) {
 //
 // It yields the flat index (counter) and a slice of indices for each axis.
 //
+// Panics if any dimension is dynamic (DynamicDim).
+//
 // To avoid allocating the slice of indices, the yielded indices is owned by the Iter() method:
 // don't change it inside the loop.
 func (s Shape) Iter() iter.Seq2[int, []int] {
+	if s.HasDynamicDims() {
+		panic(errors.Errorf("Shape.Iter() called on shape with dynamic dimensions: %s", s))
+	}
 	indices := make([]int, s.Rank())
 	return s.IterOn(indices)
 }
@@ -46,11 +56,16 @@ func (s Shape) Iter() iter.Seq2[int, []int] {
 //
 // It yields the flat index (counter) and a slice of indices for each axis.
 //
+// Panics if any dimension is dynamic (DynamicDim).
+//
 // The iteration updates the indices on the given indices slice.
 // During the iteration the caller shouldn't modify the slice of indices, otherwise it will lead to undefined behavior.
 //
 // It expects len(indices) == s.Rank(). It will panic otherwise.
 func (s Shape) IterOn(indices []int) iter.Seq2[int, []int] {
+	if s.HasDynamicDims() {
+		panic(errors.Errorf("Shape.IterOn() called on shape with dynamic dimensions: %s", s))
+	}
 	if len(indices) != s.Rank() {
 		panic(errors.Errorf("Shape.IterOn given len(indices) == %d, want it to be equal to the rank %d", len(indices), s.Rank()))
 	}
@@ -166,6 +181,8 @@ func (s Shape) IterOn(indices []int) iter.Seq2[int, []int] {
 // It yields the flat index and the update indices for all axes of the shape (not only the one in axes).
 // The indices not pointed by axesToIterate are not touched.
 //
+// Panics if any dimension is dynamic (DynamicDim).
+//
 // Args:
 //   - axesToIterate: axes of the shape to iterate over. They must be 0 <= axis < rank.
 //     Axes not included here are not touched in the indices.
@@ -194,6 +211,9 @@ func (s Shape) IterOn(indices []int) iter.Seq2[int, []int] {
 //	    fmt.Printf("flatIdx=%d, indices=%v\n", flatIdx, indices)
 //	}
 func (s Shape) IterOnAxes(axesToIterate, strides, indices []int) iter.Seq2[int, []int] {
+	if s.HasDynamicDims() {
+		panic(errors.Errorf("Shape.IterOnAxes() called on shape with dynamic dimensions: %s", s))
+	}
 	rank := s.Rank()
 
 	// Validate and initialize strides
@@ -246,7 +266,7 @@ func (s Shape) IterOnAxes(axesToIterate, strides, indices []int) iter.Seq2[int, 
 			}
 
 			// Increment indices to the next set of coordinates
-			// (row-major order: the last axis changes fastest).
+			// (row-major order: the last index changes fastest).
 			for axisIdx := len(axesToIterate) - 1; axisIdx >= 0; axisIdx-- {
 				axis := axesToIterate[axisIdx]
 				indices[axis]++

--- a/shapes/iter.go
+++ b/shapes/iter.go
@@ -20,7 +20,7 @@ func (s Shape) Strides() (strides []int) {
 	if rank == 0 {
 		return
 	}
-	if s.HasDynamicDims() {
+	if s.IsDynamic() {
 		panic(errors.Errorf("Shape.Strides() called on shape with dynamic dimensions: %s", s))
 	}
 	strides = make([]int, rank)
@@ -45,7 +45,7 @@ func (s Shape) Strides() (strides []int) {
 // To avoid allocating the slice of indices, the yielded indices is owned by the Iter() method:
 // don't change it inside the loop.
 func (s Shape) Iter() iter.Seq2[int, []int] {
-	if s.HasDynamicDims() {
+	if s.IsDynamic() {
 		panic(errors.Errorf("Shape.Iter() called on shape with dynamic dimensions: %s", s))
 	}
 	indices := make([]int, s.Rank())
@@ -63,7 +63,7 @@ func (s Shape) Iter() iter.Seq2[int, []int] {
 //
 // It expects len(indices) == s.Rank(). It will panic otherwise.
 func (s Shape) IterOn(indices []int) iter.Seq2[int, []int] {
-	if s.HasDynamicDims() {
+	if s.IsDynamic() {
 		panic(errors.Errorf("Shape.IterOn() called on shape with dynamic dimensions: %s", s))
 	}
 	if len(indices) != s.Rank() {
@@ -211,7 +211,7 @@ func (s Shape) IterOn(indices []int) iter.Seq2[int, []int] {
 //	    fmt.Printf("flatIdx=%d, indices=%v\n", flatIdx, indices)
 //	}
 func (s Shape) IterOnAxes(axesToIterate, strides, indices []int) iter.Seq2[int, []int] {
-	if s.HasDynamicDims() {
+	if s.IsDynamic() {
 		panic(errors.Errorf("Shape.IterOnAxes() called on shape with dynamic dimensions: %s", s))
 	}
 	rank := s.Rank()

--- a/shapes/iter.go
+++ b/shapes/iter.go
@@ -14,14 +14,11 @@ import (
 //
 // Notice the strides are **not in bytes**, but in indices.
 //
-// Panics if any dimension is dynamic (DynamicDim).
+// It panics if any dimension is dynamic (DynamicDim), see Shape.IsDynamic.
 func (s Shape) Strides() (strides []int) {
 	rank := s.Rank()
 	if rank == 0 {
 		return
-	}
-	if s.IsDynamic() {
-		panic(errors.Errorf("Shape.Strides() called on shape with dynamic dimensions: %s", s))
 	}
 	strides = make([]int, rank)
 	if s.IsZeroSize() {
@@ -29,9 +26,24 @@ func (s Shape) Strides() (strides []int) {
 		return
 	}
 	currentStride := 1
-	for dim := rank - 1; dim >= 0; dim-- {
-		strides[dim] = currentStride
-		currentStride *= s.Dimensions[dim]
+	for axis := rank - 1; axis >= 0; axis-- {
+		strides[axis] = currentStride
+		dim := s.Dimensions[axis]
+		if dim <= 0 {
+			switch dim {
+			case DynamicDim:
+				panic(errors.Errorf("Shape.Strides() called on shape with dynamic dimensions: %s", s))
+			case 0:
+				for i := range strides {
+					strides[i] = 0
+				}
+				return strides
+			default:
+				panic(errors.Errorf("Shape.Strides() called on shape with invalid negative dimension %d at axis %d: %s",
+					dim, axis, s))
+			}
+		}
+		currentStride *= dim
 	}
 	return
 }

--- a/shapes/shapes.go
+++ b/shapes/shapes.go
@@ -73,7 +73,14 @@ type Shape struct {
 	DType dtypes.DType
 
 	// Dimensions is the size of each axis. Its length determines the rank.
+	// A value of DynamicDim (-1) indicates a dynamic axis whose size is unknown at graph build time.
 	Dimensions []int
+
+	// AxisNames holds optional names for each axis. nil means no axis names (the default).
+	// When non-nil, len(AxisNames) must equal len(Dimensions).
+	// An empty string "" means the axis is unnamed. A non-empty string names the axis.
+	AxisNames []string `json:"axis_names,omitempty"`
+
 	// TupleShapes is used if this Shape represents a tuple of elements.
 	// Internal use only.
 	TupleShapes []Shape `json:"tuple,omitempty"` // Shapes of the tuple, if this is a tuple.
@@ -141,6 +148,18 @@ func (s Shape) String() string {
 	if s.Rank() == 0 {
 		return fmt.Sprintf("(%s)", s.DType)
 	}
+	if s.AxisNames != nil {
+		parts := make([]string, s.Rank())
+		for i, dim := range s.Dimensions {
+			name := s.AxisNames[i]
+			if name != "" {
+				parts[i] = fmt.Sprintf("%s=%d", name, dim)
+			} else {
+				parts[i] = fmt.Sprintf("%d", dim)
+			}
+		}
+		return fmt.Sprintf("(%s)[%s]", s.DType, strings.Join(parts, " "))
+	}
 	return fmt.Sprintf("(%s)%v", s.DType, s.Dimensions)
 }
 
@@ -150,6 +169,9 @@ func (s Shape) String() string {
 func (s Shape) Size() (size int) {
 	size = 1
 	for _, d := range s.Dimensions {
+		if d == DynamicDim {
+			panic(errors.Errorf("Shape.Size() called on shape with dynamic dimensions: %s", s))
+		}
 		size *= d
 	}
 	return
@@ -213,8 +235,12 @@ func (s Shape) Equal(s2 Shape) bool {
 	if s.IsScalar() {
 		return true
 	}
-	// For normal shapes just compare dimensions.
-	return slices.Equal(s.Dimensions, s2.Dimensions)
+	// Compare dimensions.
+	if !slices.Equal(s.Dimensions, s2.Dimensions) {
+		return false
+	}
+	// Compare axis names.
+	return axisNamesEqual(s.AxisNames, s2.AxisNames)
 }
 
 // EqualDimensions compares two shapes for equality of dimensions. Dtypes can be different.
@@ -247,6 +273,7 @@ func (s Shape) EqualDimensions(s2 Shape) bool {
 func (s Shape) Clone() (s2 Shape) {
 	s2.DType = s.DType
 	s2.Dimensions = slices.Clone(s.Dimensions)
+	s2.AxisNames = slices.Clone(s.AxisNames)
 	if s.TupleSize() > 0 {
 		s2.TupleShapes = make([]Shape, 0, len(s.TupleShapes))
 		for _, subShape := range s.TupleShapes {
@@ -256,7 +283,19 @@ func (s Shape) Clone() (s2 Shape) {
 	return
 }
 
+// gobFormatV1 is a marker value used to distinguish the new gob format (with AxisNames)
+// from the old format (without). In the old format, this position held numTuples (>= 0).
+const gobFormatV1 = -1
+
 // GobSerialize shape in binary format.
+//
+// Format v1 (current): DType, Dimensions, -1 (version marker), hasAxisNames (bool),
+// [AxisNames if hasAxisNames], numTuples, [sub-shapes...].
+//
+// Old format: DType, Dimensions, numTuples, [sub-shapes...].
+// GobDeserialize handles both formats for backward compatibility (old data → new code).
+// Note: new-format data cannot be read by old code (the -1 marker would be interpreted
+// as numTuples, causing a panic). This is forward-compatible only.
 func (s Shape) GobSerialize(encoder *gob.Encoder) (err error) {
 	enc := func(e any) {
 		if err != nil {
@@ -269,6 +308,12 @@ func (s Shape) GobSerialize(encoder *gob.Encoder) (err error) {
 	}
 	enc(s.DType)
 	enc(s.Dimensions)
+	enc(gobFormatV1)
+	hasAxisNames := s.AxisNames != nil
+	enc(hasAxisNames)
+	if hasAxisNames {
+		enc(s.AxisNames)
+	}
 	enc(len(s.TupleShapes))
 	if err != nil {
 		return
@@ -283,6 +328,7 @@ func (s Shape) GobSerialize(encoder *gob.Encoder) (err error) {
 }
 
 // GobDeserialize a Shape. Returns new Shape or an error.
+// Handles both the old format (without AxisNames) and the v1 format (with AxisNames).
 func GobDeserialize(decoder *gob.Decoder) (s Shape, err error) {
 	dec := func(data any) {
 		if err != nil {
@@ -295,8 +341,27 @@ func GobDeserialize(decoder *gob.Decoder) (s Shape, err error) {
 	}
 	dec(&s.DType)
 	dec(&s.Dimensions)
+
+	// Read version marker or numTuples (for backward compat).
+	// Old format: this int is numTuples (>= 0).
+	// New format (v1): this int is -1, followed by hasAxisNames, [axisNames], numTuples.
+	var marker int
+	dec(&marker)
+
 	var numTuples int
-	dec(&numTuples)
+	if marker == gobFormatV1 {
+		// New format: read axis names, then numTuples.
+		var hasAxisNames bool
+		dec(&hasAxisNames)
+		if hasAxisNames {
+			dec(&s.AxisNames)
+		}
+		dec(&numTuples)
+	} else {
+		// Old format: marker is numTuples directly.
+		numTuples = marker
+	}
+
 	if err != nil {
 		return
 	}
@@ -332,6 +397,15 @@ func ConcatenateDimensions(s1, s2 Shape) (shape Shape) {
 	shape.Dimensions = make([]int, s1.Rank()+s2.Rank())
 	copy(shape.Dimensions, s1.Dimensions)
 	copy(shape.Dimensions[s1.Rank():], s2.Dimensions)
+	if s1.AxisNames != nil || s2.AxisNames != nil {
+		shape.AxisNames = make([]string, s1.Rank()+s2.Rank())
+		if s1.AxisNames != nil {
+			copy(shape.AxisNames, s1.AxisNames)
+		}
+		if s2.AxisNames != nil {
+			copy(shape.AxisNames[s1.Rank():], s2.AxisNames)
+		}
+	}
 	return
 }
 

--- a/shapes/shapes.go
+++ b/shapes/shapes.go
@@ -87,12 +87,16 @@ type Shape struct {
 }
 
 // Make returns a Shape structure filled with the values given.
+//
+// See MakeDynamic for shapes with dynamic and/or named axes.
 // See MakeTuple for tuple shapes.
 func Make(dtype dtypes.DType, dimensions ...int) Shape {
 	s := Shape{Dimensions: slices.Clone(dimensions), DType: dtype}
 	for _, dim := range dimensions {
 		if dim < 0 {
-			panic(errors.Errorf("shapes.Make(%s): cannot create a shape with an axis with dimension < 0", s))
+			panic(errors.Errorf(
+				"shapes.Make(%s): cannot create a shape with an axis with dimension < 0 "+
+					"-- see MakeDynamic to create dynamic shapes", s))
 		}
 	}
 	return s
@@ -148,24 +152,28 @@ func (s Shape) String() string {
 	if s.Rank() == 0 {
 		return fmt.Sprintf("(%s)", s.DType)
 	}
-	if s.AxisNames != nil {
-		parts := make([]string, s.Rank())
-		for i, dim := range s.Dimensions {
+	parts := make([]string, s.Rank())
+	for i, dim := range s.Dimensions {
+		if dim == DynamicDim {
+			parts[i] = "?"
+		} else {
+			parts[i] = fmt.Sprintf("%d", dim)
+		}
+		if len(s.AxisNames) > i {
 			name := s.AxisNames[i]
 			if name != "" {
-				parts[i] = fmt.Sprintf("%s=%d", name, dim)
-			} else {
-				parts[i] = fmt.Sprintf("%d", dim)
+				parts[i] = fmt.Sprintf("%s=%s", name, parts[i])
 			}
 		}
-		return fmt.Sprintf("(%s)[%s]", s.DType, strings.Join(parts, " "))
 	}
-	return fmt.Sprintf("(%s)%v", s.DType, s.Dimensions)
+	return fmt.Sprintf("(%s)[%s]", s.DType, strings.Join(parts, ", "))
 }
 
 // Size returns the number of elements (not bytes) for this shape. It's the product of all dimensions.
 //
-// For the number of bytes used to store this shape, see Shape.Memory.
+// It panics if s.IsDynamic().
+//
+// For the number of bytes used to store this shape, see Shape.ByteSize.
 func (s Shape) Size() (size int) {
 	size = 1
 	for _, d := range s.Dimensions {
@@ -183,7 +191,6 @@ func (s Shape) Size() (size int) {
 // Notice scalars are not zero in size -- they have size one, but rank zero.
 func (s Shape) IsZeroSize() bool {
 	return slices.Contains(s.Dimensions, 0)
-
 }
 
 // ByteSize returns the number of bytes used to store an array of the given shape.
@@ -243,7 +250,9 @@ func (s Shape) Equal(s2 Shape) bool {
 	return axisNamesEqual(s.AxisNames, s2.AxisNames)
 }
 
-// EqualDimensions compares two shapes for equality of dimensions. Dtypes can be different.
+// EqualDimensions compares two shapes for equality of dimensions.
+//
+// DType and axis names are ignored.
 func (s Shape) EqualDimensions(s2 Shape) bool {
 	if s.IsTuple() {
 		if !s2.IsTuple() {
@@ -284,7 +293,9 @@ func (s Shape) Clone() (s2 Shape) {
 }
 
 // gobFormatV1 is a marker value used to distinguish the new gob format (with AxisNames)
-// from the old format (without). In the old format, this position held numTuples (>= 0).
+// from the old format (without).
+//
+// In the old format, the corresponding gob-encoded position held numTuples (>= 0).
 const gobFormatV1 = -1
 
 // GobSerialize shape in binary format.
@@ -308,12 +319,18 @@ func (s Shape) GobSerialize(encoder *gob.Encoder) (err error) {
 	}
 	enc(s.DType)
 	enc(s.Dimensions)
+
+	// Encode the format version: currently gobFormatV1.
 	enc(gobFormatV1)
+
+	// Encode the axis names.
 	hasAxisNames := s.AxisNames != nil
 	enc(hasAxisNames)
 	if hasAxisNames {
 		enc(s.AxisNames)
 	}
+
+	// Encode the tuple shapes.
 	enc(len(s.TupleShapes))
 	if err != nil {
 		return
@@ -328,7 +345,7 @@ func (s Shape) GobSerialize(encoder *gob.Encoder) (err error) {
 }
 
 // GobDeserialize a Shape. Returns new Shape or an error.
-// Handles both the old format (without AxisNames) and the v1 format (with AxisNames).
+// Handles both the old format (without a format version) and the v1 format (with AxisNames).
 func GobDeserialize(decoder *gob.Decoder) (s Shape, err error) {
 	dec := func(data any) {
 		if err != nil {
@@ -342,14 +359,16 @@ func GobDeserialize(decoder *gob.Decoder) (s Shape, err error) {
 	dec(&s.DType)
 	dec(&s.Dimensions)
 
-	// Read version marker or numTuples (for backward compat).
+	// Read version version or numTuples (for backward compat).
 	// Old format: this int is numTuples (>= 0).
 	// New format (v1): this int is -1, followed by hasAxisNames, [axisNames], numTuples.
-	var marker int
-	dec(&marker)
+	var version int
+	dec(&version)
 
 	var numTuples int
-	if marker == gobFormatV1 {
+
+	switch {
+	case version == gobFormatV1:
 		// New format: read axis names, then numTuples.
 		var hasAxisNames bool
 		dec(&hasAxisNames)
@@ -357,9 +376,13 @@ func GobDeserialize(decoder *gob.Decoder) (s Shape, err error) {
 			dec(&s.AxisNames)
 		}
 		dec(&numTuples)
-	} else {
-		// Old format: marker is numTuples directly.
-		numTuples = marker
+
+	case version >= 0:
+		// Old vormat, where instead of version we have numTuples.
+		numTuples = version
+
+	default:
+		err = errors.Errorf("unknown Shape format version %d !? (maybe input came from a newer GoMLX version?)", version)
 	}
 
 	if err != nil {

--- a/shapes/shapes.go
+++ b/shapes/shapes.go
@@ -11,8 +11,11 @@
 // Any dynamic dimension must be named (it must have a non-empty AxisName), so their values can be
 // inferred when needed (see AxisBindings).
 //
-// Go float16 and bfloat16 support uses the simple implementations in [github.com/gomlx/compute/dtypes/float16]
-// and [github.com/gomlx/compute/dtypes/bfloat16].
+// ## Immutable Semantics
+//
+// The Shape object should be immutable semantic after creation: function that need to mutate shapes
+// should clone first (see Shape.Clone), mutate, and return the updated (and henceforward immutable) shape.
+// It's ok to simply copy shapes (shallow copy) if they are not meant to be mutated.
 //
 // ## Glossary
 //

--- a/shapes/shapes.go
+++ b/shapes/shapes.go
@@ -42,6 +42,11 @@
 //     and axes names. Dynamic axes must have an associated name, while concrete axes are usually unnamed ("").
 //   - MakeTuple(shapes...): internal use, create a shape that represents a tuple of shapes. Internal use, and subject
 //     to change.
+//
+// # Iterators and Strides
+//
+// Shapes support several iteration facilities.
+// See [Shape.Iter], [Shape.IterOn], [Shape.IterOnAxes] and [Shape.Strides].
 package shapes
 
 import (

--- a/shapes/shapes.go
+++ b/shapes/shapes.go
@@ -2,11 +2,14 @@
 
 // Package shapes define Shape and DType and associated tools.
 //
-// Shape represents the shape (rank, dimensions, and DType) of either a Tensor or the expected
-// shape of a node in a computation Graph. DType indicates the data type for a Tensor's unit element.
+// Shape represents the shape (rank, dimensions for each axis, and DType) of either a Tensor or the expected
+// shape of a node in a computation graph. DType indicates the data type for a Tensor's unit element.
 //
-// Shape and DType are used both by the concrete tensor values (see pkg/core/tensors package) and when
-// working on the symbolic computation graph (see pkg/core/graph package).
+// Optionally, the shape can also carry axes names.
+//
+// It also supports "dynamic shapes", where one or more axis has an undefined (DynamicDim == -1) dimension.
+// Any dynamic dimension must be named (it must have a non-empty AxisName), so their values can be
+// inferred when needed (see AxisBindings).
 //
 // Go float16 and bfloat16 support uses the simple implementations in [github.com/gomlx/compute/dtypes/float16]
 // and [github.com/gomlx/compute/dtypes/bfloat16].
@@ -14,43 +17,28 @@
 // ## Glossary
 //
 //   - Rank: number of axes (dimensions) of a Tensor.
-//   - Axis: is the index of a dimension on a multidimensional Tensor. Sometimes used
+//   - Axis: is the index of a dimension on a multidimensional array (tensor). Sometimes used
 //     interchangeably with Dimension, but here we try to refer to a dimension index as "axis"
-//     (plural axes), and its size as its dimension.
+//     (plural axes), and its size as its dimension. An axis may also have an associated name.
 //   - Dimension: the size of a multi-dimension Tensor in one of its axes. See the example below.
+//   - DynamicDim (-1): special dimension value that indicates the axis is dynamic (unknown at graph building
+//     and compilation time). Axes with dynamic dimensions must be named.
 //   - DType: the data type of the unit element in a tensor. Enumeration defined in github.com/gomlx/compute/dtypes
 //   - Scalar: is a shape where there are no axes (or dimensions), only a single value
 //     of the associated DType.
 //
 // Example: The multi-dimensional array `[][]int32{{0, 1, 2}, {3, 4, 5}}` if converted to a Tensor
-// would have shape `(int32)[2 3]`. We say it has rank 2 (so 2 axes), axis 0 has
+// would have shape `(int32)[2, 3]`. We say it has rank 2 (so 2 axes), axis 0 has
 // dimension 2, and axis 1 has dimension 3. This shape could be created with
 // `shapes.Make(int32, 2, 3)`.
 //
-// ## Asserts
+// ## Creating a new shape:
 //
-// When coding ML models, one delicate part is keeping tabs on the shape of
-// graph nodes -- unfortunately, there is no compile-time checking of values,
-// so validation only happens in runtime. To facilitate and also to serve as code documentation,
-// this package provides two variations of _assert_ functionality. Examples:
-//
-// AssertRank and AssertDims check that the rank and dimensions of the given
-// object (that has a `Shape` method) match, otherwise it panics. The `-1` means
-// the dimension is unchecked (it can be anything).
-//
-//	func modelGraph(ctx *context.Context, spec any, inputs []*Node) ([]*Node) {
-//		_ = spec  // Not needed here, we know the dataset.
-//		shapes.AssertRank(inputs, 2)
-//		batchSize := inputs.Shape().Dimensions[0]
-//		logits := layers.Dense(ctx, inputs[0], /* useBias= */ true, /* outputDim= */ 1)
-//		shapes.AssertDims(logits, batchSize, -1)
-//		return []*Node{logits}
-//	}
-//
-// ```
-//
-// If you don't want to panic, but instead return an error through the `graph.Graph`, you can
-// use the `Node.AssertDims()` method. So it would look like `logits.AssertDims(batchSize, -1)`.
+//   - Make(dtype, dimensions...int): create a concrete (no dynamic axes) un-named shape.
+//   - MakeDynamic(dtype, dimensions []int, axesNames []string): create a shape with (optional) dynamic axes
+//     and axes names. Dynamic axes must have an associated name, while concrete axes are usually unnamed ("").
+//   - MakeTuple(shapes...): internal use, create a shape that represents a tuple of shapes. Internal use, and subject
+//     to change.
 package shapes
 
 import (

--- a/standard_ops.go
+++ b/standard_ops.go
@@ -222,9 +222,9 @@ type StandardOps interface {
 	//     {{1 , 1},
 	//     {2 , 2}}
 	//
-	// Dynamic shapes: the operand axes with dynamic lengths ([shapes.DynamicDim]) cannot be broadcast and must
-	// be preserved as dynamic in the output -- their axis names must match in the outputShape
-	// (in the corresponding axis).
+	// Dynamic shapes: When broadcasting, an operand axis with a dynamic length
+	// cannot be broadcast and must be preserved as dynamic in the output -- their axis names
+	// must exactly match in the outputShape.
 	// But new dynamic dimensions can be introduced in the output -- either mapping from an axis with dimension 1,
 	// or from a newly introduced axis. Notice that introducing new dynamic axis names that are not resolved
 	// by any input parameter will result in an error.

--- a/standard_ops.go
+++ b/standard_ops.go
@@ -221,6 +221,13 @@ type StandardOps interface {
 	//     will generate output
 	//     {{1 , 1},
 	//     {2 , 2}}
+	//
+	// Dynamic shapes: the operand axes with dynamic lengths ([shapes.DynamicDim]) cannot be broadcast and must
+	// be preserved as dynamic in the output -- their axis names must match in the outputShape
+	// (in the corresponding axis).
+	// But new dynamic dimensions can be introduced in the output -- either mapping from an axis with dimension 1,
+	// or from a newly introduced axis. Notice that introducing new dynamic axis names that are not resolved
+	// by any input parameter will result in an error.
 	BroadcastInDim(x Value, outputShape shapes.Shape, broadcastAxes []int) (Value, error)
 
 	// Ceil returns the Op that represents the output of the corresponding operation.

--- a/standard_ops.go
+++ b/standard_ops.go
@@ -137,6 +137,9 @@ type StandardOps interface {
 	//
 	//	ArgMinMax(x={{2, 0, 7}, {-3, 4, 2}}, axis=1, isMin=true) -> {1, 0}  // (it chooses the 0 and the -3)
 	//	ArgMinMax(x={{2, 0, 7}, {-3, 4, 2}}, axis=0, isMin=false) -> {0, 1, 0} // (it chooses the 2, 4, and 7)
+	//
+	// Dynamic shapes: ArgMinMax on a dynamic axis removes that axis (and its name), preserving names
+	// of other dynamic axes.
 	ArgMinMax(x Value, axis int, outputDType dtypes.DType, isMin bool) (Value, error)
 
 	// BatchNormForInference implements batch normalization for inference.
@@ -188,6 +191,9 @@ type StandardOps interface {
 	//
 	// 	Bitcast([1]uint32{0xdeadbeef}, dtypes.UInt16) -> [1][2]uint16{{0xbeef, 0xdead}} // Little-endian encoding.
 	// 	Bitcast([1][2]uint16{{0xbeef, 0xdead}}, dtypes.UInt32) -> [1]uint32{0xdeadbeef}
+	//
+	// Dynamic shapes: Bitcasting that collapses or expands a dynamic dimension is currently not
+	// supported (requires axis expressions).
 	Bitcast(operand Value, targetDType dtypes.DType) (Value, error)
 
 	// BitCount returns the number of bits that are set to one.
@@ -254,6 +260,9 @@ type StandardOps interface {
 	// All axes that are not being concatenated must match dimensions, except on the axes being concatenated.
 	// It doesn't work with scalars -- use ExpandAxes.
 	// If there is only one operand, it is returned and this is a no-op.
+	//
+	// Dynamic shapes: Concatenation on a dynamic axis is currently not supported, because the resulting
+	// size (e.g. batchSize + batchSize) cannot be represented symbolically yet (requires axis expressions).
 	Concatenate(axis int, operands ...Value) (Value, error)
 
 	// Conj returns the conjugate of a complex number. E.g: Conj(1+3i) = 1-3i
@@ -288,6 +297,9 @@ type StandardOps interface {
 	// Note:
 	//   - Another common term for "channels" is "features".
 	//   - "Kernel" is also commonly called "weights" or "filters".
+	//
+	// Dynamic shapes: Operation on a dynamic spatial axis that changes its size (stride > 1, padding != 0,
+	// window > 1, etc.) is currently not supported (requires axis expressions).
 	ConvGeneral(
 		input, kernel Value,
 		axes ConvolveAxesConfig,
@@ -322,6 +334,8 @@ type StandardOps interface {
 	// the input, except if configured otherwise in config.OutputDType.
 	//
 	// It provides the basic means of implementing Einsum.
+	//
+	// Dynamic shapes: Aligned or contracted dynamic axes must have the same name for both lhs and rhs.
 	DotGeneral(
 		lhs Value,
 		lhsContractingAxes, lhsBatchAxes []int,
@@ -442,6 +456,10 @@ type StandardOps interface {
 	//
 	// Out-of-bound (and negative) indices <i> are adjusted with max(min(<i>, axisDimension-1), 0), meaning they
 	// are taken from the border of the axes.
+	//
+	// Dynamic shapes: Batch axes (from startIndices) and offset axes (from operand) preserve their names
+	// in the output. If an offset axis is partially sliced (sliceSize != operand dimension), its name is dropped.
+	//
 	// TODO: Add batch support: operandBatchingAxes and startIndicesBatchingAxes.
 	Gather(
 		operand, startIndices Value,
@@ -547,6 +565,9 @@ type StandardOps interface {
 	// Pad injects padding on the start, end, or interior (in between each element) of the given operand.
 	// There must be at most `operand.Rank()` axesConfig values. Missing PadAxis are assumed to be zeros,
 	// that is, no padding for those axes.
+	//
+	// Dynamic shapes: Padding on a dynamic axis is currently not supported if the padding is non-zero,
+	// because the resulting size cannot be represented symbolically yet (requires axis expressions).
 	Pad(x, fillValue Value, axesConfig ...PadAxis) (Value, error)
 
 	// Pow returns the Op that represents the output of the corresponding operation.
@@ -641,6 +662,9 @@ type StandardOps interface {
 	//   If nil, it's assumed to be 1 (no dilation) for each axis. Values must be >= 1.
 	// - paddings: virtual padding to be added to the input at the edges (start and end) of each axis.
 	//   If nil, it's assumed to be 0 for each axis.
+	//
+	// Dynamic shapes: Operation on a dynamic axis that changes its size (stride > 1, padding != 0,
+	// window > 1, etc.) is currently not supported (requires axis expressions).
 	ReduceWindow(
 		input Value,
 		reductionType ReduceOpType,
@@ -682,6 +706,9 @@ type StandardOps interface {
 	Rsqrt(x Value) (Value, error)
 
 	// ScatterMax scatter values from updates pointed by scatterIndices to operand, by taking the Max.
+	//
+	// Dynamic shapes: Operand and updates shapes can have dynamic dimensions. Currently operations
+	// that change the size of dynamic axes are not supported.
 	ScatterMax(
 		operand, scatterIndices, updates Value,
 		indexVectorAxis int,
@@ -690,6 +717,9 @@ type StandardOps interface {
 	) (Value, error)
 
 	// ScatterMin scatter values from updates pointed by scatterIndices to operand, by taking the Min.
+	//
+	// Dynamic shapes: Operand and updates shapes can have dynamic dimensions. Currently operations
+	// that change the size of dynamic axes are not supported.
 	ScatterMin(
 		operand, scatterIndices, updates Value,
 		indexVectorAxis int,
@@ -698,6 +728,9 @@ type StandardOps interface {
 	) (Value, error)
 
 	// ScatterSum values from updates pointed by scatterIndices to operand.
+	//
+	// Dynamic shapes: Operand and updates shapes can have dynamic dimensions. Currently operations
+	// that change the size of dynamic axes are not supported.
 	ScatterSum(
 		operand, scatterIndices, updates Value,
 		indexVectorAxis int,
@@ -744,6 +777,11 @@ type StandardOps interface {
 	// Examples:
 	// 	Slice(x={0, 1, 2, 3, 4}, starts={2}, limits={4}, strides=nil) -> {2, 3}
 	// 	Slice(x={0, 1, 2, 3, 4}, starts={2}, limits={5}, strides={2}) -> {2, 4}
+	//
+	// Dynamic shapes: A limit index can be set to `shapes.DynamicDim` (-1) to indicate the end of
+	// the dimension. Partial slices of dynamic axes are currently not supported if they result in
+	// a dynamic-sized output (requires axis expressions). Slicing a dynamic axis with static
+	// bounds (e.g. from 0 to 10) results in a static output size (e.g. 10).
 	Slice(x Value, starts, limits, strides []int) (Value, error)
 
 	// Sqrt returns the Op that represents the output of the corresponding operation.

--- a/standard_ops.go
+++ b/standard_ops.go
@@ -648,6 +648,11 @@ type StandardOps interface {
 	// Reshape reshapes x to the new dimensions.
 	// Total size cannot change, it's just a "reinterpretation" of the same flat data.
 	// The dtype remains the same, see ConvertDType to actually convert the values.
+	//
+	// This version of reshape doesn't support reshaping dynamic dimensions (axes with [shapes.DynamicDim]).
+	// Any dynamic dimensions in the input must be matched by dynamic dimensions in the output, and their
+	// axis names are preserved. If new axes are created, the dynamic axis in the input x and dimensions are
+	// matched in order.
 	Reshape(x Value, dimensions ...int) (Value, error)
 
 	// Reverse returns x with the values for the given dimensions reversed, that is,


### PR DESCRIPTION
This PR introduces Dynamic Shapes for the `compute.Shapes` definition, and specifies some limited support in the `compute.Backend` API. Finally, it also provides a proof-of-concept partial implementation in the Go backend.

It is **experimental** and support is limited -- we need more specialized operations to handle dynamic shaped inputs, and some existing operations need to be further designed to proper handled dynamic shapes.

 1. Shape Inference (`shapeinference` package):
       * Remove suffix "Op" for individual operations.
       * Refined Broadcasting Logic: Updated BinaryOp to correctly handle `DynamicDim` during broadcasting (e.g., broadcasting a dimension of size 1 into a dynamic dimension).
       * Dynamic Reshape Support: Updated `Reshape` to skip size validation when dynamic dimensions are involved, deferring this to execution-time specialization.
       * Improved Validation: Updated `Gather` and `Slice` to skip bounds checking for dynamic axes during graph building.
       * Axis Name Propagation: Ensured `AxisNames` are correctly propagated or unified in `Reduce`, `Transpose`, and `Concatenate`.

   3. Go Backend (`internal/gobackend`):
       * Shape Specialization:
           * Implemented Recompute for `ConvGeneral` to update shape-dependent metadata (strides, dilated dimensions) during specialization.
           * Verified existing Recompute implementations for `DotGeneral`, `Gather`, and `Slice`.
       * Execution Logic: Updated Execute in `internal/gobackend/exec.go` to strictly validate shapes for static parameters while allowing flexible matching for dynamic ones.

   4. Core API & Infrastructure:
       * Code Generation: Ran go generate ./... to update all enumerations, registration stubs, and "not implemented" base classes.
       * Test Maintenance: Updated `internal/gobackend/function_test.go` to match the updated `FunctionExecutable.Execute` signature, which now requires a `ShapeSpecialization` argument.

   5. Verification:
       * Added new test cases to `shapeinference/shapeinference_test.go` covering dynamic reshape and broadcast axis name propagation.
       * Verified that all tests pass across the repository, including compliance tests for the Go backend.

  The system now supports building and executing graphs with symbolic axes that are resolved at runtime based on the actual input shapes. This avoids expensive recompilations when only
  dimensions like "batch size" or "sequence length" change.
  
Note: this started as a port and adaptation of [GoMLX' Dynamic Shape PR 358](https://github.com/gomlx/gomlx/pull/358), but was largely cleaned up, fixed and the design and implementation of key operations behavior were defined in this PR.

