### PR TITLE
Fix test dependencies, clean up AVX tests and rename SimpleGo to Go backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ some of the example models to benchmark your backend against some of the others.
 
 - `GOMLX_BACKEND`: defines the backend engine to use (if using `backends.New()`). The value is formatted as "<backend_name>[:<backend_config>]",
   with the config part being optional. Examples:
-  - `GOMLX_BACKEND=go`: Use the `SimpleGo` backend, the pure Go implementation that is very portable but slow.
+  - `GOMLX_BACKEND=go`: Use the "Go backend", the pure Go implementation that is very portable but slow.
   - `GOMLX_BACKEND="xla:cpu"`: Use XLA (the faster backend, only runs on Linux now) for CPU
   - `GOMLX_BACKEND="xla:cuda"`: Use XLA for for Nvidia CUDA
   - `GOMLX_BACKEND="xla:/path/to/my/pjrt_plugin.so"`: Use XLA with an arbitrary PJRT. PJRT is a plugin system for XLA to support different hardware.

--- a/internal/gobackend/README.md
+++ b/internal/gobackend/README.md
@@ -1,6 +1,6 @@
-# SimpleGo Backend
+# Go Backend
 
-SimpleGo implements a simple, and not very fast, but very portable backend for GoMLX.
+The "go" backend implements a simple, and not very fast, but very portable backend for GoMLX.
 
 The priority is to make something that will work everywhere and is "ergonomic" (doesn't require
 installing any associated C/C++/Rust library, or special packages other than Go itself).

--- a/internal/gobackend/buffers.go
+++ b/internal/gobackend/buffers.go
@@ -160,7 +160,7 @@ func (b *Backend) PutBuffer(buffer *Buffer) {
 		return
 	}
 	if !buffer.InUse {
-		panic(errors.New("double-freeing simplego buffer"))
+		panic(errors.New("double-freeing Go backend buffer"))
 	}
 	if buffer.isUserFed {
 		// User-fed buffers are not returned to the pool to avoid unbounded growth

--- a/internal/gobackend/closure.go
+++ b/internal/gobackend/closure.go
@@ -82,7 +82,7 @@ func (n *Node) AddNodeCapturedInputs(closure *Function) {
 func (f *Function) ValidateClosure(opName, closureName string, closure compute.Function) (*Function, error) {
 	fn, ok := closure.(*Function)
 	if !ok {
-		return nil, errors.Errorf("%s: %s must be a *simplego.Function, got %T", opName, closureName, closure)
+		return nil, errors.Errorf("%s: %s must be a *gobackend.Function, got %T", opName, closureName, closure)
 	}
 	if fn.RawParent != f {
 		return nil, errors.Errorf("%s: %s must be a closure of the current function", opName, closureName)

--- a/internal/gobackend/dot/dot_test.go
+++ b/internal/gobackend/dot/dot_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 
 func TestDotGeneral(t *testing.T) {
 	if _, ok := backend.(*gobackend.Backend); !ok {
-		t.Skip("Skipping test because backend is not a SimpleGo Backend")
+		t.Skip("Skipping test because backend is not the Go backend")
 	}
 
 	lhs := [][][]float32{{{1, 2, 3}}, {{4, 5, 6}}}
@@ -63,5 +63,3 @@ func TestDotGeneral(t *testing.T) {
 		t.Fatalf("Unexpected result (-want +got):\n%s", diff)
 	}
 }
-
-

--- a/internal/gobackend/dot/layout_test.go
+++ b/internal/gobackend/dot/layout_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestTransposeToLayout(t *testing.T) {
 	if _, ok := backend.(*gobackend.Backend); !ok {
-		t.Skip("Skipping test because backend is not a SimpleGo Backend")
+		t.Skip("Skipping test because backend is not the Go backend")
 	}
 
 	testCases := []struct {

--- a/internal/gobackend/dot/matmul/avx2_internal_test.go
+++ b/internal/gobackend/dot/matmul/avx2_internal_test.go
@@ -1,0 +1,103 @@
+package matmul
+
+import (
+	"simd/archsimd"
+	"testing"
+	"unsafe"
+)
+
+func TestAVX2(t *testing.T) {
+	if !archsimd.X86.AVX2() {
+		t.Skip("AVX2 is not supported on this architecture")
+	}
+
+	t.Run("Transpose/4x4x64bits", func(t *testing.T) {
+		var input [4 * 4]uint64
+		for i := range input {
+			input[i] = uint64(i)
+		}
+
+		v0 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[0*4])))
+		v1 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[1*4])))
+		v2 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[2*4])))
+		v3 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[3*4])))
+
+		q0, q1, q2, q3 := avx2Transpose4x4x64bits(v0, v1, v2, v3)
+
+		var output [4 * 4]uint64
+		q0.Store((*[4]uint64)(unsafe.Pointer(&output[0*4])))
+		q1.Store((*[4]uint64)(unsafe.Pointer(&output[1*4])))
+		q2.Store((*[4]uint64)(unsafe.Pointer(&output[2*4])))
+		q3.Store((*[4]uint64)(unsafe.Pointer(&output[3*4])))
+
+		for c := range 4 { // logical column
+			for r := range 4 { // logical row
+				expected := uint64(r*4 + c)
+				got := output[c*4+r]
+				if got != expected {
+					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
+				}
+			}
+		}
+	})
+
+	t.Run("Transpose/4x8x32bits", func(t *testing.T) {
+		var input [4 * 8]uint32
+		for i := range input {
+			input[i] = uint32(i)
+		}
+
+		v0 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[0*8])))
+		v1 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[1*8])))
+		v2 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[2*8])))
+		v3 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[3*8])))
+
+		q0, q1, q2, q3 := avx2Transpose4x8x32bits(v0, v1, v2, v3)
+
+		var output [4 * 8]uint32
+		q0.Store((*[8]uint32)(unsafe.Pointer(&output[0*8])))
+		q1.Store((*[8]uint32)(unsafe.Pointer(&output[1*8])))
+		q2.Store((*[8]uint32)(unsafe.Pointer(&output[2*8])))
+		q3.Store((*[8]uint32)(unsafe.Pointer(&output[3*8])))
+
+		for c := range 8 { // logical column
+			for r := range 4 { // logical row
+				expected := uint32(r*8 + c)
+				got := output[c*4+r]
+				if got != expected {
+					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
+				}
+			}
+		}
+	})
+
+	t.Run("Transpose/4x16x16bits", func(t *testing.T) {
+		var input [4 * 16]uint16
+		for i := range input {
+			input[i] = uint16(i)
+		}
+
+		v0 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[0*16])))
+		v1 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[1*16])))
+		v2 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[2*16])))
+		v3 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[3*16])))
+
+		q0, q1, q2, q3 := avx2Transpose4x16x16bits(v0, v1, v2, v3)
+
+		var output [4 * 16]uint16
+		q0.Store((*[16]uint16)(unsafe.Pointer(&output[0*16])))
+		q1.Store((*[16]uint16)(unsafe.Pointer(&output[1*16])))
+		q2.Store((*[16]uint16)(unsafe.Pointer(&output[2*16])))
+		q3.Store((*[16]uint16)(unsafe.Pointer(&output[3*16])))
+
+		for c := range 16 { // logical column
+			for r := range 4 { // logical row
+				expected := uint16(r*16 + c)
+				got := output[c*4+r]
+				if got != expected {
+					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
+				}
+			}
+		}
+	})
+}

