### PR TITLE
Added FusedDense layout

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2026-07-28:
+  - Updated FusedDense to take a `DenseConfig` options parameter, which now includes layout information of the weights.
+  - Renamed `AxesLayout` -> `AttentionAxesLayout` (since it's for attention only).
+
 # Initial release
 
 - Moved GoMLX's `backends/simplego` to `gobackend`.

--- a/fused_ops.go
+++ b/fused_ops.go
@@ -2,25 +2,25 @@
 
 package compute
 
-// AxesLayout specifies the ordering of axes in 4D attention tensors.
-type AxesLayout int
+// AttentionAxesLayout specifies the ordering of axes in 4D attention tensors.
+type AttentionAxesLayout int
 
 const (
-	// AxesLayoutBHSD is the [batch, heads, seq, dim] layout used by PyTorch's F.scaled_dot_product_attention,
+	// AttentionAxesLayoutBHSD is the [batch, heads, seq, dim] layout used by PyTorch's F.scaled_dot_product_attention,
 	// ONNX, and most inference runtimes.
-	AxesLayoutBHSD AxesLayout = iota
+	AttentionAxesLayoutBHSD AttentionAxesLayout = iota
 
-	// AxesLayoutBSHD is the [batch, seq, heads, dim] layout used internally by MultiHeadAttention
+	// AttentionAxesLayoutBSHD is the [batch, seq, heads, dim] layout used internally by MultiHeadAttention
 	// (after Dense projections which produce [batch, seq, heads, dim]).
-	AxesLayoutBSHD
+	AttentionAxesLayoutBSHD
 )
 
 // String returns the name of the layout.
-func (l AxesLayout) String() string {
+func (l AttentionAxesLayout) String() string {
 	switch l {
-	case AxesLayoutBHSD:
+	case AttentionAxesLayoutBHSD:
 		return "BHSD"
-	case AxesLayoutBSHD:
+	case AttentionAxesLayoutBSHD:
 		return "BSHD"
 	default:
 		return "unknown"
@@ -28,23 +28,53 @@ func (l AxesLayout) String() string {
 }
 
 // SeqAxis returns the axis index for the sequence dimension.
-func (l AxesLayout) SeqAxis() int {
+func (l AttentionAxesLayout) SeqAxis() int {
 	switch l {
-	case AxesLayoutBSHD:
+	case AttentionAxesLayoutBSHD:
 		return 1
-	default: // AxesLayoutBHSD
+	default: // AttentionAxesLayoutBHSD
 		return 2
 	}
 }
 
 // HeadsAxis returns the axis index for the heads dimension.
-func (l AxesLayout) HeadsAxis() int {
+func (l AttentionAxesLayout) HeadsAxis() int {
 	switch l {
-	case AxesLayoutBSHD:
+	case AttentionAxesLayoutBSHD:
 		return 2
-	default: // AxesLayoutBHSD
+	default: // AttentionAxesLayoutBHSD
 		return 1
 	}
+}
+
+// DenseLayout specifies the layout (axis ordering) of the weight matrix in Dense operations.
+type DenseLayout int
+
+const (
+	// DenseLayoutInputOutputs specifies that weights have shape [in_features, out_features...] (0, default).
+	DenseLayoutInputOutputs DenseLayout = iota
+	// DenseLayoutOutputsInput specifies that weights have shape [out_features..., in_features].
+	DenseLayoutOutputsInput
+)
+
+// String returns the name of the dense weight layout.
+func (l DenseLayout) String() string {
+	switch l {
+	case DenseLayoutInputOutputs:
+		return "InputOutputs"
+	case DenseLayoutOutputsInput:
+		return "OutputsInput"
+	default:
+		return "unknown"
+	}
+}
+
+// DenseConfig holds configuration parameters for FusedDense operations.
+type DenseConfig struct {
+	// Activation is applied after the matmul+bias; set to ActivationNone for no activation.
+	Activation ActivationType
+	// WeightLayout specifies the layout of the weight matrix (DenseLayoutInputOutputs or DenseLayoutOutputsInput).
+	WeightLayout DenseLayout
 }
 
 // QuantizationScheme specifies how quantized integer values map to floating-point values.
@@ -305,13 +335,16 @@ type FusedOps interface {
 
 	// FusedDense performs fused matmul + optional bias + optional activation.
 	//
-	// It does y = activation(x @ W + bias). Where @ is a standard matmul,
-	// it contracts x's last axis with weight's first axis.
+	// It does y = activation(x @ W + bias) for DenseLayoutInputOutputs, or
+	// y = activation(x @ W^T + bias) for DenseLayoutOutputsInput.
+	// Where @ is a standard matmul.
 	//
-	// - x: [batch..., in_features], weight: [in_features, out_features...],
+	// - x: [batch..., in_features]
+	// - weight: [in_features, out_features...] (if WeightLayout is DenseLayoutInputOutputs)
+	//   or [out_features..., in_features] (if WeightLayout is DenseLayoutOutputsInput)
 	// - bias: [out_features...] (nil-able).
-	// - activation: applied after the matmul+bias; set to ActivationNone for no activation.
-	FusedDense(x, weight, bias Value, activation ActivationType) (Value, error)
+	// - options: DenseConfig options (activation and weight layout).
+	FusedDense(x, weight, bias Value, options DenseConfig) (Value, error)
 
 	// FusedScaledDotProductAttention computes multi-head scaled dot-product attention.
 	//
@@ -323,9 +356,9 @@ type FusedOps interface {
 	//
 	// Inputs:
 	//   - query, key, value: 4D tensors whose axis ordering is determined by axesLayout.
-	//     For AxesLayoutBHSD: query [batch, numHeads, seqLen, headDim],
+	//     For AttentionAxesLayoutBHSD: query [batch, numHeads, seqLen, headDim],
 	//                         key/value [batch, numKVHeads, kvLen, headDim].
-	//     For AxesLayoutBSHD: query [batch, seqLen, numHeads, headDim],
+	//     For AttentionAxesLayoutBSHD: query [batch, seqLen, numHeads, headDim],
 	//                         key/value [batch, kvLen, numKVHeads, headDim].
 	//   - axesLayout: determines the axis ordering of query/key/value tensors
 	//   - options: optional parameters (nil uses defaults). See ScaledDotProductAttentionConfig.
@@ -341,7 +374,7 @@ type FusedOps interface {
 	//     VJP, so the caller differentiates the decomposed attention instead.
 	FusedScaledDotProductAttention(
 		query, key, value Value,
-		axesLayout AxesLayout,
+		axesLayout AttentionAxesLayout,
 		options *ScaledDotProductAttentionConfig) (output Value, statesForVJP []Value, err error)
 
 	// FusedScaledDotProductAttentionVJP computes the gradients (dQuery, dKey, dValue) of
@@ -354,7 +387,7 @@ type FusedOps interface {
 	// the caller falls back to differentiating the decomposed attention.
 	FusedScaledDotProductAttentionVJP(
 		query, key, value Value,
-		axesLayout AxesLayout,
+		axesLayout AttentionAxesLayout,
 		options *ScaledDotProductAttentionConfig,
 		output Value, statesForVJP []Value, dOutput Value) (dQuery, dKey, dValue Value, err error)
 

--- a/internal/cmd/gobackend_opsregistration/opsregistration.go
+++ b/internal/cmd/gobackend_opsregistration/opsregistration.go
@@ -140,8 +140,14 @@ func normalizeParameterTypes(method *backendparser.Method) {
 				param.Type = "...compute.PadAxis"
 			case "ActivationType":
 				param.Type = "compute.ActivationType"
+			case "DenseConfig":
+				param.Type = "compute.DenseConfig"
+			case "DenseLayout":
+				param.Type = "compute.DenseLayout"
+			case "AttentionAxesLayout":
+				param.Type = "compute.AttentionAxesLayout"
 			case "AxesLayout":
-				param.Type = "compute.AxesLayout"
+				param.Type = "compute.AttentionAxesLayout"
 			case "QuantizationScheme":
 				param.Type = "compute.QuantizationScheme"
 			case "DotGeneralConfig":

--- a/internal/cmd/notimplemented_generator/standardops.go
+++ b/internal/cmd/notimplemented_generator/standardops.go
@@ -92,8 +92,14 @@ func GenerateStandardOpsInterface(methods []backendparser.Method) {
 				pi.Type = "...compute.PadAxis"
 			case "ActivationType":
 				pi.Type = "compute.ActivationType"
+			case "DenseConfig":
+				pi.Type = "compute.DenseConfig"
+			case "DenseLayout":
+				pi.Type = "compute.DenseLayout"
+			case "AttentionAxesLayout":
+				pi.Type = "compute.AttentionAxesLayout"
 			case "AxesLayout":
-				pi.Type = "compute.AxesLayout"
+				pi.Type = "compute.AttentionAxesLayout"
 			case "QuantizationScheme":
 				pi.Type = "compute.QuantizationScheme"
 			case "DotGeneralConfig":

--- a/internal/gobackend/fusedops/dense.go
+++ b/internal/gobackend/fusedops/dense.go
@@ -16,21 +16,22 @@ func init() {
 }
 
 type nodeFusedDense struct {
-	activation compute.ActivationType
+	options compute.DenseConfig
 }
 
 func (d *nodeFusedDense) EqualNodeData(other gobackend.NodeDataComparable) bool {
-	return d.activation == other.(*nodeFusedDense).activation
+	return d.options == other.(*nodeFusedDense).options
 }
 
 // FusedDense performs fused matmul + optional bias + optional activation:
 //
-//	y = activation(x @ W + bias)
+//	y = activation(x @ W + bias) (for DenseLayoutInputOutputs)
+//	y = activation(x @ W^T + bias) (for DenseLayoutOutputsInput)
 //
 // The matmul is delegated to DotGeneral (which selects the optimal execution
 // path at build time). FusedDense then adds bias and applies activation on top
 // of the DotGeneral result.
-func FusedDense(f *gobackend.Function, x, weight, bias compute.Value, activation compute.ActivationType) (compute.Value, error) {
+func FusedDense(f *gobackend.Function, x, weight, bias compute.Value, options compute.DenseConfig) (compute.Value, error) {
 	values := []compute.Value{x, weight}
 	if bias != nil {
 		values = append(values, bias)
@@ -47,18 +48,38 @@ func FusedDense(f *gobackend.Function, x, weight, bias compute.Value, activation
 			xNode.Shape.Rank(), wNode.Shape.Rank())
 	}
 	inFeatures := xNode.Shape.Dimensions[xNode.Shape.Rank()-1]
-	if inFeatures != wNode.Shape.Dimensions[0] {
-		return nil, errors.Errorf("FusedDense: x's last dim (%d) must match weight's first dim (%d)",
-			inFeatures, wNode.Shape.Dimensions[0])
+
+	var weightContractAxis int
+	var outDims []int
+
+	switch options.WeightLayout {
+	case compute.DenseLayoutInputOutputs:
+		if inFeatures != wNode.Shape.Dimensions[0] {
+			return nil, errors.Errorf("FusedDense: x's last dim (%d) must match weight's first dim (%d) for DenseLayoutInputOutputs",
+				inFeatures, wNode.Shape.Dimensions[0])
+		}
+		weightContractAxis = 0
+		outDims = make([]int, xNode.Shape.Rank()-1+wNode.Shape.Rank()-1)
+		copy(outDims, xNode.Shape.Dimensions[:xNode.Shape.Rank()-1])
+		copy(outDims[xNode.Shape.Rank()-1:], wNode.Shape.Dimensions[1:])
+	case compute.DenseLayoutOutputsInput:
+		weightLastAxis := wNode.Shape.Rank() - 1
+		if inFeatures != wNode.Shape.Dimensions[weightLastAxis] {
+			return nil, errors.Errorf("FusedDense: x's last dim (%d) must match weight's last dim (%d) for DenseLayoutOutputsInput",
+				inFeatures, wNode.Shape.Dimensions[weightLastAxis])
+		}
+		weightContractAxis = weightLastAxis
+		outDims = make([]int, xNode.Shape.Rank()-1+wNode.Shape.Rank()-1)
+		copy(outDims, xNode.Shape.Dimensions[:xNode.Shape.Rank()-1])
+		copy(outDims[xNode.Shape.Rank()-1:], wNode.Shape.Dimensions[:weightLastAxis])
+	default:
+		return nil, errors.Errorf("FusedDense: unknown WeightLayout %v", options.WeightLayout)
 	}
 
-	outDims := make([]int, xNode.Shape.Rank()-1+wNode.Shape.Rank()-1)
-	copy(outDims, xNode.Shape.Dimensions[:xNode.Shape.Rank()-1])
-	copy(outDims[xNode.Shape.Rank()-1:], wNode.Shape.Dimensions[1:])
 	outShape := shapes.Make(xNode.Shape.DType, outDims...)
 
-	// Build DotGeneral sub-node for the matmul: contract x's last axis with weight's first.
-	dotResult, err := f.DotGeneral(xNode, []int{xNode.Shape.Rank() - 1}, nil, wNode, []int{0}, nil, compute.DotGeneralConfig{})
+	// Build DotGeneral sub-node for the matmul: contract x's last axis with weight's specified contract axis.
+	dotResult, err := f.DotGeneral(xNode, []int{xNode.Shape.Rank() - 1}, nil, wNode, []int{weightContractAxis}, nil, compute.DotGeneralConfig{})
 	if err != nil {
 		return nil, errors.WithMessagef(err, "FusedDense: DotGeneral")
 	}
@@ -73,7 +94,7 @@ func FusedDense(f *gobackend.Function, x, weight, bias compute.Value, activation
 		fusedInputs = append(fusedInputs, inputs[2])
 	}
 
-	data := &nodeFusedDense{activation: activation}
+	data := &nodeFusedDense{options: options}
 	node, _ := f.GetOrCreateNode(compute.OpTypeFusedDense, outShape, fusedInputs, data)
 	return node, nil
 }
@@ -93,7 +114,7 @@ func execFusedDense(backend *gobackend.Backend, node *gobackend.Node, inputs []*
 	data := node.Data.(*nodeFusedDense)
 
 	// If no bias and no activation, just return the matmul result directly.
-	if bias == nil && data.activation == compute.ActivationNone {
+	if bias == nil && data.options.Activation == compute.ActivationNone {
 		if inputsOwned[0] {
 			inputs[0] = nil // Signal to executor that we reused the input.
 			return matmul, nil
@@ -125,12 +146,12 @@ func execFusedDense(backend *gobackend.Backend, node *gobackend.Node, inputs []*
 		if bias != nil {
 			fusedDenseAddBias[float32](output, bias)
 		}
-		fusedDenseApplyActivation[float32](backend, output, data.activation)
+		fusedDenseApplyActivation[float32](backend, output, data.options.Activation)
 	case dtypes.Float64:
 		if bias != nil {
 			fusedDenseAddBias[float64](output, bias)
 		}
-		fusedDenseApplyActivation[float64](backend, output, data.activation)
+		fusedDenseApplyActivation[float64](backend, output, data.options.Activation)
 	default:
 		return nil, errors.Wrapf(compute.ErrNotImplemented, "FusedDense: dtype %s", output.RawShape.DType)
 	}

--- a/internal/gobackend/fusedops/sdpa.go
+++ b/internal/gobackend/fusedops/sdpa.go
@@ -17,9 +17,9 @@ import (
 //
 // Inputs:
 //   - query, key, value: 4D tensors whose axis ordering is determined by axesLayout.
-//     For AxesLayoutBHSD: query [batch, numHeads, seqLen, headDim],
+//     For AttentionAxesLayoutBHSD: query [batch, numHeads, seqLen, headDim],
 //     key/value [batch, numKVHeads, kvLen, headDim].
-//     For AxesLayoutBSHD: query [batch, seqLen, numHeads, headDim],
+//     For AttentionAxesLayoutBSHD: query [batch, seqLen, numHeads, headDim],
 //     key/value [batch, kvLen, numKVHeads, headDim].
 //   - mask: [seqLen, kvLen] (seqLen is the query sequence length): optional (can be nil) mask
 //     that can be either boolean or additive (any dtype other than Bool). See also causal below.
@@ -41,7 +41,7 @@ import (
 func FusedScaledDotProductAttention(
 	f *gobackend.Function,
 	query, key, value compute.Value,
-	axesLayout compute.AxesLayout,
+	axesLayout compute.AttentionAxesLayout,
 	options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
 	// The Go backend has no fused flash backward, so it returns nil statesForVJP; its gradient
 	// goes through the decomposed path (FusedScaledDotProductAttentionVJP is ErrNotImplemented).
@@ -63,7 +63,7 @@ func init() {
 type nodeScaledDotProductAttention struct {
 	numHeads   int
 	numKVHeads int
-	axesLayout compute.AxesLayout
+	axesLayout compute.AttentionAxesLayout
 	scale      float64
 	causal     bool
 	hasMask    bool
@@ -98,7 +98,7 @@ func (d *nodeScaledDotProductAttention) equalOptions(o *nodeScaledDotProductAtte
 func buildSDPANode(
 	f *gobackend.Function, opType compute.OpType, opName string,
 	query, key, value compute.Value,
-	axesLayout compute.AxesLayout,
+	axesLayout compute.AttentionAxesLayout,
 	options *compute.ScaledDotProductAttentionConfig) (compute.Value, error) {
 	var mask compute.Value
 	if options != nil {
@@ -173,7 +173,7 @@ func buildSDPANode(
 		// Score shape is [B, H, S, Skv]. Bias dims are right-aligned and each must be 1
 		// or equal to the corresponding score dim (standard broadcasting contract).
 		var batchDim, numHeadsDim, seqDim, kvDim int
-		if axesLayout == compute.AxesLayoutBSHD {
+		if axesLayout == compute.AttentionAxesLayoutBSHD {
 			batchDim = qNode.Shape.Dimensions[0]
 			numHeadsDim = numHeads
 			seqDim = qNode.Shape.Dimensions[1]
@@ -256,7 +256,7 @@ func execFusedScaledDotProductAttention(backend *gobackend.Backend, node *goback
 
 	// For rank-4 BSHD masks/bias [batch, seq, heads, kvLen], transpose to BHSD so that
 	// per-head data is contiguous [seqLen, kvLen]. Rank ≤ 3 have no head axis and work as-is.
-	if data.axesLayout == compute.AxesLayoutBSHD {
+	if data.axesLayout == compute.AttentionAxesLayoutBSHD {
 		if mask != nil && mask.RawShape.Rank() == 4 {
 			var err error
 			mask, err = transposeBuffer(backend, mask, []int{0, 2, 1, 3})
@@ -551,7 +551,7 @@ func sdpaMultiHeadGeneric[T float32 | float64](query, key, value, mask, bias, ou
 	var qBatchStride, kvBatchStride int // element stride between consecutive batches
 	var qHeadStride, kvHeadStride int   // element stride between consecutive heads at seq=0
 
-	if data.axesLayout == compute.AxesLayoutBSHD {
+	if data.axesLayout == compute.AttentionAxesLayoutBSHD {
 		// [batch, seq, heads, dim]
 		seqLen = dims[1]
 		headDim = dims[3]

--- a/internal/gobackend/fusedops/sdpa_direct_test.go
+++ b/internal/gobackend/fusedops/sdpa_direct_test.go
@@ -46,7 +46,7 @@ func TestSDPADirect_ConfigFieldsCompile(t *testing.T) {
 		Causal:           true,
 	}
 	got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -72,7 +72,7 @@ func TestSDPADirect_WithSeqLens(t *testing.T) {
 	kvLen := []int32{1}
 	got, err := testutil.Exec1(b, []any{q, k, v, qLen, kvLen}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: false}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -96,7 +96,7 @@ func TestSDPADirect_WithSeqLensCausal(t *testing.T) {
 	kvLen := []int32{2}
 	got, err := testutil.Exec1(b, []any{q, k, v, qLen, kvLen}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: true}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -149,7 +149,7 @@ func TestSDPADirect_SeqLenWrongDtype(t *testing.T) {
 	kvLen := []int64{2}
 	_, err := testutil.Exec1(b, []any{q, k, v, qLen, kvLen}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: false}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err == nil {
@@ -170,7 +170,7 @@ func TestSDPADirect_SeqLenClamped(t *testing.T) {
 	kvLenPos := []int32{2}
 	got, err := testutil.Exec1(b, []any{q, k, v, qLenNeg, kvLenPos}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: false}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -187,7 +187,7 @@ func TestSDPADirect_SeqLenClamped(t *testing.T) {
 	kvLenLarge := []int32{999}
 	got2, err := testutil.Exec1(b, []any{q, k, v, qLenLarge, kvLenLarge}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 		cfg := &compute.ScaledDotProductAttentionConfig{QuerySeqLen: params[3], KeyValueSeqLen: params[4], Scale: 1.0, Causal: false}
-		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+		out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 		return out, err
 	})
 	if err != nil {
@@ -224,7 +224,7 @@ func TestSDPADirect_BiasValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := testutil.Exec1(b, []any{q, k, v, tc.bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3], Scale: 1.0, Causal: false}
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 				return out, err
 			})
 			if err == nil {
@@ -249,7 +249,7 @@ func TestSDPADirect_FP8NotImplemented(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConvertDType to F8E4M3FN failed: %+v", err)
 	}
-	_, _, err = mainFn.FusedScaledDotProductAttention(q8, q8, q8, compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
+	_, _, err = mainFn.FusedScaledDotProductAttention(q8, q8, q8, compute.AttentionAxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 	if err == nil {
 		t.Fatalf("SDPA with F8 input must return an error, got nil")
 	}

--- a/internal/gobackend/gen_opsregistration.go
+++ b/internal/gobackend/gen_opsregistration.go
@@ -313,12 +313,12 @@ func (f *Function) FusedAttentionQKVProjection(x compute.Value, wQKV compute.Val
 	return RegisterFusedAttentionQKVProjection.Fn(f, x, wQKV, biasQ, biasK, biasV, queryDim, keyValueDim)
 }
 
-func (f *Function) FusedDense(x compute.Value, weight compute.Value, bias compute.Value, activation compute.ActivationType) (compute.Value, error) {
+func (f *Function) FusedDense(x compute.Value, weight compute.Value, bias compute.Value, options compute.DenseConfig) (compute.Value, error) {
 	if RegisterFusedDense.Fn == nil {
 		// Operation not registered, fallback to notimplemented.Function, which will return the appropriate error.
-		return f.Function.FusedDense(x, weight, bias, activation)
+		return f.Function.FusedDense(x, weight, bias, options)
 	}
-	return RegisterFusedDense.Fn(f, x, weight, bias, activation)
+	return RegisterFusedDense.Fn(f, x, weight, bias, options)
 }
 
 func (f *Function) FusedGelu(x compute.Value, exact bool) (compute.Value, error) {
@@ -345,7 +345,7 @@ func (f *Function) FusedQuantizedDense(x compute.Value, weights compute.Value, b
 	return RegisterFusedQuantizedDense.Fn(f, x, weights, bias, weightsQuantization, activation)
 }
 
-func (f *Function) FusedScaledDotProductAttention(query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
+func (f *Function) FusedScaledDotProductAttention(query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AttentionAxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
 	if RegisterFusedScaledDotProductAttention.Fn == nil {
 		// Operation not registered, fallback to notimplemented.Function, which will return the appropriate error.
 		return f.Function.FusedScaledDotProductAttention(query, key, value, axesLayout, options)
@@ -353,7 +353,7 @@ func (f *Function) FusedScaledDotProductAttention(query compute.Value, key compu
 	return RegisterFusedScaledDotProductAttention.Fn(f, query, key, value, axesLayout, options)
 }
 
-func (f *Function) FusedScaledDotProductAttentionVJP(query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery compute.Value, dKey compute.Value, dValue compute.Value, err error) {
+func (f *Function) FusedScaledDotProductAttentionVJP(query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AttentionAxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery compute.Value, dKey compute.Value, dValue compute.Value, err error) {
 	if RegisterFusedScaledDotProductAttentionVJP.Fn == nil {
 		// Operation not registered, fallback to notimplemented.Function, which will return the appropriate error.
 		return f.Function.FusedScaledDotProductAttentionVJP(query, key, value, axesLayout, options, output, statesForVJP, dOutput)
@@ -1037,7 +1037,7 @@ var (
 	RegisterFusedAttentionQKVProjection = OpHandlerRegistration[func(f *Function, x compute.Value, wQKV compute.Value, biasQ compute.Value, biasK compute.Value, biasV compute.Value, queryDim int, keyValueDim int) (query compute.Value, key compute.Value, value compute.Value, err error)]{
 		Method: "FusedAttentionQKVProjection",
 	}
-	RegisterFusedDense = OpHandlerRegistration[func(f *Function, x compute.Value, weight compute.Value, bias compute.Value, activation compute.ActivationType) (compute.Value, error)]{
+	RegisterFusedDense = OpHandlerRegistration[func(f *Function, x compute.Value, weight compute.Value, bias compute.Value, options compute.DenseConfig) (compute.Value, error)]{
 		Method: "FusedDense",
 	}
 	RegisterFusedGelu = OpHandlerRegistration[func(f *Function, x compute.Value, exact bool) (compute.Value, error)]{
@@ -1049,10 +1049,10 @@ var (
 	RegisterFusedQuantizedDense = OpHandlerRegistration[func(f *Function, x compute.Value, weights compute.Value, bias compute.Value, weightsQuantization *compute.Quantization, activation compute.ActivationType) (compute.Value, error)]{
 		Method: "FusedQuantizedDense",
 	}
-	RegisterFusedScaledDotProductAttention = OpHandlerRegistration[func(f *Function, query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error)]{
+	RegisterFusedScaledDotProductAttention = OpHandlerRegistration[func(f *Function, query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AttentionAxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error)]{
 		Method: "FusedScaledDotProductAttention",
 	}
-	RegisterFusedScaledDotProductAttentionVJP = OpHandlerRegistration[func(f *Function, query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery compute.Value, dKey compute.Value, dValue compute.Value, err error)]{
+	RegisterFusedScaledDotProductAttentionVJP = OpHandlerRegistration[func(f *Function, query compute.Value, key compute.Value, value compute.Value, axesLayout compute.AttentionAxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery compute.Value, dKey compute.Value, dValue compute.Value, err error)]{
 		Method: "FusedScaledDotProductAttentionVJP",
 	}
 	RegisterFusedSoftmax = OpHandlerRegistration[func(f *Function, x compute.Value, axis int) (compute.Value, error)]{

--- a/notimplemented/function.go
+++ b/notimplemented/function.go
@@ -123,10 +123,10 @@ func (f Function) OptimizationBarrier(operands ...compute.Value) ([]compute.Valu
 // FusedScaledDotProductAttention and its VJP have multi-value returns the notimplemented
 // generator does not template, so they are stubbed by hand.
 
-func (f Function) FusedScaledDotProductAttention(query, key, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
+func (f Function) FusedScaledDotProductAttention(query, key, value compute.Value, axesLayout compute.AttentionAxesLayout, options *compute.ScaledDotProductAttentionConfig) (output compute.Value, statesForVJP []compute.Value, err error) {
 	return nil, nil, f.baseErrFn(compute.OpTypeFusedScaledDotProductAttention)
 }
 
-func (f Function) FusedScaledDotProductAttentionVJP(query, key, value compute.Value, axesLayout compute.AxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery, dKey, dValue compute.Value, err error) {
+func (f Function) FusedScaledDotProductAttentionVJP(query, key, value compute.Value, axesLayout compute.AttentionAxesLayout, options *compute.ScaledDotProductAttentionConfig, output compute.Value, statesForVJP []compute.Value, dOutput compute.Value) (dQuery, dKey, dValue compute.Value, err error) {
 	return nil, nil, nil, errors.Wrapf(compute.ErrNotImplemented, "FusedScaledDotProductAttentionVJP not implemented by this backend")
 }

--- a/notimplemented/gen_standard_ops.go
+++ b/notimplemented/gen_standard_ops.go
@@ -317,13 +317,16 @@ func (f Function) Floor(x compute.Value) (compute.Value, error) {
 
 // FusedDense performs fused matmul + optional bias + optional activation.
 //
-// It does y = activation(x @ W + bias). Where @ is a standard matmul,
-// it contracts x's last axis with weight's first axis.
+// It does y = activation(x @ W + bias) for DenseLayoutInputOutputs, or
+// y = activation(x @ W^T + bias) for DenseLayoutOutputsInput.
+// Where @ is a standard matmul.
 //
-// - x: [batch..., in_features], weight: [in_features, out_features...],
-// - bias: [out_features...] (nil-able).
-// - activation: applied after the matmul+bias; set to ActivationNone for no activation.
-func (f Function) FusedDense(x compute.Value, weight compute.Value, bias compute.Value, activation compute.ActivationType) (compute.Value, error) {
+//   - x: [batch..., in_features]
+//   - weight: [in_features, out_features...] (if WeightLayout is DenseLayoutInputOutputs)
+//     or [out_features..., in_features] (if WeightLayout is DenseLayoutOutputsInput)
+//   - bias: [out_features...] (nil-able).
+//   - options: DenseConfig options (activation and weight layout).
+func (f Function) FusedDense(x compute.Value, weight compute.Value, bias compute.Value, options compute.DenseConfig) (compute.Value, error) {
 	return nil, f.baseErrFn(compute.OpTypeFusedDense)
 }
 

--- a/support/backendtest/benchmarks.go
+++ b/support/backendtest/benchmarks.go
@@ -380,7 +380,7 @@ func BenchmarkDense(b *testing.B, backend compute.Backend) {
 
 		fused, err := newBenchExec(backend, allShapes, allDatas,
 			func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				return f.FusedDense(params[0], params[1], params[2], compute.ActivationNone)
+				return f.FusedDense(params[0], params[1], params[2], compute.DenseConfig{Activation: compute.ActivationNone})
 			})
 		if err != nil {
 			b.Fatalf("Failed to create fused benchmark: %+v", err)
@@ -552,7 +552,7 @@ func BenchmarkQuantizedDense(b *testing.B, backend compute.Backend) {
 			[]shapes.Shape{xShape, f32WeightsShape, biasShape},
 			[]any{xData, f32WeightsData, biasData},
 			func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				return f.FusedDense(params[0], params[1], params[2], compute.ActivationNone)
+				return f.FusedDense(params[0], params[1], params[2], compute.DenseConfig{Activation: compute.ActivationNone})
 			})
 		if err != nil {
 			b.Fatalf("Failed to create Float32Dense benchmark: %+v", err)

--- a/support/backendtest/fusedops.go
+++ b/support/backendtest/fusedops.go
@@ -183,7 +183,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 
 		t.Run("None", func(t *testing.T) {
 			got, err := testutil.Exec1(b, []any{x, w, bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				return f.FusedDense(params[0], params[1], params[2], compute.ActivationNone)
+				return f.FusedDense(params[0], params[1], params[2], compute.DenseConfig{Activation: compute.ActivationNone})
 			})
 			if err != nil {
 				t.Fatalf("FusedDense failed: %+v", err)
@@ -199,7 +199,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			w2 := [][]float32{{1, 1}, {0, -1}}
 			b2 := []float32{-1, -1}
 			got, err := testutil.Exec1(b, []any{x2, w2, b2}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				return f.FusedDense(params[0], params[1], params[2], compute.ActivationRelu)
+				return f.FusedDense(params[0], params[1], params[2], compute.DenseConfig{Activation: compute.ActivationRelu})
 			})
 			if err != nil {
 				t.Fatalf("FusedDense failed: %+v", err)
@@ -218,7 +218,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float32{{{{1}, {1}}}}
 			v := [][][][]float32{{{{10}, {20}}}}
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -243,7 +243,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]bfloat16.BFloat16{{{onesX8, onesX8}}}
 			v := [][][][]bfloat16.BFloat16{{{tensX8, twentyX8}}} // [1, 1, 2, 8]
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -268,7 +268,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float16.Float16{{{onesX8, onesX8}}}
 			v := [][][][]float16.Float16{{{tensX8, twentyX8}}} // [1, 1, 2, 8]
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -289,7 +289,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float32{{{{1}}, {{1}}}}
 			v := [][][][]float32{{{{10}}, {{20}}}}
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -314,7 +314,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]bfloat16.BFloat16{{{onesX8}, {onesX8}}}
 			v := [][][][]bfloat16.BFloat16{{{tensX8}, {twentyX8}}} // [1, 2, 1, 8]
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -340,7 +340,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float16.Float16{{{onesX8}, {onesX8}}}
 			v := [][][][]float16.Float16{{{tensX8}, {twentyX8}}} // [1, 2, 1, 8]
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBSHD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -362,7 +362,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			v := [][][][]float32{{{{10}, {20}}}} // [1,1,2,1]
 			mask := [][]bool{{true, false}}      // [1, 2]
 			got, err := testutil.Exec1(b, []any{q, k, v, mask}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: false, Mask: params[3]})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: false, Mask: params[3]})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -382,7 +382,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			k := [][][][]float32{{{{1}, {1}}}}
 			v := [][][][]float32{{{{10}, {20}}}}
 			got, err := testutil.Exec1(b, []any{q, k, v}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true, QuantizedMatmuls: true})
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, &compute.ScaledDotProductAttentionConfig{Scale: 1.0, Causal: true, QuantizedMatmuls: true})
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -411,7 +411,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			bias := [][][][]float32{{{{-10, 10}, {-10, 10}}}} // [1,1,2,2] batch,head,seqLen,kvLen
 			got, err := testutil.Exec1(b, []any{q, k, v, bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3], Scale: 1.0, Causal: false}
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -441,7 +441,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			bias := [][][][]float32{{{{0, -100}, {0, 10}}}} // [1,1,2,2]
 			got, err := testutil.Exec1(b, []any{q, k, v, bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3], Scale: 1.0, Causal: true}
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {
@@ -478,7 +478,7 @@ func TestFusedOps(t *testing.T, b compute.Backend) {
 			}}}
 			got, err := testutil.Exec1(b, []any{q, k, v, bias}, func(f compute.Function, params []compute.Value) (compute.Value, error) {
 				cfg := &compute.ScaledDotProductAttentionConfig{Bias: params[3], Scale: 1.0, Causal: false}
-				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AxesLayoutBHSD, cfg)
+				out, _, err := f.FusedScaledDotProductAttention(params[0], params[1], params[2], compute.AttentionAxesLayoutBHSD, cfg)
 				return out, err
 			})
 			if err != nil && compute.IsNotImplemented(err) {


### PR DESCRIPTION
  1. ./compute/fused_ops.go updates:
      • Changed FusedDense signature to FusedDense(x, weight, bias Value, options DenseConfig) (Value, error).
      • Defined type DenseConfig struct { Activation ActivationType, WeightLayout DenseLayout } where DenseLayout can be DenseLayoutInputOutputs (0, default) or DenseLayoutOutputsInput
      (iota), with documentation.
      • Renamed AxesLayout to AttentionAxesLayout and updated constants (AttentionAxesLayoutBHSD, AttentionAxesLayoutBSHD) along with method receivers.
  2. Refactored AxesLayout usages: • Fixed references across ./compute, ./go-xla, ./onnx-gomlx, and ./gomlx.
  3. Code Regeneration in ./compute: • Ran go generate ./... in ./compute after updating the generators (gobackend_opsregistration and notimplemented_generator) to recognize DenseConfig, DenseLayout, and AttentionAxesLayout.
  4. Updated gobackend Implementation: • Updated ./compute/internal/gobackend/fusedops/dense.go to handle DenseConfig and DenseLayoutOutputsInput (contracting the last axis of weight when layout is DenseLayoutOutputsInput).