### PR TITLE
fastmath: fast float32 exp for fused softmax

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -40,6 +40,8 @@ auto-differentiation, use GoMLX instead.
   "Shardy". Somewhat experimental for now.
 - `internal/cmd`: mostly "generators" used to automatically generate code for
   different packages. Referred in `//go:generate ...` in the various packages.
+- `internal/fastmath`: float32 math approximations for go-backend kernels
+  where small error is acceptable (e.g. softmax, activations).
 - `internal/gobackend`: the implementation of the "go" backend. It consists of
   buffer and execution logic, and "registration" of ops during build and
   execution. The implementation of each op is (or is being moved to) in its

--- a/internal/fastmath/exp.go
+++ b/internal/fastmath/exp.go
@@ -1,0 +1,73 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package fastmath
+
+import (
+	"math"
+)
+
+// Float32 range limits for exp, matching Cephes expf.
+//
+// Outside [minLogF, maxLogF], a finite float32 exp either overflows the
+// normal range or underflows to a subnormal/zero. We clamp instead of
+// returning ±Inf / subnormals: overflow → maxNumF, underflow → 0.
+const (
+	maxNumF = 1.7014117331926442990585209174225846272e38 // largest finite Cephes float32 result
+	maxLogF = 88.02969187150841                          // ≈ 127 ln 2
+	minLogF = -88.02969187150841                         // ≈ -127 ln 2
+
+	log2E = 1.44269504088896341 // log₂(e) = 1/ln 2
+	ln2Hi = 0.693359375         // 355/512; high part of ln 2
+	ln2Lo = -2.12194440e-4      // ln2Hi+ln2Lo = ln 2 (split for accuracy)
+
+	// Cephes expf Remez coefficients for e^g on the reduced argument g ∈ [-ln2/2, ln2/2].
+	// Close to Taylor 1/n! but fitted for float32.
+	p7 = 1.9875691500e-4
+	p6 = 1.3981999507e-3
+	p5 = 8.3334519073e-3
+	p4 = 4.1665795894e-2
+	p3 = 1.6666665459e-1
+	p2 = 5.0000001201e-1
+)
+
+// Exp32 approximates e^x for float32.
+//
+// Algorithm (Cephes-style expf, Stephen L. Moshier):
+//  1. Clamp x to [minLogF, maxLogF] (see constants above).
+//  2. Reduce: x = n·ln2 + g with |g| ≤ ln2/2, n = round(x / ln2).
+//     ln2 is split (ln2Hi, ln2Lo) so n·ln2 is subtracted accurately.
+//  3. Approximate e^g with a degree-7 Horner polynomial (Cephes).
+//  4. Scale by exact 2^n via the float32 exponent field: bits (n+127)<<23.
+//
+// Accuracy vs math.Exp: max relative error < 1e-7 over the normal float32
+// range (see TestExp32Accuracy). Not bit-identical to math.Exp;
+// overflow/underflow return a large finite / 0 rather than ±Inf / subnormals.
+//
+// Intended for go-backend fused ops (softmax, etc.) where math.Exp on float32
+// dominates runtime and this precision is enough. Softmax always evaluates
+// exp(x-max) ≤ 1, so arguments are ≤ 0 and the overflow clamp is unused.
+func Exp32(x float32) float32 {
+	if x > maxLogF {
+		return maxNumF
+	}
+	if x < minLogF {
+		return 0
+	}
+
+	// n = round(x / ln 2); g = x - n·ln 2 (range-reduced remainder).
+	z := float32(math.Floor(float64(x)*log2E + 0.5))
+	g := x - z*ln2Hi - z*ln2Lo
+	n := int(z)
+
+	// Exact power-of-two scale: float32 exponent bits hold n + bias(127).
+	// Safe because the clamps keep n ∈ [-127, 127].
+	scale := math.Float32frombits(uint32(int32(n)+127) << 23)
+	return scale * expPoly(g)
+}
+
+// expPoly approximates e^x for |x| ≤ ln2/2 using Cephes's Horner polynomial:
+//
+//	e^x ≈ 1 + x + x²·P(x)
+func expPoly(x float32) float32 {
+	return (((((p7*x+p6)*x+p5)*x+p4)*x+p3)*x+p2)*(x*x) + x + 1.0
+}

--- a/internal/fastmath/exp.go
+++ b/internal/fastmath/exp.go
@@ -6,47 +6,34 @@ import (
 	"math"
 )
 