--- a/internal/gobackend/dot/matmul/avx2_test.go
+++ b/internal/gobackend/dot/matmul/avx2_test.go
@@ -2,15 +2,15 @@
 
 //go:build amd64 && goexperiment.simd
 
-package matmul
+package matmul_test
 
 import (
 	"simd/archsimd"
 	"testing"
-	"unsafe"
 
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/internal/gobackend/dot"
+	"github.com/gomlx/compute/internal/gobackend/dot/matmul"
 	"github.com/gomlx/compute/support/backendtest"
 )
 
@@ -22,120 +22,24 @@ func TestAVX2(t *testing.T) {
 	// Force AVX2 variant only for NonTransposed.
 	defer func() {
 		dot.ResetTestRegistrations()
-		ForceSmallVariant = false
-		ForceLargeVariant = false
+		matmul.ForceSmallVariant = false
+		matmul.ForceLargeVariant = false
 	}()
 	dot.ResetTestRegistrations()
-	RegisterAVX2ForTests()
+	matmul.RegisterAVX2ForTests()
 
 	backend := compute.MustNew()
 	defer backend.Finalize()
 
 	t.Run("Small", func(t *testing.T) {
-		ForceSmallVariant = true
-		ForceLargeVariant = false
+		matmul.ForceSmallVariant = true
+		matmul.ForceLargeVariant = false
 		backendtest.TestDotGeneral(t, backend)
 	})
 
 	t.Run("Large", func(t *testing.T) {
-		ForceSmallVariant = false
-		ForceLargeVariant = true
+		matmul.ForceSmallVariant = false
+		matmul.ForceLargeVariant = true
 		backendtest.TestDotGeneral(t, backend)
-	})
-}
-
-func TestAVX2Transpose(t *testing.T) {
-	if !archsimd.X86.AVX2() {
-		t.Skip("AVX2 is not supported on this architecture")
-	}
-
-	t.Run("Transpose/4x4x64bits", func(t *testing.T) {
-		var input [4 * 4]uint64
-		for i := range input {
-			input[i] = uint64(i)
-		}
-
-		v0 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[0*4])))
-		v1 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[1*4])))
-		v2 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[2*4])))
-		v3 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[3*4])))
-
-		q0, q1, q2, q3 := avx2Transpose4x4x64bits(v0, v1, v2, v3)
-
-		var output [4 * 4]uint64
-		q0.Store((*[4]uint64)(unsafe.Pointer(&output[0*4])))
-		q1.Store((*[4]uint64)(unsafe.Pointer(&output[1*4])))
-		q2.Store((*[4]uint64)(unsafe.Pointer(&output[2*4])))
-		q3.Store((*[4]uint64)(unsafe.Pointer(&output[3*4])))
-
-		for c := range 4 { // logical column
-			for r := range 4 { // logical row
-				expected := uint64(r*4 + c)
-				got := output[c*4+r]
-				if got != expected {
-					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
-				}
-			}
-		}
-	})
-
-	t.Run("Transpose/4x8x32bits", func(t *testing.T) {
-		var input [4 * 8]uint32
-		for i := range input {
-			input[i] = uint32(i)
-		}
-
-		v0 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[0*8])))
-		v1 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[1*8])))
-		v2 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[2*8])))
-		v3 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[3*8])))
-
-		q0, q1, q2, q3 := avx2Transpose4x8x32bits(v0, v1, v2, v3)
-
-		var output [4 * 8]uint32
-		q0.Store((*[8]uint32)(unsafe.Pointer(&output[0*8])))
-		q1.Store((*[8]uint32)(unsafe.Pointer(&output[1*8])))
-		q2.Store((*[8]uint32)(unsafe.Pointer(&output[2*8])))
-		q3.Store((*[8]uint32)(unsafe.Pointer(&output[3*8])))
-
-		for c := range 8 { // logical column
-			for r := range 4 { // logical row
-				expected := uint32(r*8 + c)
-				got := output[c*4+r]
-				if got != expected {
-					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
-				}
-			}
-		}
-	})
-
-	t.Run("Transpose/4x16x16bits", func(t *testing.T) {
-		var input [4 * 16]uint16
-		for i := range input {
-			input[i] = uint16(i)
-		}
-
-		v0 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[0*16])))
-		v1 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[1*16])))
-		v2 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[2*16])))
-		v3 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[3*16])))
-
-		q0, q1, q2, q3 := avx2Transpose4x16x16bits(v0, v1, v2, v3)
-
-		var output [4 * 16]uint16
-		q0.Store((*[16]uint16)(unsafe.Pointer(&output[0*16])))
-		q1.Store((*[16]uint16)(unsafe.Pointer(&output[1*16])))
-		q2.Store((*[16]uint16)(unsafe.Pointer(&output[2*16])))
-		q3.Store((*[16]uint16)(unsafe.Pointer(&output[3*16])))
-
-		for c := range 16 { // logical column
-			for r := range 4 { // logical row
-				expected := uint16(r*16 + c)
-				got := output[c*4+r]
-				if got != expected {
-					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
-				}
-			}
-		}
 	})
 }

