### PR TITLE
Fix build tags in avx2 matmul test to guard against missing SIMD support

### DIFF
--- a/internal/gobackend/dot/matmul/avx2_internal_test.go
+++ b/internal/gobackend/dot/matmul/avx2_internal_test.go
@@ -1,4 +1,9 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+//go:build amd64 && goexperiment.simd
+
 package matmul
+
 
 import (
 	"simd/archsimd"


### PR DESCRIPTION
This PR adds the missing `//go:build` tag to guard the AVX2 internal test in the matmul package when SIMD support is not enabled or on non-amd64 architectures.

### Changes:
- Added `//go:build amd64 && goexperiment.simd` to `internal/gobackend/dot/matmul/avx2_internal_test.go` to prevent compilation errors when the `simd` experiment is not active.
- Added the standard GoMLX Authors copyright header to the file.