-// Float32 range limits for exp, matching Cephes expf.
-//
-// Outside [minLogF, maxLogF], a finite float32 exp either overflows the
-// normal range or underflows to a subnormal/zero. We clamp instead of
-// returning ±Inf / subnormals: overflow → maxNumF, underflow → 0.
-const (
-	maxNumF = 1.7014117331926442990585209174225846272e38 // largest finite Cephes float32 result
-	maxLogF = 88.02969187150841                          // ≈ 127 ln 2
-	minLogF = -88.02969187150841                         // ≈ -127 ln 2
-
-	log2E = 1.44269504088896341 // log₂(e) = 1/ln 2
-	ln2Hi = 0.693359375         // 355/512; high part of ln 2
-	ln2Lo = -2.12194440e-4      // ln2Hi+ln2Lo = ln 2 (split for accuracy)
-
-	// Cephes expf Remez coefficients for e^g on the reduced argument g ∈ [-ln2/2, ln2/2].
-	// Close to Taylor 1/n! but fitted for float32.
-	p7 = 1.9875691500e-4
-	p6 = 1.3981999507e-3
-	p5 = 8.3334519073e-3
-	p4 = 4.1665795894e-2
-	p3 = 1.6666665459e-1
-	p2 = 5.0000001201e-1
-)
-
 // Exp32 approximates e^x for float32.
 //
 // Algorithm (Cephes-style expf, Stephen L. Moshier):
-//  1. Clamp x to [minLogF, maxLogF] (see constants above).
+//  1. Clamp x to ≈ [-127 ln 2, 127 ln 2].
 //  2. Reduce: x = n·ln2 + g with |g| ≤ ln2/2, n = round(x / ln2).
-//     ln2 is split (ln2Hi, ln2Lo) so n·ln2 is subtracted accurately.
+//     ln2 is split (hi/lo) so n·ln2 is subtracted accurately.
 //  3. Approximate e^g with a degree-7 Horner polynomial (Cephes).
 //  4. Scale by exact 2^n via the float32 exponent field: bits (n+127)<<23.
 //
 // Accuracy vs math.Exp: max relative error < 1e-7 over the normal float32