--- a/internal/gobackend/dot/matmul/avx512_internal_test.go
+++ b/internal/gobackend/dot/matmul/avx512_internal_test.go
@@ -1,3 +1,7 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+//go:build amd64 && goexperiment.simd
+
 package matmul
 
 import (
@@ -12,6 +16,10 @@ import (
 )
 
 func TestAVX512(t *testing.T) {
+	if !archsimd.X86.AVX512() {
+		t.Skip("AVX2 is not supported on this architecture")
+	}
+
 	t.Run("Pack", func(t *testing.T) {
 		t.Run("Float32", func(t *testing.T) {
 			runPackLHSTests(t, avx512PackLHSKernelRows4[float32], 4)

--- a/internal/gobackend/dot/matmul/avx512_internal_test.go
+++ b/internal/gobackend/dot/matmul/avx512_internal_test.go
@@ -1,0 +1,182 @@
+package matmul
+
+import (
+	"fmt"
+	"simd/archsimd"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/gomlx/compute/dtypes/bfloat16"
+	"github.com/gomlx/compute/dtypes/float16"
+)
+
+func TestAVX512(t *testing.T) {
+	t.Run("Pack", func(t *testing.T) {
+		t.Run("Float32", func(t *testing.T) {
+			runPackLHSTests(t, avx512PackLHSKernelRows4[float32], 4)
+			runPackRHSTests(t, avx512PackRHSNonTransposed[float32], 32)
+			runApplyPackedOutputTests(t, avx512ApplyPackedOutputFloat32)
+		})
+		t.Run("BFloat16", func(t *testing.T) {
+			runPackLHSTestsHalfPrecision(t, avx512PackLHSKernelRows4[bfloat16.BFloat16], 4)
+			runPackRHSTestsHalfPrecision(t, avx512PackRHSNonTransposed[bfloat16.BFloat16], 32)
+		})
+		t.Run("Float16", func(t *testing.T) {
+			runPackLHSTestsHalfPrecision(t, avx512PackLHSKernelRows4[float16.Float16], 4)
+			runPackRHSTestsHalfPrecision(t, avx512PackRHSNonTransposed[float16.Float16], 32)
+		})
+		t.Run("Float64", func(t *testing.T) {
+			runPackLHSTests(t, avx512PackLHSKernelRows4[float64], 4)
+			runPackRHSTests(t, avx512PackRHSNonTransposed[float64], 16)
+			runApplyPackedOutputTests(t, avx512ApplyPackedOutputFloat64)
+		})
+	})
+
+	t.Run("Transpose/4x8x64bits", func(t *testing.T) {
+		var input [4 * 8]uint64
+		for i := range input {
+			input[i] = uint64(i)
+		}
+
+		v0 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[0*8])))
+		v1 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[1*8])))
+		v2 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[2*8])))
+		v3 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[3*8])))
+
+		q0, q1, q2, q3 := avx512Transpose4x8x64bits(v0, v1, v2, v3)
+
+		var output [4 * 8]uint64
+		q0.Store((*[8]uint64)(unsafe.Pointer(&output[0*8])))
+		q1.Store((*[8]uint64)(unsafe.Pointer(&output[1*8])))
+		q2.Store((*[8]uint64)(unsafe.Pointer(&output[2*8])))
+		q3.Store((*[8]uint64)(unsafe.Pointer(&output[3*8])))
+
+		for c := range 8 { // logical column
+			for r := range 4 { // logical row
+				expected := uint64(r*8 + c)
+				got := output[c*4+r]
+				if got != expected {
+					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
+				}
+			}
+		}
+	})
+
+	t.Run("Transpose/4x16x32bits", func(t *testing.T) {
+		var input [4 * 16]uint32
+		for i := range input {
+			input[i] = uint32(i)
+		}
+
+		v0 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[0*16])))
+		v1 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[1*16])))
+		v2 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[2*16])))
+		v3 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[3*16])))
+
+		q0, q1, q2, q3 := avx512Transpose4x16x32bits(v0, v1, v2, v3)
+
+		// fmt.Printf("\nv0: [%s]\n", transposeIndicesFor4x16x32bits(v0))
+		// fmt.Printf("v1: [%s]\n", transposeIndicesFor4x16x32bits(v1))
+		// fmt.Printf("v0.InterleaveLoGrouped(v1)= [%s]\n\n",
+		// 	transposeIndicesFor4x16x32bits(v0.InterleaveLoGrouped(v1)))
+
+		fmt.Printf("q0: [%s]\n", transposeIndicesFor4x16x32bits(q0))
+		fmt.Printf("q1: [%s]\n", transposeIndicesFor4x16x32bits(q1))
+		fmt.Printf("q2: [%s]\n", transposeIndicesFor4x16x32bits(q2))
+		fmt.Printf("q3: [%s]\n", transposeIndicesFor4x16x32bits(q3))
+
+		var output [4 * 16]uint32
+		q0.Store((*[16]uint32)(unsafe.Pointer(&output[0*16])))
+		q1.Store((*[16]uint32)(unsafe.Pointer(&output[1*16])))
+		q2.Store((*[16]uint32)(unsafe.Pointer(&output[2*16])))
+		q3.Store((*[16]uint32)(unsafe.Pointer(&output[3*16])))
+
+		for c := range 16 { // logical column
+			for r := range 4 { // logical row
+				expected := uint32(r*16 + c)
+				got := output[c*4+r]
+				if got != expected {
+					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
+				}
+			}
+		}
+	})
+
+	t.Run("Transpose/4x32x16bits", func(t *testing.T) {
+		var input [4 * 32]uint16
+		for i := range input {
+			input[i] = uint16(i)
+		}
+
+		v0 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[0*32])))
+		v1 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[1*32])))
+		v2 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[2*32])))
+		v3 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[3*32])))
+
+		q0, q1, q2, q3 := avx512Transpose4x32x16bits(v0, v1, v2, v3)
+
+		// fmt.Printf("\nv0: [%s]\n", transposeIndicesFor4x32x16bits(v0))
+		// fmt.Printf("v1: [%s]\n", transposeIndicesFor4x32x16bits(v1))
+		// fmt.Printf("v0.InterleaveLoGrouped(v1)= [%s]\n\n",
+		// 	transposeIndicesFor4x32x16bits(v0.InterleaveLoGrouped(v1)))
+
+		fmt.Printf("q0: [%s]\n", transposeIndicesFor4x32x16bits(q0))
+		fmt.Printf("q1: [%s]\n", transposeIndicesFor4x32x16bits(q1))
+		fmt.Printf("q2: [%s]\n", transposeIndicesFor4x32x16bits(q2))
+		fmt.Printf("q3: [%s]\n", transposeIndicesFor4x32x16bits(q3))
+
+		var output [4 * 32]uint16
+		q0.Store((*[32]uint16)(unsafe.Pointer(&output[0*32])))
+		q1.Store((*[32]uint16)(unsafe.Pointer(&output[1*32])))
+		q2.Store((*[32]uint16)(unsafe.Pointer(&output[2*32])))
+		q3.Store((*[32]uint16)(unsafe.Pointer(&output[3*32])))
+
+		for c := range 32 { // logical column
+			for r := range 4 { // logical row
+				expected := uint16(r*32 + c)
+				got := output[c*4+r]
+				if got != expected {
+					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
+				}
+			}
+		}
+	})
+}
+
+func transposeIndicesFor4x16x32bits(vec archsimd.Uint32x16) string {
+	var sb strings.Builder
+	var values [16]uint32
+	vec.Store(&values)
+	for i, val := range values {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		vecNum := val / 16
+		vecIdx := val % 16
+		sb.WriteString(fmt.Sprintf("v_{%d,%d}", vecNum, vecIdx))
+	}
+	return sb.String()
+}
+
+func transposeIndicesFor4x32x16bits(vec archsimd.Uint16x32) string {
+	var sb strings.Builder
+	var values [32]uint16
+	vec.Store(&values)
+	for i, val := range values {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		vecNum := val / 32
+		vecIdx := val % 32
+		sb.WriteString(fmt.Sprintf("v_{%d,%d}", vecNum, vecIdx))
+	}
+	return sb.String()
+}
+
+func BenchmarkAVX512(b *testing.B) {
+	const totalRows, totalCols = 1536, 1920
+	const panelRows, panelCols = 24, 128
+	runBenchmarkPackLHS[float32](b, "PackLHS/kernelRows=4/float32", avx512PackLHSKernelRows4, totalRows, totalCols, panelRows, panelCols, 4)
+	runBenchmarkPackLHS[bfloat16.BFloat16](b, "PackLHS/kernelRows=4/bfloat16", avx512PackLHSKernelRows4, totalRows, totalCols, panelRows, panelCols, 4)
+}

