### PR TITLE
Refactor Fused Scaled Dot Product Attention API: Move scale, causal, and mask to config

### DIFF
--- a/fused_ops.go
+++ b/fused_ops.go
@@ -232,6 +232,18 @@ type ScaledDotProductAttentionConfig struct {
 	// Bias is an optional additive attention-score bias broadcast to [B,H,S,Skv]
 	// (ALiBi / relative-position). NOT the Q/K/V projection bias. nil = unused.
 	Bias Value
+
+	// Scale is the scaling factor applied to query @ key^T.
+	// If 0 (the default), it means 1/sqrt(headDim).
+	Scale float64
+
+	// Causal specifies whether to apply causal (lower-triangular) masking.
+	Causal bool
+
+	// Mask is an optional attention mask of shape [seqLen, kvLen] (or broadcastable).
+	// Boolean mask: true = attend, false = ignore.
+	// Float/additive mask: added to scores before softmax.
+	Mask Value
 }
 
 // ActivationType specifies the activation function for fused operations.
@@ -305,59 +317,44 @@ type FusedOps interface {
 	//
 	// output = softmax(query @ key^T * scale + mask) @ value, computed per-head with GQA support.
 	//
+	// Conventions:
+	// - "numHeads" refers to the number of heads for the query, and "numKVHeads" for the key and value.
+	// - "seqLen" refers to the sequence length of the query, and "kvLen" is the sequence length for the key and value.
+	//
 	// Inputs:
 	//   - query, key, value: 4D tensors whose axis ordering is determined by axesLayout.
 	//     For AxesLayoutBHSD: query [batch, numHeads, seqLen, headDim],
 	//                         key/value [batch, numKVHeads, kvLen, headDim].
 	//     For AxesLayoutBSHD: query [batch, seqLen, numHeads, headDim],
 	//                         key/value [batch, kvLen, numKVHeads, headDim].
-	//   - mask: [seqLen, kvLen] (seqLen is the query sequence length): optional (can be nil) mask
-	//     that can be either boolean or additive (any dtype other than Bool). See also causal below.
-	//     Boolean mask: true = attend, false = ignore.
-	//     Float/additive mask: added to scores before softmax.
-	//     Must be broadcastable to the score tensor shape.
-	//
-	// Parameters:
-	//   - numHeads: number of query attention heads
-	//   - numKVHeads: number of key/value attention heads (for GQA; numHeads must be divisible by numKVHeads)
 	//   - axesLayout: determines the axis ordering of query/key/value tensors
-	//   - scale: scaling factor applied to query @ key^T (typically 1/sqrt(headDim))
-	//   - causal: if true, apply causal (lower-triangular) mask. Callers (e.g. attention.Core)
-	//     treat causal and mask as mutually exclusive, folding causal into the mask before calling
-	//     this method when both are needed. Backends may assume they won't both be set.
-	//   - options: optional optimization hints (nil uses defaults). See ScaledDotProductAttentionConfig.
+	//   - options: optional parameters (nil uses defaults). See ScaledDotProductAttentionConfig.
 	//
 	// Outputs:
 	//   - output: same shape as query.
 	//   - statesForVJP: optional (may be nil/empty). When the backend supports a fused backward
 	//     (FusedScaledDotProductAttentionVJP), it returns whatever backward-pass state that
-	//     backend's fused VJP needs (e.g. per-row softmax log-sum-exp stats, and/or a workspace
-	//     tensor for cuDNN FMHA variants that require one). The set and shapes of these values are
-	//     backend-specific; the VJP is only ever called with the exact slice this call returned.
+	//     backend's fused VJP needs.
+	//     The number, semantics and shapes of these values are backend-specific; the VJP is only
+	//     ever called with the exact slice this call returned.
 	//     Backends without a fused backward return nil/empty here and ErrNotImplemented from the
 	//     VJP, so the caller differentiates the decomposed attention instead.
 	FusedScaledDotProductAttention(
-		query, key, value, mask Value,
-		numHeads, numKVHeads int,
+		query, key, value Value,
 		axesLayout AxesLayout,
-		scale float64,
-		causal bool,
 		options *ScaledDotProductAttentionConfig) (output Value, statesForVJP []Value, err error)
 
 	// FusedScaledDotProductAttentionVJP computes the gradients (dQuery, dKey, dValue) of
 	// FusedScaledDotProductAttention given the forward output, the statesForVJP it returned, and
-	// the adjoint output gradient dOutput. The query/key/value/mask and numHeads..options parameters are
+	// the adjoint output gradient dOutput. The query/key/value and options parameters are
 	// the same values passed to the forward call.
 	//
 	// Backends that return non-nil/non-empty statesForVJP from the forward and implement a fused
 	// backward (e.g. the cuDNN flash backward) implement this. Others return ErrNotImplemented so
 	// the caller falls back to differentiating the decomposed attention.
 	FusedScaledDotProductAttentionVJP(
-		query, key, value, mask Value,
-		numHeads, numKVHeads int,
+		query, key, value Value,
 		axesLayout AxesLayout,
-		scale float64,
-		causal bool,
 		options *ScaledDotProductAttentionConfig,
 		output Value, statesForVJP []Value, dOutput Value) (dQuery, dKey, dValue Value, err error)
 

--- a/internal/gobackend/fusedops/sdpa.go
+++ b/internal/gobackend/fusedops/sdpa.go
@@ -40,14 +40,13 @@ import (
 // Output: same shape as query.
 func FusedScaledDotProductAttention(
 	f *gobackend.Function,
-	query, key, value, mask compute.Value,
-	numHeads, numKVHeads int, axesLayout compute.AxesLayout,
-	scale float64, causal bool,
+	query, key, value compute.Value,
+	axesLayout compute.AxesLayout,
 	options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
 	// The Go backend has no fused flash backward, so it returns nil statesForVJP; its gradient
 	// goes through the decomposed path (FusedScaledDotProductAttentionVJP is ErrNotImplemented).
 	out, err := buildSDPANode(f, compute.OpTypeFusedScaledDotProductAttention, "FusedScaledDotProductAttention",
-		query, key, value, mask, numHeads, numKVHeads, axesLayout, scale, causal, options)
+		query, key, value, axesLayout, options)
 	return out, nil, err
 }
 
@@ -98,10 +97,13 @@ func (d *nodeScaledDotProductAttention) equalOptions(o *nodeScaledDotProductAtte
 // buildSDPANode builds the SDPA computation node.
 func buildSDPANode(
 	f *gobackend.Function, opType compute.OpType, opName string,
-	query, key, value, mask compute.Value,
-	numHeads, numKVHeads int, axesLayout compute.AxesLayout,
-	scale float64, causal bool,
+	query, key, value compute.Value,
+	axesLayout compute.AxesLayout,
 	options *compute.ScaledDotProductAttentionConfig) (compute.Value, error) {
+	var mask compute.Value
+	if options != nil {
+		mask = options.Mask
+	}
 	values := []compute.Value{query, key, value}
 	if mask != nil {
 		values = append(values, mask)
@@ -124,18 +126,38 @@ func buildSDPANode(
 		return nil, err
 	}
 	qNode := inputs[0]
+	kNode := inputs[1]
 
 	if qNode.Shape.Rank() != 4 {
 		return nil, errors.Errorf("%s: query must have rank 4, got %d", opName, qNode.Shape.Rank())
+	}
+	if kNode.Shape.Rank() != 4 {
+		return nil, errors.Errorf("%s: key must have rank 4, got %d", opName, kNode.Shape.Rank())
 	}
 	switch qNode.Shape.DType {
 	case dtypes.F8E4M3FN, dtypes.F8E5M2:
 		return nil, errors.Wrapf(compute.ErrNotImplemented,
 			"%s: float8 input dtype %s is not implemented in the go backend", opName, qNode.Shape.DType)
 	}
+
+	numHeads := qNode.Shape.Dimensions[axesLayout.HeadsAxis()]
+	numKVHeads := kNode.Shape.Dimensions[axesLayout.HeadsAxis()]
+
 	if numHeads <= 0 || numKVHeads <= 0 || numHeads%numKVHeads != 0 {
 		return nil, errors.Errorf("%s: numHeads (%d) must be positive and divisible by numKVHeads (%d)", opName, numHeads, numKVHeads)
 	}
+
+	var scale float64
+	var causal bool
+	if options != nil {
+		scale = options.Scale
+		causal = options.Causal
+	}
+	if scale == 0 {
+		headDim := qNode.Shape.Dimensions[3] // headDim is always the last axis!
+		scale = 1.0 / math.Sqrt(float64(headDim))
+	}
+
 	if hasBias {
 		// Bias input is the last appended value; resolve its node from inputs.
 		biasIdx := len(inputs) - 1
@@ -150,7 +172,6 @@ func buildSDPANode(
 		}
 		// Score shape is [B, H, S, Skv]. Bias dims are right-aligned and each must be 1
 		// or equal to the corresponding score dim (standard broadcasting contract).
-		kNode := inputs[1]
 		var batchDim, numHeadsDim, seqDim, kvDim int
 		if axesLayout == compute.AxesLayoutBSHD {
 			batchDim = qNode.Shape.Dimensions[0]

--- a/internal/gobackend/fusedops/sdpa_direct_test.go
+++ b/internal/gobackend/fusedops/sdpa_direct_test.go
@@ -42,9 +42,11 @@ func TestSDPADirect_ConfigFieldsCompile(t *testing.T) {
 		QuantizedMatmuls: false,
 		QuerySeqLen:      nil,
 		KeyValueSeqLen:   nil,
+		Scale:            1.0,
+		Causal:           true,
 	}
 	got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, true, cfg)
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -69,8 +71,8 @@ func TestSDPADirect_WithSeqLens(t *testing.T) {
 	qLen := []int32{2}
 	kvLen := []int32{1}
 	got, err := testutil.Exec1(b, []any{q, k, v, qLen, kvLen}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4]}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, false, cfg)
+		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: false}
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -93,8 +95,8 @@ func TestSDPADirect_WithSeqLensCausal(t *testing.T) {
 	qLen := []int32{2}
 	kvLen := []int32{2}
 	got, err := testutil.Exec1(b, []any{q, k, v, qLen, kvLen}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4]}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, true, cfg)
+		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: true}
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -146,8 +148,8 @@ func TestSDPADirect_SeqLenWrongDtype(t *testing.T) {
 	qLen := []int64{2}
 	kvLen := []int64{2}
 	_, err := testutil.Exec1(b, []any{q, k, v, qLen, kvLen}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4]}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, false, cfg)