-// range (see TestExp32Accuracy). Not bit-identical to math.Exp;
+// range (see TestExp32). Not bit-identical to math.Exp;
 // overflow/underflow return a large finite / 0 rather than ±Inf / subnormals.
 //
 // Intended for go-backend fused ops (softmax, etc.) where math.Exp on float32
 // dominates runtime and this precision is enough. Softmax always evaluates
 // exp(x-max) ≤ 1, so arguments are ≤ 0 and the overflow clamp is unused.
 func Exp32(x float32) float32 {
+	// Cephes expf range / reduction constants.
+	const (
+		maxNumF = 1.7014117331926442990585209174225846272e38 // largest finite Cephes float32 result
+		maxLogF = 88.02969187150841                          // ≈ 127 ln 2
+		minLogF = -88.02969187150841                         // ≈ -127 ln 2
+
+		log2E = 1.44269504088896341 // log₂(e) = 1/ln 2
+		ln2Hi = 0.693359375         // 355/512; high part of ln 2
+		ln2Lo = -2.12194440e-4      // ln2Hi+ln2Lo = ln 2 (split for accuracy)
+	)
+
 	if x > maxLogF {
 		return maxNumF
 	}
@@ -62,12 +49,22 @@ func Exp32(x float32) float32 {
 	// Exact power-of-two scale: float32 exponent bits hold n + bias(127).
 	// Safe because the clamps keep n ∈ [-127, 127].
 	scale := math.Float32frombits(uint32(int32(n)+127) << 23)
-	return scale * expPoly(g)
+	return scale * exp32Poly(g)
 }
 
-// expPoly approximates e^x for |x| ≤ ln2/2 using Cephes's Horner polynomial:
+// exp32Poly approximates e^x for |x| ≤ ln2/2 using Cephes's Horner polynomial:
 //
 //	e^x ≈ 1 + x + x²·P(x)
-func expPoly(x float32) float32 {
+func exp32Poly(x float32) float32 {
+	const (
+		// Cephes expf Remez coefficients for e^g on the reduced argument g ∈ [-ln2/2, ln2/2].
+		// Close to Taylor 1/n! but fitted for float32.
+		p7 = 1.9875691500e-4
+		p6 = 1.3981999507e-3
+		p5 = 8.3334519073e-3
+		p4 = 4.1665795894e-2
+		p3 = 1.6666665459e-1
+		p2 = 5.0000001201e-1
+	)
 	return (((((p7*x+p6)*x+p5)*x+p4)*x+p3)*x+p2)*(x*x) + x + 1.0
 }

--- a/internal/fastmath/exp_test.go
+++ b/internal/fastmath/exp_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package fastmath
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gomlx/compute/support/testutil"
+)
+
+func TestExp32(t *testing.T) {
+	t.Run("ExactAtZero", func(t *testing.T) {
+		if got := Exp32(0); got != 1 {
+			t.Errorf("Exp32(0) = %v, want exactly 1", got)
+		}
+	})
+
+	t.Run("Clamps", func(t *testing.T) {
+		if got := Exp32(maxLogF + 1); got != maxNumF {
+			t.Errorf("Exp32(maxLogF+1) = %v, want maxNumF %v", got, float32(maxNumF))
+		}
+		if got := Exp32(1e30); got != maxNumF {
+			t.Errorf("Exp32(1e30) = %v, want maxNumF %v", got, float32(maxNumF))
+		}
+		if got := Exp32(minLogF - 1); got != 0 {
+			t.Errorf("Exp32(minLogF-1) = %v, want 0", got)
+		}
+		if got := Exp32(-1e30); got != 0 {
+			t.Errorf("Exp32(-1e30) = %v, want 0", got)
+		}
+	})
+
+	t.Run("FiniteNonNegative", func(t *testing.T) {
+		for x := float32(-100); x <= 100; x += 0.002 {
+			got := Exp32(x)
+			if math.IsInf(float64(got), 0) || math.IsNaN(float64(got)) {
+				t.Fatalf("Exp32(%g) = %v, want finite", x, got)
+			}
+			if got < 0 {
+				t.Fatalf("Exp32(%g) = %v, want non-negative", x, got)
+			}
+		}
+	})
+
+	t.Run("Accuracy", func(t *testing.T) {
+		const bound = 1e-7
+		for x := float32(-87); x <= 88; x += 0.001 {
+			if ok, diff := testutil.IsInRelativeDelta(math.Exp(float64(x)), float64(Exp32(x)), bound); !ok {
+				t.Fatalf("relative error exceeds bound %.0e at x=%g:\n%s", bound, x, diff)
+			}
+		}
+	})
+}

--- a/internal/fastmath/exp_test.go
+++ b/internal/fastmath/exp_test.go
@@ -17,17 +17,18 @@ func TestExp32(t *testing.T) {
 	})
 
 	t.Run("Clamps", func(t *testing.T) {
-		if got := Exp32(maxLogF + 1); got != maxNumF {
-			t.Errorf("Exp32(maxLogF+1) = %v, want maxNumF %v", got, float32(maxNumF))
+		overflow := Exp32(1e30)
+		if math.IsInf(float64(overflow), 0) || math.IsNaN(float64(overflow)) || overflow <= 0 {
+			t.Errorf("Exp32(1e30) = %v, want large finite", overflow)
 		}
-		if got := Exp32(1e30); got != maxNumF {
-			t.Errorf("Exp32(1e30) = %v, want maxNumF %v", got, float32(maxNumF))
-		}
-		if got := Exp32(minLogF - 1); got != 0 {
-			t.Errorf("Exp32(minLogF-1) = %v, want 0", got)
+		if got := Exp32(90); got != overflow {
+			t.Errorf("Exp32(90) = %v, want same overflow clamp %v", got, overflow)
 		}
 		if got := Exp32(-1e30); got != 0 {
 			t.Errorf("Exp32(-1e30) = %v, want 0", got)
+		}
+		if got := Exp32(-90); got != 0 {
+			t.Errorf("Exp32(-90) = %v, want 0", got)
 		}
 	})
 

--- a/internal/fastmath/fastmath.go
+++ b/internal/fastmath/fastmath.go
@@ -1,0 +1,9 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+// Package fastmath provides faster float32 approximations of selected math
+// functions for use in go-backend kernels where small errors are acceptable
+// (e.g. softmax, activations).
+//
+// Not for paths that need standard-library accuracy or special-value behavior
+// (Inf, NaN, subnormals). Use math.* there instead.
+package fastmath

--- a/internal/gobackend/fusedops/softmax.go
+++ b/internal/gobackend/fusedops/softmax.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes"
+	"github.com/gomlx/compute/internal/fastmath"
 	"github.com/gomlx/compute/internal/gobackend"
 	"github.com/gomlx/compute/shapes"
 	"github.com/pkg/errors"
@@ -46,6 +47,7 @@ func FusedSoftmax(f *gobackend.Function, x compute.Value, axis int) (compute.Val
 
 // execFusedSoftmax implements optimized softmax with better cache locality.
 // Three passes over the axis: find max, compute exp(x-max) and sum, then normalize.
+// Float32 uses fastmath.Exp32; float64 uses math.Exp.
 func execFusedSoftmax(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, _ []bool) (*gobackend.Buffer, error) {
 	data := node.Data.(*nodeFusedSoftmax)
 	axis := data.axis
@@ -57,9 +59,9 @@ func execFusedSoftmax(backend *gobackend.Backend, node *gobackend.Node, inputs [
 
 	switch input.RawShape.DType {
 	case dtypes.Float32:
-		fusedSoftmax(input.Flat.([]float32), output.Flat.([]float32), axis, node.Shape)
+		fusedSoftmax(input.Flat.([]float32), output.Flat.([]float32), axis, node.Shape, fastmath.Exp32)
 	case dtypes.Float64:
-		fusedSoftmax(input.Flat.([]float64), output.Flat.([]float64), axis, node.Shape)
+		fusedSoftmax(input.Flat.([]float64), output.Flat.([]float64), axis, node.Shape, math.Exp)
 	default:
 		return nil, errors.Wrapf(compute.ErrNotImplemented, "FusedSoftmax: dtype %s", input.RawShape.DType)
 	}
@@ -83,7 +85,7 @@ func fusedSoftmaxComputeAxisStrides(shape shapes.Shape, axis int) (outerSize, ax
 	return
 }
 
-func fusedSoftmax[T float32 | float64](input, output []T, axis int, shape shapes.Shape) {
+func fusedSoftmax[T float32 | float64](input, output []T, axis int, shape shapes.Shape, expFn func(T) T) {
 	outerSize, axisSize, innerSize := fusedSoftmaxComputeAxisStrides(shape, axis)
 	for outer := range outerSize {
 		for inner := range innerSize {
@@ -102,7 +104,7 @@ func fusedSoftmax[T float32 | float64](input, output []T, axis int, shape shapes
 			var sum T
 			for i := range axisSize {
 				idx := baseIdx + i*innerSize
-				output[idx] = T(math.Exp(float64(input[idx] - maxVal)))
+				output[idx] = expFn(input[idx] - maxVal)
 				sum += output[idx]
 			}
 


### PR DESCRIPTION
## Summary

Speeds up the fused softmax float32 kernel by 35–42% (per tensor shape) by
replacing `math.Exp` with a fast float32 exp approximation, with no change to
memory use and no compliance regressions, with approximation error below the
project’s tolerance.

## Motivation

The go-backend has no JIT, so fused kernels are hand-written. Profiling the
fused softmax kernel showed `math.Exp` dominated its runtime — softmax's
middle pass calls it once per element, and `math.Exp` operates in float64 (with
the float32 kernel paying a convert-in/convert-out cost on top).

Softmax doesn't need full `math.Exp` precision: it evaluates `exp(x - max)`, so
every argument is `≤ 0`, and the result is immediately normalized. A float32
approximation with `< 1e-7` relative error is well within tolerance.

## What changed

- New `internal/fastmath` package with `Exp32`, a Cephes-style `expf`
  approximation (range reduction `e^x = 2^n · e^g` + a degree-7 Horner
  polynomial, with the `2^n` scale built directly from the float32 exponent
  bits). Maximum relative error is below `1e-7` versus `math.Exp` over
  `[-87, 0]`, covering the normal-output range relevant to softmax.
- `fusedSoftmax` takes an `expFn` parameter; the float32 path uses
  `fastmath.Exp32`, the float64 path is unchanged (`math.Exp`).

## Benchmarks

`BenchmarkSoftmax/Fused`, Apple M1 (`darwin/arm64`), interleaved
main-vs-branch. The table reports the median of 8 runs; statistical
significance was evaluated with `benchstat`:

| shape | before | after | Δ |
|---|---|---|---|
| 8×64 | 13.43µs | 8.68µs | −35.4% |
| 32×128 | 78.53µs | 46.96µs | −40.2% |
| 64×512 | 589.9µs | 340.1µs | −42.3% |
| 8×16×64 | 156.5µs | 92.16µs | −41.1% |
| 4×8×32×128 | 2.414ms | 1.398ms | −42.1% |

All Δ at `p < 0.001` (`n=8`). `B/op` and `allocs/op` unchanged. Measured
end-to-end through the backend + executor, so it reflects caller-visible time,
not an isolated microbenchmark.

## Correctness

- Fused softmax compliance suite (`TestCompliance/FusedOps/FusedSoftmax`:
  1D, 2D, NegativeAxis, Stability) passes unchanged.
- New `Exp32` unit tests: exactness at 0, clamp behavior, finite/non-negative
  over `[-100, 100]` (guards an underflow edge case), and relative error
  `< 1e-7` vs `math.Exp`.

## Attribution

The float32 exp is derived from Cephes `expf` (Stephen L. Moshier) — the
range-reduction constants and polynomial coefficients are the standard Cephes
values, reimplemented in Go and credited in the source.