--- a/internal/gobackend/dot/matmul/avx512_test.go
+++ b/internal/gobackend/dot/matmul/avx512_test.go
@@ -2,19 +2,15 @@
 
 //go:build amd64 && goexperiment.simd
 
-package matmul
+package matmul_test
 
 import (
-	"fmt"
 	"simd/archsimd"
-	"strings"
 	"testing"
-	"unsafe"
 
 	"github.com/gomlx/compute"
-	"github.com/gomlx/compute/dtypes/bfloat16"
-	"github.com/gomlx/compute/dtypes/float16"
 	"github.com/gomlx/compute/internal/gobackend/dot"
+	"github.com/gomlx/compute/internal/gobackend/dot/matmul"
 	"github.com/gomlx/compute/support/backendtest"
 )
 
@@ -26,193 +22,24 @@ func TestAVX512(t *testing.T) {
 	// Force AVX512 variant only for NonTransposed.
 	defer func() {
 		dot.ResetTestRegistrations()
-		ForceSmallVariant = false
-		ForceLargeVariant = false
+		matmul.ForceSmallVariant = false
+		matmul.ForceLargeVariant = false
 	}()
 	dot.ResetTestRegistrations()
-	RegisterAVX512ForTests()
+	matmul.RegisterAVX512ForTests()
 
 	backend := compute.MustNew()
 	defer backend.Finalize()
 
 	t.Run("Small", func(t *testing.T) {
-		ForceSmallVariant = true
-		ForceLargeVariant = false
+		matmul.ForceSmallVariant = true
+		matmul.ForceLargeVariant = false
 		backendtest.TestDotGeneral(t, backend)
 	})
 
 	t.Run("Large", func(t *testing.T) {
-		ForceSmallVariant = false
-		ForceLargeVariant = true
+		matmul.ForceSmallVariant = false
+		matmul.ForceLargeVariant = true
 		backendtest.TestDotGeneral(t, backend)
 	})
-
-	t.Run("Pack", func(t *testing.T) {
-		t.Run("Float32", func(t *testing.T) {
-			runPackLHSTests(t, avx512PackLHSKernelRows4[float32], 4)
-			runPackRHSTests(t, avx512PackRHSNonTransposed[float32], 32)
-			runApplyPackedOutputTests(t, avx512ApplyPackedOutputFloat32)
-		})
-		t.Run("BFloat16", func(t *testing.T) {
-			runPackLHSTestsHalfPrecision(t, avx512PackLHSKernelRows4[bfloat16.BFloat16], 4)
-			runPackRHSTestsHalfPrecision(t, avx512PackRHSNonTransposed[bfloat16.BFloat16], 32)
-		})
-		t.Run("Float16", func(t *testing.T) {
-			runPackLHSTestsHalfPrecision(t, avx512PackLHSKernelRows4[float16.Float16], 4)
-			runPackRHSTestsHalfPrecision(t, avx512PackRHSNonTransposed[float16.Float16], 32)
-		})
-		t.Run("Float64", func(t *testing.T) {
-			runPackLHSTests(t, avx512PackLHSKernelRows4[float64], 4)
-			runPackRHSTests(t, avx512PackRHSNonTransposed[float64], 16)
-			runApplyPackedOutputTests(t, avx512ApplyPackedOutputFloat64)
-		})
-	})
-
-	t.Run("Transpose/4x8x64bits", func(t *testing.T) {
-		var input [4 * 8]uint64
-		for i := range input {
-			input[i] = uint64(i)
-		}
-
-		v0 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[0*8])))
-		v1 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[1*8])))
-		v2 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[2*8])))
-		v3 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[3*8])))
-
-		q0, q1, q2, q3 := avx512Transpose4x8x64bits(v0, v1, v2, v3)
-
-		var output [4 * 8]uint64
-		q0.Store((*[8]uint64)(unsafe.Pointer(&output[0*8])))
-		q1.Store((*[8]uint64)(unsafe.Pointer(&output[1*8])))
-		q2.Store((*[8]uint64)(unsafe.Pointer(&output[2*8])))
-		q3.Store((*[8]uint64)(unsafe.Pointer(&output[3*8])))
-
-		for c := range 8 { // logical column
-			for r := range 4 { // logical row
-				expected := uint64(r*8 + c)
-				got := output[c*4+r]
-				if got != expected {
-					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
-				}
-			}
-		}
-	})
-
-	t.Run("Transpose/4x16x32bits", func(t *testing.T) {
-		var input [4 * 16]uint32
-		for i := range input {
-			input[i] = uint32(i)
-		}
-
-		v0 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[0*16])))
-		v1 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[1*16])))
-		v2 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[2*16])))
-		v3 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[3*16])))
-
-		q0, q1, q2, q3 := avx512Transpose4x16x32bits(v0, v1, v2, v3)
-
-		// fmt.Printf("\nv0: [%s]\n", transposeIndicesFor4x16x32bits(v0))
-		// fmt.Printf("v1: [%s]\n", transposeIndicesFor4x16x32bits(v1))
-		// fmt.Printf("v0.InterleaveLoGrouped(v1)= [%s]\n\n",
-		// 	transposeIndicesFor4x16x32bits(v0.InterleaveLoGrouped(v1)))
-
-		fmt.Printf("q0: [%s]\n", transposeIndicesFor4x16x32bits(q0))
-		fmt.Printf("q1: [%s]\n", transposeIndicesFor4x16x32bits(q1))
-		fmt.Printf("q2: [%s]\n", transposeIndicesFor4x16x32bits(q2))
-		fmt.Printf("q3: [%s]\n", transposeIndicesFor4x16x32bits(q3))
-
-		var output [4 * 16]uint32
-		q0.Store((*[16]uint32)(unsafe.Pointer(&output[0*16])))
-		q1.Store((*[16]uint32)(unsafe.Pointer(&output[1*16])))
-		q2.Store((*[16]uint32)(unsafe.Pointer(&output[2*16])))
-		q3.Store((*[16]uint32)(unsafe.Pointer(&output[3*16])))
-
-		for c := range 16 { // logical column
-			for r := range 4 { // logical row
-				expected := uint32(r*16 + c)
-				got := output[c*4+r]
-				if got != expected {
-					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
-				}
-			}
-		}
-	})
-
-	t.Run("Transpose/4x32x16bits", func(t *testing.T) {
-		var input [4 * 32]uint16
-		for i := range input {
-			input[i] = uint16(i)
-		}
-
-		v0 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[0*32])))
-		v1 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[1*32])))
-		v2 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[2*32])))
-		v3 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[3*32])))
-
-		q0, q1, q2, q3 := avx512Transpose4x32x16bits(v0, v1, v2, v3)
-
-		// fmt.Printf("\nv0: [%s]\n", transposeIndicesFor4x32x16bits(v0))
-		// fmt.Printf("v1: [%s]\n", transposeIndicesFor4x32x16bits(v1))
-		// fmt.Printf("v0.InterleaveLoGrouped(v1)= [%s]\n\n",
-		// 	transposeIndicesFor4x32x16bits(v0.InterleaveLoGrouped(v1)))
-
-		fmt.Printf("q0: [%s]\n", transposeIndicesFor4x32x16bits(q0))
-		fmt.Printf("q1: [%s]\n", transposeIndicesFor4x32x16bits(q1))
-		fmt.Printf("q2: [%s]\n", transposeIndicesFor4x32x16bits(q2))
-		fmt.Printf("q3: [%s]\n", transposeIndicesFor4x32x16bits(q3))
-
-		var output [4 * 32]uint16
-		q0.Store((*[32]uint16)(unsafe.Pointer(&output[0*32])))
-		q1.Store((*[32]uint16)(unsafe.Pointer(&output[1*32])))
-		q2.Store((*[32]uint16)(unsafe.Pointer(&output[2*32])))
-		q3.Store((*[32]uint16)(unsafe.Pointer(&output[3*32])))
-
-		for c := range 32 { // logical column
-			for r := range 4 { // logical row
-				expected := uint16(r*32 + c)
-				got := output[c*4+r]
-				if got != expected {
-					t.Errorf("At output col %d, row %d: got %d, expected %d", c, r, got, expected)
-				}
-			}
-		}
-	})
-
-}
-
-func transposeIndicesFor4x16x32bits(vec archsimd.Uint32x16) string {
-	var sb strings.Builder
-	var values [16]uint32
-	vec.Store(&values)
-	for i, val := range values {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		vecNum := val / 16
-		vecIdx := val % 16
-		sb.WriteString(fmt.Sprintf("v_{%d,%d}", vecNum, vecIdx))
-	}
-	return sb.String()
-}
-
-func transposeIndicesFor4x32x16bits(vec archsimd.Uint16x32) string {
-	var sb strings.Builder
-	var values [32]uint16
-	vec.Store(&values)
-	for i, val := range values {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		vecNum := val / 32
-		vecIdx := val % 32
-		sb.WriteString(fmt.Sprintf("v_{%d,%d}", vecNum, vecIdx))
-	}
-	return sb.String()
-}
-
-func BenchmarkAVX512(b *testing.B) {
-	const totalRows, totalCols = 1536, 1920
-	const panelRows, panelCols = 24, 128
-	runBenchmarkPackLHS[float32](b, "PackLHS/kernelRows=4/float32", avx512PackLHSKernelRows4, totalRows, totalCols, panelRows, panelCols, 4)
-	runBenchmarkPackLHS[bfloat16.BFloat16](b, "PackLHS/kernelRows=4/bfloat16", avx512PackLHSKernelRows4, totalRows, totalCols, panelRows, panelCols, 4)
 }