+		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: false}
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err == nil {
@@ -167,8 +169,8 @@ func TestSDPADirect_SeqLenClamped(t *testing.T) {
 	qLenNeg := []int32{-5}
 	kvLenPos := []int32{2}
 	got, err := testutil.Exec1(b, []any{q, k, v, qLenNeg, kvLenPos}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4]}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, false, cfg)
+		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: false}
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -184,8 +186,8 @@ func TestSDPADirect_SeqLenClamped(t *testing.T) {
 	qLenLarge := []int32{999}
 	kvLenLarge := []int32{999}
 	got2, err := testutil.Exec1(b, []any{q, k, v, qLenLarge, kvLenLarge}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4]}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, false, cfg)
+		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: false}
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -221,8 +223,8 @@ func TestSDPADirect_BiasValidation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := testutil.Exec1(b, []any{q, k, v, tc.bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3]}
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, false, cfg)
+				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3], Scale: 1.0, Causal: false}
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 				return out, err
 			})
 			if err == nil {
@@ -247,7 +249,7 @@ func TestSDPADirect_FP8NotImplemented(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConvertDType to F8E4M3FN failed: %+v", err)
 	}
-	_, _, err = mainFn.FusedScaledDotProductAttention(q8, q8, q8, nil, 1, 1, compute.AxesLayoutBHSD, 1.0, true, nil)
+	_, _, err = mainFn.FusedScaledDotProductAttention(q8, q8, q8, compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 	if err == nil {
 		t.Fatalf("SDPA with F8 input must return an error, got nil")
 	}

--- a/internal/gobackend/gen_opsregistration.go
+++ b/internal/gobackend/gen_opsregistration.go
@@ -345,20 +345,20 @@ func (f *Function) FusedQuantizedDense(x compute.Value, weights compute.Value, b
 	return RegisterFusedQuantizedDense.Fn(f, x, weights, bias, weightsQuantization, activation)
 }
 
-func (f *Function) FusedScaledDotProductAttention(query compute.Value, key compute.Value, value compute.Value, mask compute.Value, numHeads int, numKVHeads int, axesLayout compute.AxesLayout, scale float64, causal bool, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
+func (f *Function) FusedScaledDotProductAttention(query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
 	if RegisterFusedScaledDotProductAttention.Fn == nil {
 		// Operation not registered, fallback to notimplemented.Function, which will return the appropriate error.
-		return f.Function.FusedScaledDotProductAttention(query, key, value, mask, numHeads, numKVHeads, axesLayout, scale, causal, options)
+		return f.Function.FusedScaledDotProductAttention(query, key, value, axesLayout, options)
 	}
-	return RegisterFusedScaledDotProductAttention.Fn(f, query, key, value, mask, numHeads, numKVHeads, axesLayout, scale, causal, options)
+	return RegisterFusedScaledDotProductAttention.Fn(f, query, key, value, axesLayout, options)
 }
 
-func (f *Function) FusedScaledDotProductAttentionVJP(query compute.Value, key compute.Value, value compute.Value, mask compute.Value, numHeads int, numKVHeads int, axesLayout compute.AxesLayout, scale float64, causal bool, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery compute.Value, dKey compute.Value, dValue compute.Value, err error) {
+func (f *Function) FusedScaledDotProductAttentionVJP(query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery compute.Value, dKey compute.Value, dValue compute.Value, err error) {
 	if RegisterFusedScaledDotProductAttentionVJP.Fn == nil {
 		// Operation not registered, fallback to notimplemented.Function, which will return the appropriate error.
-		return f.Function.FusedScaledDotProductAttentionVJP(query, key, value, mask, numHeads, numKVHeads, axesLayout, scale, causal, options, output, statesForVJP, dOutput)
+		return f.Function.FusedScaledDotProductAttentionVJP(query, key, value, axesLayout, options, output, statesForVJP, dOutput)
 	}
-	return RegisterFusedScaledDotProductAttentionVJP.Fn(f, query, key, value, mask, numHeads, numKVHeads, axesLayout, scale, causal, options, output, statesForVJP, dOutput)
+	return RegisterFusedScaledDotProductAttentionVJP.Fn(f, query, key, value, axesLayout, options, output, statesForVJP, dOutput)
 }
 
 func (f *Function) FusedSoftmax(x compute.Value, axis int) (compute.Value, error) {
@@ -1049,10 +1049,10 @@ var (
 	RegisterFusedQuantizedDense = OpHandlerRegistration[func(f *Function, x compute.Value, weights compute.Value, bias compute.Value, weightsQuantization *compute.Quantization, activation compute.ActivationType) (compute.Value, error)]{
 		Method: "FusedQuantizedDense",
 	}
-	RegisterFusedScaledDotProductAttention = OpHandlerRegistration[func(f *Function, query compute.Value, key compute.Value, value compute.Value, mask compute.Value, numHeads int, numKVHeads int, axesLayout compute.AxesLayout, scale float64, causal bool, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error)]{
+	RegisterFusedScaledDotProductAttention = OpHandlerRegistration[func(f *Function, query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error)]{
 		Method: "FusedScaledDotProductAttention",
 	}
-	RegisterFusedScaledDotProductAttentionVJP = OpHandlerRegistration[func(f *Function, query compute.Value, key compute.Value, value compute.Value, mask compute.Value, numHeads int, numKVHeads int, axesLayout compute.AxesLayout, scale float64, causal bool, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery compute.Value, dKey compute.Value, dValue compute.Value, err error)]{
+	RegisterFusedScaledDotProductAttentionVJP = OpHandlerRegistration[func(f *Function, query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery compute.Value, dKey compute.Value, dValue compute.Value, err error)]{
 		Method: "FusedScaledDotProductAttentionVJP",
 	}
 	RegisterFusedSoftmax = OpHandlerRegistration[func(f *Function, x compute.Value, axis int) (compute.Value, error)]{

--- a/notimplemented/function.go
+++ b/notimplemented/function.go
@@ -123,10 +123,10 @@ func (f Function) OptimizationBarrier(operands ...compute.Value) ([]compute.Valu
 // FusedScaledDotProductAttention and its VJP have multi-value returns the notimplemented
 // generator does not template, so they are stubbed by hand.
 
-func (f Function) FusedScaledDotProductAttention(query, key, value, mask compute.Value, numHeads, numKVHeads int, axesLayout compute.AxesLayout, scale float64, causal bool, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
+func (f Function) FusedScaledDotProductAttention(query, key, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
 	return nil, nil, f.baseErrFn(compute.OpTypeFusedScaledDotProductAttention)
 }
 
-func (f Function) FusedScaledDotProductAttentionVJP(query, key, value, mask compute.Value, numHeads, numKVHeads int, axesLayout compute.AxesLayout, scale float64, causal bool, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery, dKey, dValue compute.Value, err error) {
+func (f Function) FusedScaledDotProductAttentionVJP(query, key, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery, dKey, dValue compute.Value, err error) {
 	return nil, nil, nil, errors.Wrapf(compute.ErrNotImplemented, "FusedScaledDotProductAttentionVJP not implemented by this backend")
 }

--- a/support/backendtest/fusedops.go
+++ b/support/backendtest/fusedops.go
@@ -218,7 +218,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float32{{{{1}, {1}}}}
 			v := [][][][]float32{{{{10}, {20}}}}
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, true, nil)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -243,7 +243,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]bfloat16.BFloat16{{{onesX8, onesX8}}}
 			v := [][][][]bfloat16.BFloat16{{{tensX8, twentyX8}}} // [1, 1, 2, 8]
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, true, nil)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -268,7 +268,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float16.Float16{{{onesX8, onesX8}}}
 			v := [][][][]float16.Float16{{{tensX8, twentyX8}}} // [1, 1, 2, 8]
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, true, nil)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -289,7 +289,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float32{{{{1}}, {{1}}}}
 			v := [][][][]float32{{{{10}}, {{20}}}}
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBSHD, 1.0, true, nil)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -314,7 +314,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]bfloat16.BFloat16{{{onesX8}, {onesX8}}}
 			v := [][][][]bfloat16.BFloat16{{{tensX8}, {twentyX8}}} // [1, 2, 1, 8]
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBSHD, 1.0, true, nil)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -340,7 +340,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float16.Float16{{{onesX8}, {onesX8}}}
 			v := [][][][]float16.Float16{{{tensX8}, {twentyX8}}} // [1, 2, 1, 8]
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBSHD, 1.0, true, nil)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -362,7 +362,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			v := [][][][]float32{{{{10}, {20}}}} // [1,1,2,1]
 			mask := [][]bool{{true, false}}      // [1, 2]
 			got, err := testutil.Exec1(b, []any{q, k, v, mask}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], params[3], 1, 1, compute.AxesLayoutBHSD, 1.0, false, nil)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: false, Mask: params[3]})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -382,7 +382,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float32{{{{1}, {1}}}}
 			v := [][][][]float32{{{{10}, {20}}}}
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, true, &compute.ScaledDotProductAttentionConfig{QuantizedMatmuls: true})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true, QuantizedMatmuls: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -410,8 +410,8 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			v := [][][][]float32{{{{10}, {20}}}}              // [1,1,2,1]
 			bias := [][][][]float32{{{{-10, 10}, {-10, 10}}}} // [1,1,2,2] batch,head,seqLen,kvLen
 			got, err := testutil.Exec1(b, []any{q, k, v, bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3]}
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, false, cfg)
+				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3], Scale: 1.0, Causal: false}
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -440,8 +440,8 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			v := [][][][]float32{{{{10}, {20}}}}            // [1,1,2,1]
 			bias := [][][][]float32{{{{0, -100}, {0, 10}}}} // [1,1,2,2]
 			got, err := testutil.Exec1(b, []any{q, k, v, bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3]}
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, true, cfg)
+				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3], Scale: 1.0, Causal: true}
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -477,8 +477,8 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 				{bf16(-100), bf16(100)},
 			}}}
 			got, err := testutil.Exec1(b, []any{q, k, v, bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3]}
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], nil, 1, 1, compute.AxesLayoutBHSD, 1.0, false, cfg)
+				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3], Scale: 1.0, Causal: false}
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {


### PR DESCRIPTION
This PR refactors the Fused Scaled Dot Product Attention (SDPA) interface in compute:

- Removed redundant numHeads and numKVHeads parameters (inferred directly from shape dimensions using axesLayout).
- Moved optional scale, causal, and mask parameters into ScaledDotProductAttentionConfig.
- Documented that Scale == 0 defaults to 1/sqrt(headDim).
- Updated the Go backend implementation, stubs, and unit/integration tests.