--- a/internal/gobackend/dtypemap.go
+++ b/internal/gobackend/dtypemap.go
@@ -137,7 +137,7 @@ func (d *DTypePairMap) Register(dtype1, dtype2 dtypes.DType, priority RegisterPr
 
 // Constraints --------------------------------------------------------------------------------------------------------
 
-// SupportedTypesConstraints enumerates the types supported by SimpleGo.
+// SupportedTypesConstraints enumerates the types supported by the Go backend.
 type SupportedTypesConstraints interface {
 	bool | int8 | int16 | int32 | int64 | uint8 | uint16 | uint32 | uint64 | float32 | float64 |
 		bfloat16.BFloat16 | float16.Float16

--- a/internal/gobackend/function.go
+++ b/internal/gobackend/function.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Function implements compute.Function for SimpleGo.
+// Function implements compute.Function for the Go backend.
 type Function struct {
 	notimplemented.Function
 

--- a/internal/gobackend/function_test.go
+++ b/internal/gobackend/function_test.go
@@ -17,7 +17,7 @@ import (
 func TestFunctionCapabilities(t *testing.T) {
 	caps := backend.Capabilities()
 	if !caps.Functions {
-		t.Errorf("SimpleGo should support Functions capability")
+		t.Errorf("Go backend should support Functions capability")
 	}
 }
 

--- a/internal/gobackend/gobackend.go
+++ b/internal/gobackend/gobackend.go
@@ -128,7 +128,7 @@ type Backend struct {
 	SchedulingStrategy ScheduleStrategy
 }
 
-// Compile-time check that simplego.Backend implements compute.Backend.
+// Compile-time check that the gobackend.Backend implements compute.Backend.
 var _ compute.Backend = &Backend{}
 
 // Name returns the short name of the backend. E.g.: "xla" for the Xla/PJRT plugin.
@@ -184,7 +184,7 @@ func (b *Backend) Builder(name string) compute.Builder {
 }
 
 func notImplementedError(opType compute.OpType) error {
-	return errors.Wrapf(notimplemented.NotImplementedError, "sorry, op %q not implemented in SimpleGo (the \"go\" backend) yet "+
+	return errors.Wrapf(notimplemented.NotImplementedError, "sorry, op %q not implemented in the \"go\" backend yet "+
 		"-- reach out to github.com/gomlx/gomlx and open an issue if you need this op, this helps us prioritize the work",
 		opType)
 }

--- a/internal/gobackend/ops/convertdtype.go
+++ b/internal/gobackend/ops/convertdtype.go
@@ -250,7 +250,7 @@ func unpackUint2Bits(packed []byte, dst []int8) {
 
 func init() {
 	// Register sub-byte type conversions (Int4, Uint4).
-	// In simplego, Int4/Uint4 values are stored packed: 2 nibbles per byte.
+	// In the Go backend, Int4/Uint4 values are stored packed: 2 nibbles per byte.
 	// Bitcast from uint8 produces packed buffers (flat = []byte). ConvertDType
 	// unpacks them into one value per element of the target type.
 	// Low nibble (bits 0-3) is the first element, high nibble (bits 4-7) is the second.

--- a/internal/gobackend/passes/passes_test.go
+++ b/internal/gobackend/passes/passes_test.go
@@ -1,6 +1,7 @@
-package passes
+package passes_test
 
 import (
+	_ "github.com/gomlx/compute/internal/gobackend/defaultpkgs"
 	"k8s.io/klog/v2"
 )
 

--- a/optype.go
+++ b/optype.go
@@ -137,7 +137,7 @@ const (
 	// Internal operations (backend-specific, not part of public API)
 
 	// OpTypeBlockForDotGeneral pre-blocks a tensor for efficient DotGeneral execution.
-	// This is an internal optimization used by the simplego backend.
+	// This is an internal optimization used by the go backend.
 	OpTypeBlockForDotGeneral
 
 	// Fused operations: high-level ops that backends may implement natively.

--- a/support/backendparser/backendparser.go
+++ b/support/backendparser/backendparser.go
@@ -12,10 +12,9 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
-	"strings"
 
 	"github.com/gomlx/compute/internal/exceptions"
 	"github.com/gomlx/compute/internal/must"
@@ -177,126 +176,14 @@ func ParseBuilder() ([]Method, error) {
 	return methods, nil
 }
 
-// isTargetModule checks if the go.mod contents declare the target module.
-func isTargetModule(modBytes []byte, target string) bool {
-	for line := range strings.SplitSeq(string(modBytes), "\n") {
-		line = strings.TrimSpace(line)
-		if after, ok := strings.CutPrefix(line, "module "); ok {
-			modName := strings.TrimSpace(after)
-			if idx := strings.Index(modName, "//"); idx != -1 {
-				modName = strings.TrimSpace(modName[:idx])
-			}
-			if modName == target {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// checkGoWork parses the go.work file at the given path and checks if any of
-// its use directives point to a directory containing the target module.
-func checkGoWork(gowork, moduleName string) (string, error) {
-	workBytes, err := os.ReadFile(gowork)
-	if err != nil {
-		return "", err
-	}
-	workDir := filepath.Dir(gowork)
-
-	var inUseBlock bool
-	for line := range strings.SplitSeq(string(workBytes), "\n") {
-		if idx := strings.Index(line, "//"); idx != -1 {
-			line = line[:idx]
-		}
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		var usePath string
-		if inUseBlock {
-			if line == ")" {
-				inUseBlock = false
-				continue
-			}
-			usePath = strings.Trim(line, "\"'`")
-		} else if after, ok := strings.CutPrefix(line, "use "); ok {
-			rest := strings.TrimSpace(after)
-			if rest == "(" {
-				inUseBlock = true
-				continue
-			} else {
-				usePath = strings.Trim(rest, "\"'`")
-			}
-		} else if line == "use(" || line == "use (" {
-			inUseBlock = true
-			continue
-		}
-
-		if usePath != "" {
-			if !filepath.IsAbs(usePath) {
-				usePath = filepath.Join(workDir, usePath)
-			}
-			if modBytes, err := os.ReadFile(filepath.Join(usePath, "go.mod")); err == nil {
-				if isTargetModule(modBytes, moduleName) {
-					return usePath, nil
-				}
-			}
-		}
-	}
-	return "", fmt.Errorf("module %s not found in go.work", moduleName)
-}
-
 // findModuleRoot returns the absolute path to the module root directory
-// for github.com/gomlx/compute.
+// for github.com/gomlx/compute, determined relative to this file's location.
 func findModuleRoot() (string, error) {
-	const moduleName = "github.com/gomlx/compute"
-
-	// 1. Check if the current module (as stated in go.mod) is github.com/gomlx/compute
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("could not get caller information to determine module root")
 	}
-	for d := dir; ; {
-		if modBytes, err := os.ReadFile(filepath.Join(d, "go.mod")); err == nil {
-			if isTargetModule(modBytes, moduleName) {
-				return d, nil
-			}
-			break // Found a go.mod, but not our target module, stop going up
-		}
-		parent := filepath.Dir(d)
-		if parent == d {
-			break
-		}
-		d = parent
-	}
-
-	// 2. Check if any of the paths in go.work refer to github.com/gomlx/compute
-	if outWork, err := exec.Command("go", "env", "GOWORK").Output(); err == nil {
-		gowork := strings.TrimSpace(string(outWork))
-		if gowork != "" {
-			if usePath, err := checkGoWork(gowork, moduleName); err == nil {
-				return usePath, nil
-			}
-		}
-	}
-
-	// 3. Check if Go has the cached code for github.com/gomlx/compute
-	if outCache, err := exec.Command("go", "env", "GOMODCACHE").Output(); err == nil {
-		modCache := strings.TrimSpace(string(outCache))
-		if modCache == "" {
-			if gopath, err := exec.Command("go", "env", "GOPATH").Output(); err == nil {
-				modCache = filepath.Join(strings.TrimSpace(string(gopath)), "pkg", "mod")
-			}
-		}
-		if modCache != "" {
-			matches, err := filepath.Glob(filepath.Join(modCache, filepath.FromSlash(moduleName)+"@*"))
-			if err == nil && len(matches) > 0 {
-				slices.Sort(matches)
-				return matches[len(matches)-1], nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("could not find module root for %s (checked current go.mod, go.work, and GOMODCACHE)", moduleName)
+	// filename is the path to support/backendparser/backendparser.go.
+	// Go up 2 levels (to support/, then to compute root directory).
+	return filepath.Join(filepath.Dir(filename), "../.."), nil
 }

--- a/support/backendparser/backendparser_test.go
+++ b/support/backendparser/backendparser_test.go
@@ -16,13 +16,14 @@ func TestParseBuilder(t *testing.T) {
 	// Check Add method
 	var foundAdd, foundConstant bool
 	for _, method := range methods {
-		if method.Name == "Add" {
+		switch method.Name {
+		case "Add":
 			if len(method.Comments) == 0 || method.Comments[0] == "" {
 				t.Errorf("Add method has no comment: %+v", method)
 			}
 			fmt.Printf("Add: %+v\n", method)
 			foundAdd = true
-		} else if method.Name == "Constant" {
+		case "Constant":
 			if len(method.Comments) == 0 || method.Comments[0] == "" {
 				t.Errorf("Constant method has no comment: %+v", method)
 			}

--- a/support/backendtest/benchmarks.go
+++ b/support/backendtest/benchmarks.go
@@ -430,7 +430,7 @@ func randomUint8(n int) []uint8 {
 // BenchmarkQuantizedDense compares fused quantized-dense (which uses highway SIMD
 // when available) against a decomposed path and float32 Dense as a reference.
 //
-// The decomposed path is only benchmarked for Int8 because the simplego backend
+// The decomposed path is only benchmarked for Int8 because the go backend
 // does not support bitwise shift ops needed for NF4/Int4 nibble extraction.
 func BenchmarkQuantizedDense(b *testing.B, backend compute.Backend) {
 	sizes := []struct {

--- a/support/backendtest/dotgeneral.go
+++ b/support/backendtest/dotgeneral.go
@@ -4,6 +4,7 @@ package backendtest
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gomlx/compute"
@@ -439,8 +440,10 @@ func TestDotGeneral(t *testing.T, backend compute.Backend) {
 						})
 						if err != nil {
 							// Some combinations might not be supported by all backends.
-							t.Logf("Failed for %s, %s, %s: %+v", inputDType, accumulatorDType, outputDType, err)
-							return
+							if strings.Contains(err.Error(), "no DotGeneral implementation found for layout") {
+								t.Skipf("Skipping as the backend does not support this particular DotGeneral dtype combination")
+								return
+							}
 						}
 
 						gotDType := dtypes.FromAny(result)
@@ -468,7 +471,7 @@ func TestDotGeneral(t *testing.T, backend compute.Backend) {
 				for h := range 8 {
 					for g := range 2 {
 						for d := range 256 {
-							idx := (((b*32 + q)*8 + h)*2 + g)*256 + d
+							idx := (((b*32+q)*8+h)*2+g)*256 + d
 							lhsFlat[idx] = float32(((b*32+q)*8+h)*2+g) * 0.0001
 						}
 					}
@@ -481,7 +484,7 @@ func TestDotGeneral(t *testing.T, backend compute.Backend) {
 			for k := range 32 {
 				for h := range 8 {
 					for d := range 256 {
-						idx := ((b*32 + k)*8 + h)*256 + d
+						idx := ((b*32+k)*8+h)*256 + d
 						rhsFlat[idx] = float32(((b*32+k)*8+h)*256+d) * 0.0001
 					}
 				}
@@ -496,12 +499,12 @@ func TestDotGeneral(t *testing.T, backend compute.Backend) {
 					for g := range 2 {
 						for k := range 32 {
 							var sum float64
-							lhsIdxBase := (((b*32 + q)*8 + h)*2 + g)*256
-							rhsIdxBase := ((b*32 + k)*8 + h)*256
+							lhsIdxBase := (((b*32+q)*8+h)*2 + g) * 256
+							rhsIdxBase := ((b*32+k)*8 + h) * 256
 							for d := range 256 {
 								sum += float64(lhsFlat[lhsIdxBase+d]) * float64(rhsFlat[rhsIdxBase+d])
 							}
-							outIdx := (((b*8 + h)*32 + q)*2 + g)*32 + k
+							outIdx := (((b*8+h)*32+q)*2+g)*32 + k
 							wantFlat[outIdx] = float32(sum)
 						}
 					}


### PR DESCRIPTION
This PR simplifies test dependencies (benefiting sandboxed environments), cleans up SIMD matmul tests, and renames the `SimpleGo` backend references to `Go`.

### Changes

1. **Simplified Module Root Resolution in `backendparser`**:
   - Replaced the complex `findModuleRoot` function (which scanned the disk and executed `go env` commands) with a compile-time path calculation using Go's `runtime.Caller` API.
   - Removed unused dependency-resolution helper functions (`isTargetModule`, `checkGoWork`) and cleaned up imports in `support/backendparser/backendparser.go`.
   - This facilitates cleaner execution in sandboxed/chroot'ed environments where command execution or arbitrary path-scanning is not feasible.

2. **AVX2 & AVX512 Test Package Splits**:
   - Split AVX2/AVX512 dot/matmul tests into internal (`matmul`) and external (`matmul_test`) packages to ensure correct encapsulation and dependency structure.
   - Updated `passes_test.go` to use `passes_test` package.

3. **Robustness in SIMD matmul tests**:
   - Skips unsupported data type combinations gracefully in testing.

4. **Renamed SimpleGo to Go backend**:
   - Cleaned up naming and updated all references from `SimpleGo` to the new `Go` backend name.