### PR TITLE
Fix dynamic shape materialization and add symbolic axis naming for Concatenate

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,8 @@
+- 2026-08-02:
+  - Fix dynamic output shape materialization in `gobackend` for `binaryOps`, `Concatenate`, and `Reduce` operations so `Buffer.RawShape` is always materialized/concrete.
+  - Implement symbolic dynamic axis naming for `Concatenate` (`=term1+term2`) with support for parsing/resolving composite symbolic names in `shapes.Resolve`.
+  - Add backend compliance tests for `binaryOps`, `Concatenate`, and `Reduce` with dynamic shapes under `support/backendtest`.
+
 - 2026-07-28:
   - Updated FusedDense to take a `DenseConfig` options parameter, which now includes layout information of the weights.
   - Renamed `AxesLayout` -> `AttentionAxesLayout` (since it's for attention only).

--- a/internal/cmd/gobackend_ops_generator/exec_binary.go
+++ b/internal/cmd/gobackend_ops_generator/exec_binary.go
@@ -59,7 +59,7 @@ func exec{{.Name}}(backend *gobackend.Backend, node *gobackend.Node, inputs []*g
 	output, err := backend.GetBuffer(node.Shape)
 	if err != nil {return nil, err}
 {{- else }}
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 {{- end }}
 
 {{- if .IsCommutative}}// Add is commutative, so if any of the two is scalar, make the rhs the scalar one.

--- a/internal/gobackend/fusedops/dense.go
+++ b/internal/gobackend/fusedops/dense.go
@@ -43,6 +43,10 @@ func FusedDense(f *gobackend.Function, x, weight, bias compute.Value, options co
 	xNode := inputs[0]
 	wNode := inputs[1]
 
+	if xNode.Shape.IsDynamic() || wNode.Shape.IsDynamic() {
+		return nil, compute.ErrNotImplemented
+	}
+
 	if xNode.Shape.Rank() < 1 || wNode.Shape.Rank() < 2 {
 		return nil, errors.Errorf("FusedDense: x must have rank >= 1 (got %d), weight must have rank >= 2 (got %d)",
 			xNode.Shape.Rank(), wNode.Shape.Rank())

--- a/internal/gobackend/ops/binaryops.go
+++ b/internal/gobackend/ops/binaryops.go
@@ -174,11 +174,30 @@ func addComparisonOp(f *gobackend.Function, opType compute.OpType, lhsOp, rhsOp 
 	return node, nil
 }
 
-// binaryOperandsAndOutput is a convenience function to get the inputs and output -- which may be the reuse of the input.
-func binaryOperandsAndOutput(backend *gobackend.Backend, inputs []*gobackend.Buffer, inputsOwned []bool, outputShape shapes.Shape) (
+// binaryOperandsAndOutputForExecution is a convenience function to get the inputs and output -- which may be the reuse of the input.
+//
+// - inputs[i] is set to nil if inputs[i] is reused.
+// - output is the buffer where the result is stored, and its shape is made static.
+func binaryOperandsAndOutputForExecution(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool, outputShape shapes.Shape) (
 	lhs, rhs, output *gobackend.Buffer, lhsIsScalarOr1, rhsIsScalarOr1 bool) {
 	lhs, rhs = inputs[0], inputs[1]
-	lhsIsScalarOr1, rhsIsScalarOr1 = lhs.RawShape.Size() == 1, rhs.RawShape.Size() == 1
+	lhsIsScalarOr1 = lhs.RawShape.Size() == 1
+	rhsIsScalarOr1 = rhs.RawShape.Size() == 1
+	if outputShape.IsDynamic() {
+		concreteOutputShape := outputShape.Clone()
+		for axis, dim := range concreteOutputShape.Dimensions {
+			if dim == shapes.DynamicDim {
+				if axis < lhs.RawShape.Rank() {
+					dim = lhs.RawShape.Dimensions[axis]
+				}
+				if axis < rhs.RawShape.Rank() && (dim == 1 || dim == shapes.DynamicDim) {
+					dim = rhs.RawShape.Dimensions[axis]
+				}
+				concreteOutputShape.Dimensions[axis] = dim
+			}
+		}
+		outputShape = concreteOutputShape
+	}
 	switch {
 	case inputsOwned[1] && rhs.RawShape.Equal(outputShape):
 		output = rhs

--- a/internal/gobackend/ops/concatenate.go
+++ b/internal/gobackend/ops/concatenate.go
@@ -43,6 +43,28 @@ func Concatenate(f *gobackend.Function, axis int, operandOps ...compute.Value) (
 func execConcatenate(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
 	axis := node.Data.(int) // Renamed from dimension
 	outputShape := node.Shape
+	if outputShape.IsDynamic() {
+		concreteShape := outputShape.Clone()
+		for d := range concreteShape.Rank() {
+			if concreteShape.Dimensions[d] == shapes.DynamicDim {
+				if d == axis {
+					concatSize := 0
+					for _, inputBuf := range inputs {
+						concatSize += inputBuf.RawShape.Dimensions[d]
+					}
+					concreteShape.Dimensions[d] = concatSize
+				} else {
+					for _, inputBuf := range inputs {
+						if inputBuf.RawShape.Dimensions[d] != shapes.DynamicDim {
+							concreteShape.Dimensions[d] = inputBuf.RawShape.Dimensions[d]
+							break
+						}
+					}
+				}
+			}
+		}
+		outputShape = concreteShape
+	}
 	dtype := outputShape.DType
 	elemSize := dtype.Size()
 	rank := outputShape.Rank()

--- a/internal/gobackend/ops/gen_exec_binary.go
+++ b/internal/gobackend/ops/gen_exec_binary.go
@@ -40,7 +40,7 @@ func init() {
 
 // execAdd executes the binary op Add.
 func execAdd(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape) // Add is commutative, so if any of the two is scalar, make the rhs the scalar one.
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape) // Add is commutative, so if any of the two is scalar, make the rhs the scalar one.
 	if lhsIsScalarOr1 && !rhsIsScalarOr1 {
 		lhs, rhs = rhs, lhs
 		// if lhsIsScalarOr1 and/or rhsIsScalarOr1 variables should stay "alive", then uncomment the line below.
@@ -179,7 +179,7 @@ func execAddNumericFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execMul executes the binary op Mul.
 func execMul(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape) // Add is commutative, so if any of the two is scalar, make the rhs the scalar one.
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape) // Add is commutative, so if any of the two is scalar, make the rhs the scalar one.
 	if lhsIsScalarOr1 && !rhsIsScalarOr1 {
 		lhs, rhs = rhs, lhs
 		// if lhsIsScalarOr1 and/or rhsIsScalarOr1 variables should stay "alive", then uncomment the line below.
@@ -318,7 +318,7 @@ func execMulNumericFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execSub executes the binary op Sub.
 func execSub(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -476,7 +476,7 @@ func execSubNumericFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execDiv executes the binary op Div.
 func execDiv(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -634,7 +634,7 @@ func execDivNumericFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execRem executes the binary op Rem.
 func execRem(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -825,7 +825,7 @@ func execRemFloatFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execPow executes the binary op Pow.
 func execPow(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -1016,7 +1016,7 @@ func execPowFloatFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execAtan2 executes the binary op Atan2.
 func execAtan2(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -1150,7 +1150,7 @@ func execAtan2FloatFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execMax executes the binary op Max.
 func execMax(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape) // Add is commutative, so if any of the two is scalar, make the rhs the scalar one.
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape) // Add is commutative, so if any of the two is scalar, make the rhs the scalar one.
 	if lhsIsScalarOr1 && !rhsIsScalarOr1 {
 		lhs, rhs = rhs, lhs
 		// if lhsIsScalarOr1 and/or rhsIsScalarOr1 variables should stay "alive", then uncomment the line below.
@@ -1289,7 +1289,7 @@ func execMaxNumericFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execMin executes the binary op Min.
 func execMin(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape) // Add is commutative, so if any of the two is scalar, make the rhs the scalar one.
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape) // Add is commutative, so if any of the two is scalar, make the rhs the scalar one.
 	if lhsIsScalarOr1 && !rhsIsScalarOr1 {
 		lhs, rhs = rhs, lhs
 		// if lhsIsScalarOr1 and/or rhsIsScalarOr1 variables should stay "alive", then uncomment the line below.
@@ -1428,7 +1428,7 @@ func execMinNumericFloat16(lhs, rhs []float16.Float16, output []float16.Float16,
 
 // execBitwiseAnd executes the binary op BitwiseAnd.
 func execBitwiseAnd(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -1498,7 +1498,7 @@ func execBitwiseAndIntegerGeneric[T gobackend.PODIntegerConstraints](lhs, rhs []
 
 // execBitwiseOr executes the binary op BitwiseOr.
 func execBitwiseOr(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -1568,7 +1568,7 @@ func execBitwiseOrIntegerGeneric[T gobackend.PODIntegerConstraints](lhs, rhs []T
 
 // execBitwiseXor executes the binary op BitwiseXor.
 func execBitwiseXor(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -1638,7 +1638,7 @@ func execBitwiseXorIntegerGeneric[T gobackend.PODIntegerConstraints](lhs, rhs []
 
 // execLogicalAnd executes the binary op LogicalAnd.
 func execLogicalAnd(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -1688,7 +1688,7 @@ func execLogicalAndBooleanGeneric[T gobackend.PODBooleanConstraints](lhs, rhs []
 
 // execLogicalOr executes the binary op LogicalOr.
 func execLogicalOr(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive
@@ -1738,7 +1738,7 @@ func execLogicalOrBooleanGeneric[T gobackend.PODBooleanConstraints](lhs, rhs []T
 
 // execLogicalXor executes the binary op LogicalXor.
 func execLogicalXor(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, lhsIsScalarOr1, rhsIsScalarOr1 := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	_, _ = lhsIsScalarOr1, rhsIsScalarOr1
 
 	switch lhs.RawShape.DType { //nolint:exhaustive

--- a/internal/gobackend/ops/reduce.go
+++ b/internal/gobackend/ops/reduce.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gomlx/compute/internal/gobackend"
 	"github.com/gomlx/compute/shapeinference"
 	"github.com/gomlx/compute/shapes"
+	"github.com/gomlx/compute/support/sets"
 	"github.com/pkg/errors"
 )
 
@@ -128,7 +129,20 @@ func execReduce(backend *gobackend.Backend, node *gobackend.Node, inputs []*goba
 		gobackend.CopyFlat(output.Flat, operand.Flat)
 		return output, nil
 	}
-	output, err := backend.GetBuffer(node.Shape)
+	outputShape := node.Shape
+	if outputShape.IsDynamic() {
+		concreteShape := outputShape.Clone()
+		axesSet := sets.MakeWith(reduceAxes...)
+		outIdx := 0
+		for axis, dim := range operand.RawShape.Dimensions {
+			if !axesSet.Has(axis) {
+				concreteShape.Dimensions[outIdx] = dim
+				outIdx++
+			}
+		}
+		outputShape = concreteShape
+	}
+	output, err := backend.GetBuffer(outputShape)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gobackend/ops/reshape.go
+++ b/internal/gobackend/ops/reshape.go
@@ -105,19 +105,20 @@ func readScalarInt(buf *gobackend.Buffer) (int, error) {
 	}
 }
 
-// execDynamicReshape implements DynamicReshape.
+// execDynamicReshape implements DynamicReshape: it materializes the dynamic values to static ones, and reuse `reshapeToShape`.
 func execDynamicReshape(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
 	operand := inputs[0]
 	specs := node.Data.([]compute.DynamicDimensionSpec)
 	concreteDims := make([]int, len(specs))
-	axisNames := make([]string, len(specs))
 	valIdx := 1
 	knownProduct := 1
 	inferredIdx := -1
 
 	for i, spec := range specs {
-		axisNames[i] = spec.Name
-		if spec.Name != "" {
+		if spec.Name == "" {
+			concreteDims[i] = spec.Static
+			knownProduct *= spec.Static
+		} else {
 			if spec.Value != nil {
 				if valIdx >= len(inputs) {
 					return nil, errors.Errorf("execDynamicReshape: missing input buffer for dynamic dimension value at spec index %d", i)
@@ -135,9 +136,6 @@ func execDynamicReshape(backend *gobackend.Backend, node *gobackend.Node, inputs
 			} else {
 				inferredIdx = i
 			}
-		} else {
-			concreteDims[i] = spec.Static
-			knownProduct *= spec.Static
 		}
 	}
 
@@ -152,6 +150,6 @@ func execDynamicReshape(backend *gobackend.Backend, node *gobackend.Node, inputs
 		concreteDims[inferredIdx] = operandSize / knownProduct
 	}
 
-	targetShape := shapes.Make(operand.RawShape.DType, concreteDims...).WithAxisNames(axisNames...)
+	targetShape := shapes.Make(operand.RawShape.DType, concreteDims...)
 	return reshapeToShape(backend, targetShape, inputs, inputsOwned)
 }

--- a/internal/gobackend/ops/shiftops.go
+++ b/internal/gobackend/ops/shiftops.go
@@ -44,7 +44,7 @@ var (
 
 // execShiftLeft executes lhs << rhs for integer types.
 func execShiftLeft(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, _, _ := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, _, _ := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	dtype := lhs.RawShape.DType
 	fnAny, err := shiftLeftDTypeMap.Get(dtype) //nolint:errcheck
 	if err != nil {
@@ -57,7 +57,7 @@ func execShiftLeft(backend *gobackend.Backend, node *gobackend.Node, inputs []*g
 
 // execShiftRightArithmetic executes arithmetic right shift (preserves sign bit for signed types).
 func execShiftRightArithmetic(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, _, _ := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, _, _ := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	dtype := lhs.RawShape.DType
 	fnAny, err := shiftRightArithmeticDTypeMap.Get(dtype) //nolint:errcheck
 	if err != nil {
@@ -71,7 +71,7 @@ func execShiftRightArithmetic(backend *gobackend.Backend, node *gobackend.Node, 
 // execShiftRightLogical executes logical right shift (zero-fills from the left, ignoring sign).
 // For signed types, we reinterpret as unsigned, shift, then reinterpret back.
 func execShiftRightLogical(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, inputsOwned []bool) (*gobackend.Buffer, error) {
-	lhs, rhs, output, _, _ := binaryOperandsAndOutput(backend, inputs, inputsOwned, node.Shape)
+	lhs, rhs, output, _, _ := binaryOperandsAndOutputForExecution(backend, node, inputs, inputsOwned, node.Shape)
 	dtype := lhs.RawShape.DType
 	fnAny, err := shiftRightLogicalDTypeMap.Get(dtype) //nolint:errcheck
 	if err != nil {

--- a/shapeinference/dotgeneral.go
+++ b/shapeinference/dotgeneral.go
@@ -49,7 +49,7 @@ func DotGeneral(
 		lDim := lhs.Dimensions[axis]
 		rDim := rhs.Dimensions[rAxis]
 		if lDim == shapes.DynamicDim && rDim == shapes.DynamicDim {
-			if lhs.AxisName(axis) != rhs.AxisName(rAxis) {
+			if !shapes.AxisNameEqual(lhs.AxisName(axis), rhs.AxisName(rAxis)) {
 				return output, errors.Errorf("DotGeneral contracting axis #%d has different axis names (axis name conflict) for lhs (%q) and rhs (%q)", i, lhs.AxisName(axis), rhs.AxisName(rAxis))
 			}
 		} else if lDim != shapes.DynamicDim && rDim != shapes.DynamicDim && lDim != rDim {
@@ -73,13 +73,14 @@ func DotGeneral(
 		lDim := lhs.Dimensions[axis]
 		rDim := rhs.Dimensions[rAxis]
 		if lDim == shapes.DynamicDim && rDim == shapes.DynamicDim {
-			if lhs.AxisName(axis) != rhs.AxisName(rAxis) {
+			if !shapes.AxisNameEqual(lhs.AxisName(axis), rhs.AxisName(rAxis)) {
 				return output, errors.Errorf("DotGeneral batch axis #%d has different axis names (axis name conflict) for lhs (%q) and rhs (%q)", i, lhs.AxisName(axis), rhs.AxisName(rAxis))
 			}
 		} else if lDim != shapes.DynamicDim && rDim != shapes.DynamicDim && lDim != rDim {
 			return output, errors.Errorf("DotGeneral batch dimensions do not match: lhs[%d]=%d, rhs[%d]=%d", axis, lDim, rAxis, rDim)
 		}
 	}
+
 
 	isRHSUsed := make([]bool, rhs.Rank())
 	for _, axis := range rhsContractingAxes {

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -284,8 +284,8 @@ func binaryOpImpl(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (outpu
 			} else if rhsDim == 1 {
 				output.Dimensions[axis] = lhsDim // broadcast: use lhs (possibly dynamic)
 			} else if lhsDim == rhsDim {
-				// Both dynamic: they must have mathing symbolic value.
-				if lhsShape.AxisNames[axis] != rhsShape.AxisNames[axis] {
+				// Both dynamic: they must have matching symbolic value.
+				if !shapes.AxisNameEqual(lhsShape.AxisName(axis), rhsShape.AxisName(axis)) {
 					err = errors.Errorf(
 						"axis #%d is dynamic for both operands, but have different axis names for BinaryOp (%s), "+
 							"they cannot be implicitly broadcast; got shapes %s and %s",
@@ -293,6 +293,7 @@ func binaryOpImpl(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (outpu
 					return shapes.Invalid(), err
 				}
 				output.Dimensions[axis] = shapes.DynamicDim // both dynamic or one dynamic non-broadcast
+
 			} else {
 				// One side is dynamic and the other is not 1.
 				err = errors.Errorf(

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -281,8 +281,20 @@ func binaryOpImpl(opType compute.OpType, lhsShape, rhsShape shapes.Shape) (outpu
 			// At least one side is dynamic.
 			if lhsDim == 1 {
 				output.Dimensions[axis] = rhsDim // broadcast: use rhs (possibly dynamic)
+				if rhsShape.AxisNames != nil {
+					if output.AxisNames == nil {
+						output.AxisNames = make([]string, output.Rank())
+					}
+					output.AxisNames[axis] = rhsShape.AxisName(axis)
+				}
 			} else if rhsDim == 1 {
 				output.Dimensions[axis] = lhsDim // broadcast: use lhs (possibly dynamic)
+				if lhsShape.AxisNames != nil {
+					if output.AxisNames == nil {
+						output.AxisNames = make([]string, output.Rank())
+					}
+					output.AxisNames[axis] = lhsShape.AxisName(axis)
+				}
 			} else if lhsDim == rhsDim {
 				// Both dynamic: they must have matching symbolic value.
 				if !shapes.AxisNameEqual(lhsShape.AxisName(axis), rhsShape.AxisName(axis)) {

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -36,6 +36,9 @@ package shapeinference
 
 import (
 	"slices"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes"
@@ -843,6 +846,7 @@ func Concatenate(inputs []shapes.Shape, axis int) (output shapes.Shape, err erro
 	}
 
 	// Validate further inputs and accumulate the concatenation axis size.
+	isConcatAxisDynamic := false
 	for i := 1; i < len(inputs); i++ {
 		currentShape := inputs[i]
 		if currentShape.DType == dtypes.InvalidDType {
@@ -859,22 +863,17 @@ func Concatenate(inputs []shapes.Shape, axis int) (output shapes.Shape, err erro
 
 		for d := range rank {
 			if d == axis {
-				// For concat axis: if either is dynamic, result is dynamic.
 				if output.Dimensions[d] == shapes.DynamicDim || currentShape.Dimensions[d] == shapes.DynamicDim {
-					// Concatenating on a dynamic axis is not supported yet, because we
-					// don't have axis expressions to represent the new size.
-					return shapes.Invalid(), errors.Errorf("ConcatenateOp: concatenation on a dynamic axis (%d, names %q and %q) is not supported yet (requires axis expressions)",
-						d, output.AxisName(d), currentShape.AxisName(d))
-				} else {
+					isConcatAxisDynamic = true
+					output.Dimensions[d] = shapes.DynamicDim
+				} else if !isConcatAxisDynamic {
 					output.Dimensions[d] += currentShape.Dimensions[d]
 				}
 			} else {
 				// For non-concat axes: allow dynamic dims on either side.
 				if output.Dimensions[d] == shapes.DynamicDim || currentShape.Dimensions[d] == shapes.DynamicDim {
 					// Dynamic dims are assumed compatible; keep dynamic.
-					if output.Dimensions[d] != shapes.DynamicDim {
-						output.Dimensions[d] = currentShape.Dimensions[d]
-					}
+					output.Dimensions[d] = shapes.DynamicDim
 				} else if currentShape.Dimensions[d] != output.Dimensions[d] {
 					return shapes.Invalid(), errors.Errorf("mismatched dimensions for ConcatenateOp at axis %d (non-concatenation axis): input #0 has %d, input #%d has %d",
 						d, output.Dimensions[d], i, currentShape.Dimensions[d])
@@ -882,9 +881,12 @@ func Concatenate(inputs []shapes.Shape, axis int) (output shapes.Shape, err erro
 			}
 		}
 
-		// Unify axis names from current input.
+		// Unify axis names from current input for non-concat axes.
 		if output.AxisNames != nil || currentShape.AxisNames != nil {
 			for d := range rank {
+				if d == axis {
+					continue
+				}
 				outputName := ""
 				if output.AxisNames != nil {
 					outputName = output.AxisNames[d]
@@ -895,11 +897,7 @@ func Concatenate(inputs []shapes.Shape, axis int) (output shapes.Shape, err erro
 				}
 				unified, nameErr := shapes.UnifyAxisName(outputName, inputName)
 				if nameErr != nil {
-					if d != axis {
-						return shapes.Invalid(), errors.Wrapf(nameErr, "axis name conflict at axis %d in ConcatenateOp", d)
-					}
-					// Concat axis with different names: drop the name.
-					unified = ""
+					return shapes.Invalid(), errors.Wrapf(nameErr, "axis name conflict at axis %d in ConcatenateOp", d)
 				}
 				if output.AxisNames == nil {
 					output.AxisNames = make([]string, rank)
@@ -908,6 +906,61 @@ func Concatenate(inputs []shapes.Shape, axis int) (output shapes.Shape, err erro
 			}
 		}
 	}
+
+	// Calculate axis name for the concatenation axis if dynamic or named.
+	hasAnonymous := false
+	var parts []string
+	for _, inp := range inputs {
+		dim := inp.Dimensions[axis]
+		name := inp.AxisName(axis)
+		if name == shapes.AnonymousAxis {
+			hasAnonymous = true
+			break
+		}
+		if dim != shapes.DynamicDim {
+			parts = append(parts, strconv.Itoa(dim))
+		} else if name != "" {
+			if strings.HasPrefix(name, shapes.SymbolicAxisPrefix) {
+				subExpr := strings.TrimPrefix(name, shapes.SymbolicAxisPrefix)
+				subParts := strings.Split(subExpr, "+")
+				for _, p := range subParts {
+					p = strings.TrimSpace(p)
+					if p == shapes.AnonymousAxis {
+						hasAnonymous = true
+						break
+					}
+					if p != "" {
+						parts = append(parts, p)
+					}
+				}
+				if hasAnonymous {
+					break
+				}
+			} else {
+				parts = append(parts, name)
+			}
+		} else {
+			// Dynamic axis without a name behaves as anonymous
+			hasAnonymous = true
+			break
+		}
+	}
+
+	var concatAxisName string
+	if hasAnonymous {
+		concatAxisName = shapes.AnonymousAxis
+	} else if len(parts) > 0 {
+		sort.Strings(parts)
+		concatAxisName = shapes.SymbolicAxisPrefix + strings.Join(parts, "+")
+	}
+
+	if concatAxisName != "" {
+		if output.AxisNames == nil {
+			output.AxisNames = make([]string, rank)
+		}
+		output.AxisNames[axis] = concatAxisName
+	}
+
 	return output, nil
 }
 

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -1213,21 +1213,20 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
-		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		if ok, diff := testutil.IsEqual([]string{"batch", "=256+512"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "=256+512"}, output.AxisNames)
 		}
 	})
 
-	t.Run("ConcatAxisNameConflictDrops", func(t *testing.T) {
-		// Different names on the concat axis → name is dropped for that axis.
+	t.Run("ConcatAxisNameSymbolicDynamic", func(t *testing.T) {
 		s1 := SD(F32, []int{-1, 10}, []string{"batch", "a"})
-		s2 := SD(F32, []int{-1, 10}, []string{"batch", "b"})
-		_, err := Concatenate([]shapes.Shape{s1, s2}, 0) // concat on axis 0 (dynamic)
-		if err == nil {
-			t.Fatalf("Expected error when concatenating on dynamic axis, but got nil")
+		s2 := SD(F32, []int{-1, 10}, []string{"batch", "a"})
+		output, err := Concatenate([]shapes.Shape{s1, s2}, 0) // concat on axis 0 (dynamic)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
 		}
-		if !strings.Contains(err.Error(), "concatenation on a dynamic axis") {
-			t.Errorf("Expected error message to mention concatenation on dynamic axis, got: %v", err)
+		if ok, diff := testutil.IsEqual([]string{"=batch+batch", "a"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"=batch+batch", "a"}, output.AxisNames)
 		}
 	})
 
@@ -1243,12 +1242,15 @@ func TestConcatenateOp_AxisNames(t *testing.T) {
 		}
 	})
 
-	t.Run("DynamicConcatAxis", func(t *testing.T) {
+	t.Run("DynamicConcatAxisSymbolic", func(t *testing.T) {
 		s1 := SD(F32, []int{-1, -1}, []string{"batch", "seq"})
 		s2 := SD(F32, []int{-1, 128}, []string{"batch", ""})
-		_, err := Concatenate([]shapes.Shape{s1, s2}, 1) // Concatenating on dynamic axis 1
-		if err == nil {
-			t.Fatalf("Expected error when concatenating on dynamic axis, but got nil")
+		output, err := Concatenate([]shapes.Shape{s1, s2}, 1) // Concatenating on dynamic axis 1
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok, diff := testutil.IsEqual([]string{"batch", "=128+seq"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "=128+seq"}, output.AxisNames)
 		}
 	})
 }
@@ -1418,16 +1420,14 @@ func TestDotGeneral_DynamicAndNames(t *testing.T) {
 
 func TestConcatenateOp_Dynamic(t *testing.T) {
 	t.Run("ConcatOnDynamicAxis", func(t *testing.T) {
-		// Concatenating on a dynamic axis should currently be an error because we can't
-		// represent the resulting size (e.g. batchSize + batchSize) symbolically.
 		s1 := SD(F32, []int{-1, 512}, []string{"batch", ""})
 		s2 := SD(F32, []int{-1, 512}, []string{"batch", ""})
-		_, err := Concatenate([]shapes.Shape{s1, s2}, 0)
-		if err == nil {
-			t.Fatalf("Expected error when concatenating on dynamic axis, but got nil")
+		output, err := Concatenate([]shapes.Shape{s1, s2}, 0)
+		if err != nil {
+			t.Fatalf("Expected no error when concatenating on dynamic axis, got %v", err)
 		}
-		if !strings.Contains(err.Error(), "concatenation on a dynamic axis") {
-			t.Errorf("Expected error message to mention concatenation on dynamic axis, got: %v", err)
+		if ok, diff := testutil.IsEqual([]string{"=batch+batch", ""}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"=batch+batch", ""}, output.AxisNames)
 		}
 	})
 
@@ -1441,8 +1441,8 @@ func TestConcatenateOp_Dynamic(t *testing.T) {
 		if ok, diff := testutil.IsEqual([]int{-1, 30}, output.Dimensions); !ok {
 			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []int{-1, 30}, output.Dimensions)
 		}
-		if ok, diff := testutil.IsEqual([]string{"batch", ""}, output.AxisNames); !ok {
-			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", ""}, output.AxisNames)
+		if ok, diff := testutil.IsEqual([]string{"batch", "=10+20"}, output.AxisNames); !ok {
+			t.Fatalf("Expected %v, got %v"+"\nDiff:\n"+diff, []string{"batch", "=10+20"}, output.AxisNames)
 		}
 	})
 }

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -1404,7 +1404,17 @@ func TestDotGeneral_DynamicAndNames(t *testing.T) {
 			t.Fatalf("Expected %v to contain %v", err.Error(), "axis name conflict")
 		}
 	})
+
+	t.Run("AnonymousAxisConflict", func(t *testing.T) {
+		lhs := SD(F32, []int{-1, 512}, []string{shapes.AnonymousAxis, ""})
+		rhs := SD(F32, []int{-1, 512}, []string{shapes.AnonymousAxis, ""})
+		_, err := DotGeneral(lhs, []int{1}, []int{0}, rhs, []int{1}, []int{0}, DotGeneralConfig{})
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+	})
 }
+
 
 func TestConcatenateOp_Dynamic(t *testing.T) {
 	t.Run("ConcatOnDynamicAxis", func(t *testing.T) {

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -132,11 +132,15 @@ func (b AxisBindings) Extract(template, concrete Shape) error {
 //
 // Rules:
 //   - "" + "" = "" (both unnamed → unnamed)
-//   - "name" + "" = "name" (one named → keep the name)
-//   - "" + "name" = "name" (one named → keep the name)
-//   - "name" + "name" = "name" (same name → keep it)
+//   - "name" + "" = "name" (one named → keep the name, provided name != AnonymousAxis)
+//   - "" + "name" = "name" (one named → keep the name, provided name != AnonymousAxis)
+//   - "name" + "name" = "name" (same name → keep it, provided name != AnonymousAxis)
+//   - AnonymousAxis + any = error (AnonymousAxis never unifies/matches with anything)
 //   - "a" + "b" = error (different names → conflict)
 func UnifyAxisName(name1, name2 string) (string, error) {
+	if name1 == AnonymousAxis || name2 == AnonymousAxis {
+		return "", errors.Errorf("incompatible axis names: %q vs %q", name1, name2)
+	}
 	if name1 == "" {
 		return name2, nil
 	}
@@ -148,6 +152,7 @@ func UnifyAxisName(name1, name2 string) (string, error) {
 	}
 	return "", errors.Errorf("incompatible axis names: %q vs %q", name1, name2)
 }
+
 
 // UnifyAxisNames unifies axis names from two shapes of the same rank.
 // Returns the unified axis names, or error on name conflicts.

--- a/shapes/bindings.go
+++ b/shapes/bindings.go
@@ -5,6 +5,7 @@ package shapes
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/gomlx/compute/support/xslices"
@@ -48,7 +49,7 @@ func (s Shape) Resolve(bindings AxisBindings) (Shape, error) {
 		if name == "" {
 			return Shape{}, errors.Errorf("Shape.Resolve: dynamic axis %d has no name and cannot be resolved: %s", i, s)
 		}
-		val, ok := bindings[name]
+		val, ok := resolveAxisName(name, bindings)
 		if !ok {
 			return Shape{}, errors.Errorf("Shape.Resolve: no binding for axis %q in shape %s", name, s)
 		}
@@ -74,7 +75,7 @@ func (s Shape) ResolvePartial(bindings AxisBindings) (Shape, error) {
 		if name == "" {
 			continue
 		}
-		val, ok := bindings[name]
+		val, ok := resolveAxisName(name, bindings)
 		if !ok {
 			continue
 		}
@@ -84,6 +85,34 @@ func (s Shape) ResolvePartial(bindings AxisBindings) (Shape, error) {
 		resolved.Dimensions[i] = val
 	}
 	return resolved, nil
+}
+
+// resolveAxisName attempts to resolve an axis name against bindings.
+// It supports symbolic sum expressions starting with SymbolicAxisPrefix (e.g., "=10+a").
+func resolveAxisName(name string, bindings AxisBindings) (int, bool) {
+	if val, ok := bindings[name]; ok {
+		return val, true
+	}
+	if strings.HasPrefix(name, SymbolicAxisPrefix) {
+		expr := strings.TrimPrefix(name, SymbolicAxisPrefix)
+		parts := strings.Split(expr, "+")
+		total := 0
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				return 0, false
+			}
+			if num, err := strconv.Atoi(part); err == nil {
+				total += num
+			} else if boundVal, ok := bindings[part]; ok {
+				total += boundVal
+			} else {
+				return 0, false
+			}
+		}
+		return total, true
+	}
+	return 0, false
 }
 
 

--- a/shapes/bindings_test.go
+++ b/shapes/bindings_test.go
@@ -261,7 +261,16 @@ func TestBindings(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
+
+		// AnonymousAxis conflict.
+		s9 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{AnonymousAxis, ""})
+		s10 := MakeDynamic(dtypes.Float32, []int{-1, 512}, []string{AnonymousAxis, ""})
+		_, err = UnifyAxisNames(s9, s10)
+		if err == nil {
+			t.Fatalf("Expected error for AnonymousAxis, got nil")
+		}
 	})
+
 
 	t.Run("RoundTrip_ExtractAndResolve", func(t *testing.T) {
 		// Extract bindings from concrete shape, then resolve template with those bindings.

--- a/shapes/bindings_test.go
+++ b/shapes/bindings_test.go
@@ -61,6 +61,18 @@ func TestBindings(t *testing.T) {
 		}
 	})
 
+	t.Run("Resolve_SymbolicAxis", func(t *testing.T) {
+		s := MakeDynamic(dtypes.Float32, []int{-1, 10}, []string{"=10+batch", ""})
+		bindings := AxisBindings{"batch": 32}
+		resolved, err := s.Resolve(bindings)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual([]int{42, 10}, resolved.Dimensions) {
+			t.Fatalf("Expected %v, got %v", []int{42, 10}, resolved.Dimensions)
+		}
+	})
+
 	t.Run("Resolve_StaticShape", func(t *testing.T) {
 		s := Make(dtypes.Float32, 32, 512)
 		// Resolve on static shape returns same shape (no-op).

--- a/shapes/dynamic.go
+++ b/shapes/dynamic.go
@@ -107,6 +107,9 @@ func (s Shape) WithAxisNames(names ...string) Shape {
 // including itself, in axis comparison helper functions.
 const AnonymousAxis = "?"
 
+// SymbolicAxisPrefix is the prefix used for dynamic composite axis names (e.g., "=10+a").
+const SymbolicAxisPrefix = "="
+
 // AxisNameEqual checks whether two individual axis names are equal.
 // If either axis name is AnonymousAxis, it returns false (it never matches anything, including itself).
 func AxisNameEqual(a, b string) bool {

--- a/shapes/dynamic.go
+++ b/shapes/dynamic.go
@@ -96,6 +96,20 @@ func (s Shape) WithAxisNames(names ...string) Shape {
 	return s2
 }
 
+// AnonymousAxis is a special-cased axis name for dynamic dimensions that should never match anything,
+// including itself, in axis comparison helper functions.
+const AnonymousAxis = "?"
+
+// axisNameEqual checks whether two individual axis names are equal.
+// If either axis name is AnonymousAxis, it returns false (it never matches anything).
+func axisNameEqual(a, b string) bool {
+	if a == AnonymousAxis || b == AnonymousAxis {
+		return false
+	}
+	return a == b
+}
+
+
 // axisNamesEqual compares two axis name slices for equality.
 // nil is considered equal to a slice of all empty strings.
 func axisNamesEqual(a, b []string) bool {
@@ -122,9 +136,10 @@ func axisNamesEqual(a, b []string) bool {
 		if b != nil {
 			bName = b[i]
 		}
-		if aName != bName {
+		if !axisNameEqual(aName, bName) {
 			return false
 		}
 	}
 	return true
 }
+

--- a/shapes/dynamic.go
+++ b/shapes/dynamic.go
@@ -24,8 +24,10 @@ const DynamicDim = -1
 //
 // axisNames must have the same length as dimensions. Use "" for unnamed axes.
 //
-// Axis names starting with "=" or "#" are reserved for internal (backend implementation) use and shouldn't e
-// used by end users.
+// Axis name reserved characters/strings:
+// - Names starting with "=" or "#" are reserved for internal (backend implementation) use.
+// - "?" (AnonymousAxis) represents a dynamic axis that should never match anything, including itself.
+// - "*" is reserved for future wildcard matching.
 //
 // Example:
 //
@@ -87,6 +89,11 @@ func (s Shape) AxisName(axis int) string {
 
 // WithAxisNames returns a copy of the shape with the given axis names set.
 // The number of names must equal the rank.
+//
+// Axis name reserved characters/strings:
+// - Names starting with "=" or "#" are reserved for internal (backend implementation) use.
+// - "?" (AnonymousAxis) represents a dynamic axis that should never match anything, including itself.
+// - "*" is reserved for future wildcard matching.
 func (s Shape) WithAxisNames(names ...string) Shape {
 	if len(names) != s.Rank() {
 		panic(errors.Errorf("Shape.WithAxisNames: len(names)=%d must equal rank=%d", len(names), s.Rank()))
@@ -100,15 +107,14 @@ func (s Shape) WithAxisNames(names ...string) Shape {
 // including itself, in axis comparison helper functions.
 const AnonymousAxis = "?"
 
-// axisNameEqual checks whether two individual axis names are equal.
-// If either axis name is AnonymousAxis, it returns false (it never matches anything).
-func axisNameEqual(a, b string) bool {
+// AxisNameEqual checks whether two individual axis names are equal.
+// If either axis name is AnonymousAxis, it returns false (it never matches anything, including itself).
+func AxisNameEqual(a, b string) bool {
 	if a == AnonymousAxis || b == AnonymousAxis {
 		return false
 	}
 	return a == b
 }
-
 
 // axisNamesEqual compares two axis name slices for equality.
 // nil is considered equal to a slice of all empty strings.
@@ -136,10 +142,9 @@ func axisNamesEqual(a, b []string) bool {
 		if b != nil {
 			bName = b[i]
 		}
-		if !axisNameEqual(aName, bName) {
+		if !AxisNameEqual(aName, bName) {
 			return false
 		}
 	}
 	return true
 }
-

--- a/shapes/dynamic_test.go
+++ b/shapes/dynamic_test.go
@@ -387,4 +387,12 @@ func TestAxisNamesEqual(t *testing.T) {
 	if axisNamesEqual([]string{"a"}, []string{"a", "b"}) {
 		t.Fatalf("Condition expected to be false")
 	}
+	if axisNamesEqual([]string{AnonymousAxis}, []string{AnonymousAxis}) {
+		t.Fatalf("Condition expected to be false for AnonymousAxis")
+	}
+	if axisNamesEqual([]string{"a"}, []string{AnonymousAxis}) {
+		t.Fatalf("Condition expected to be false for AnonymousAxis")
+	}
 }
+
+

--- a/support/backendtest/binary.go
+++ b/support/backendtest/binary.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/gomlx/compute"
+	"github.com/gomlx/compute/dtypes"
 	"github.com/gomlx/compute/dtypes/bfloat16"
+	"github.com/gomlx/compute/shapes"
 	"github.com/gomlx/compute/support/testutil"
 )
 
@@ -60,6 +62,127 @@ func TestBinaryOps(t *testing.T, b compute.Backend) {
 		if ok, diff := testutil.IsEqual([][]int32{{9, 99}, {12, 102}, {15, 105}}, y4); !ok {
 			t.Errorf("y4 value mismatch (-want +got):\n%s", diff)
 		}
+
+		// Test with dynamic shapes (broadcasting from scalar and dimension of 1).
+		t.Run("DynamicShapesBroadcasting", func(t *testing.T) {
+			t.Run("Dim1Broadcast", func(t *testing.T) {
+				builder := b.Builder("test_dynamic_add_dim1")
+				mainFn := builder.Main()
+				// LHS: shape (batch, 1) dynamic; RHS: shape (batch, 4) dynamic
+				sLHS := shapes.MakeDynamic(dtypes.Float32, []int{shapes.DynamicDim, 1}, []string{"batch", ""})
+				sRHS := shapes.MakeDynamic(dtypes.Float32, []int{shapes.DynamicDim, 4}, []string{"batch", ""})
+				pLHS, err := mainFn.Parameter("lhs", sLHS, nil)
+				if err != nil {
+					t.Fatalf("Failed creating parameter LHS: %+v", err)
+				}
+				pRHS, err := mainFn.Parameter("rhs", sRHS, nil)
+				if err != nil {
+					t.Fatalf("Failed creating parameter RHS: %+v", err)
+				}
+				outVal, err := mainFn.Add(pLHS, pRHS)
+				if err != nil {
+					t.Fatalf("Failed creating Add node: %+v", err)
+				}
+				if err := mainFn.Return([]compute.Value{outVal}, nil); err != nil {
+					t.Fatalf("Failed returning output: %+v", err)
+				}
+				exec, err := builder.Compile()
+				if err != nil {
+					t.Fatalf("Failed compiling graph: %+v", err)
+				}
+
+				bufLHS, err := b.BufferFromFlatData(0, []float32{10, 20}, shapes.Make(dtypes.Float32, 2, 1))
+				if err != nil {
+					t.Fatalf("Failed creating bufLHS: %+v", err)
+				}
+				bufRHS, err := b.BufferFromFlatData(0, []float32{1, 2, 3, 4, 5, 6, 7, 8}, shapes.Make(dtypes.Float32, 2, 4))
+				if err != nil {
+					t.Fatalf("Failed creating bufRHS: %+v", err)
+				}
+
+				results, err := exec.Execute([]compute.Buffer{bufLHS, bufRHS}, []bool{false, false}, 0)
+				if err != nil {
+					t.Fatalf("Failed executing graph with dynamic shapes: %+v", err)
+				}
+				resShape, err := results[0].Shape()
+				if err != nil {
+					t.Fatalf("Failed getting result shape: %+v", err)
+				}
+				if resShape.IsDynamic() {
+					t.Errorf("Expected concrete output shape, but got dynamic shape: %s", resShape)
+				}
+				if !resShape.EqualDimensions(shapes.Make(dtypes.Float32, 2, 4)) {
+					t.Errorf("Expected shape (2, 4), got %s", resShape)
+				}
+				gotData, err := testutil.FromBuffer(b, results[0])
+				if err != nil {
+					t.Fatalf("Failed converting output buffer: %+v", err)
+				}
+				wantData := [][]float32{{11, 12, 13, 14}, {25, 26, 27, 28}}
+				if ok, diff := testutil.IsEqual(wantData, gotData); !ok {
+					t.Errorf("Dynamic add result mismatch (-want +got):\n%s", diff)
+				}
+			})
+
+			t.Run("ScalarBroadcast", func(t *testing.T) {
+				builder := b.Builder("test_dynamic_add_scalar")
+				mainFn := builder.Main()
+				// LHS: scalar Float32; RHS: shape (batch, 3) dynamic
+				sLHS := shapes.Make(dtypes.Float32)
+				sRHS := shapes.MakeDynamic(dtypes.Float32, []int{shapes.DynamicDim, 3}, []string{"batch", ""})
+				pLHS, err := mainFn.Parameter("lhs", sLHS, nil)
+				if err != nil {
+					t.Fatalf("Failed creating parameter LHS: %+v", err)
+				}
+				pRHS, err := mainFn.Parameter("rhs", sRHS, nil)
+				if err != nil {
+					t.Fatalf("Failed creating parameter RHS: %+v", err)
+				}
+				outVal, err := mainFn.Add(pLHS, pRHS)
+				if err != nil {
+					t.Fatalf("Failed creating Add node: %+v", err)
+				}
+				if err := mainFn.Return([]compute.Value{outVal}, nil); err != nil {
+					t.Fatalf("Failed returning output: %+v", err)
+				}
+				exec, err := builder.Compile()
+				if err != nil {
+					t.Fatalf("Failed compiling graph: %+v", err)
+				}
+
+				bufLHS, err := b.BufferFromFlatData(0, []float32{10}, shapes.Make(dtypes.Float32))
+				if err != nil {
+					t.Fatalf("Failed creating bufLHS: %+v", err)
+				}
+				bufRHS, err := b.BufferFromFlatData(0, []float32{1, 2, 3, 4, 5, 6}, shapes.Make(dtypes.Float32, 2, 3))
+				if err != nil {
+					t.Fatalf("Failed creating bufRHS: %+v", err)
+				}
+
+				results, err := exec.Execute([]compute.Buffer{bufLHS, bufRHS}, []bool{false, false}, 0)
+				if err != nil {
+					t.Fatalf("Failed executing graph with dynamic shapes: %+v", err)
+				}
+				resShape, err := results[0].Shape()
+				if err != nil {
+					t.Fatalf("Failed getting result shape: %+v", err)
+				}
+				if resShape.IsDynamic() {
+					t.Errorf("Expected concrete output shape, but got dynamic shape: %s", resShape)
+				}
+				if !resShape.EqualDimensions(shapes.Make(dtypes.Float32, 2, 3)) {
+					t.Errorf("Expected shape (2, 3), got %s", resShape)
+				}
+				gotData, err := testutil.FromBuffer(b, results[0])
+				if err != nil {
+					t.Fatalf("Failed converting output buffer: %+v", err)
+				}
+				wantData := [][]float32{{11, 12, 13}, {14, 15, 16}}
+				if ok, diff := testutil.IsEqual(wantData, gotData); !ok {
+					t.Errorf("Dynamic scalar add result mismatch (-want +got):\n%s", diff)
+				}
+			})
+		})
 	})
 
 	t.Run("Mul", func(t *testing.T) {

--- a/support/backendtest/special.go
+++ b/support/backendtest/special.go
@@ -514,6 +514,65 @@ func TestSpecialOps(t *testing.T, b compute.Backend) {
 		if ok, diff := testutil.IsEqual(want3, y3); !ok {
 			t.Fatalf("Concatenate y3 mismatch:\n%s", diff)
 		}
+
+		// Test Case 4: Concatenating with dynamic shapes on non-concat axis
+		t.Run("DynamicNonConcatAxis", func(t *testing.T) {
+			builder := b.Builder("test_dynamic_concat_non_concat_axis")
+			mainFn := builder.Main()
+			s1 := shapes.MakeDynamic(dtypes.Float32, []int{shapes.DynamicDim, 2}, []string{"batch", ""})
+			s2 := shapes.MakeDynamic(dtypes.Float32, []int{shapes.DynamicDim, 3}, []string{"batch", ""})
+			p1, err := mainFn.Parameter("p1", s1, nil)
+			if err != nil {
+				t.Fatalf("Failed creating p1: %+v", err)
+			}
+			p2, err := mainFn.Parameter("p2", s2, nil)
+			if err != nil {
+				t.Fatalf("Failed creating p2: %+v", err)
+			}
+			outVal, err := mainFn.Concatenate(1, p1, p2)
+			if err != nil {
+				t.Fatalf("Failed creating Concatenate node: %+v", err)
+			}
+			if err := mainFn.Return([]compute.Value{outVal}, nil); err != nil {
+				t.Fatalf("Failed returning output: %+v", err)
+			}
+			exec, err := builder.Compile()
+			if err != nil {
+				t.Fatalf("Failed compiling graph: %+v", err)
+			}
+
+			buf1, err := b.BufferFromFlatData(0, []float32{1, 2, 3, 4}, shapes.Make(dtypes.Float32, 2, 2))
+			if err != nil {
+				t.Fatalf("Failed creating buf1: %+v", err)
+			}
+			buf2, err := b.BufferFromFlatData(0, []float32{10, 20, 30, 40, 50, 60}, shapes.Make(dtypes.Float32, 2, 3))
+			if err != nil {
+				t.Fatalf("Failed creating buf2: %+v", err)
+			}
+
+			results, err := exec.Execute([]compute.Buffer{buf1, buf2}, []bool{false, false}, 0)
+			if err != nil {
+				t.Fatalf("Failed executing Concatenate with dynamic non-concat axis: %+v", err)
+			}
+			resShape, err := results[0].Shape()
+			if err != nil {
+				t.Fatalf("Failed getting result shape: %+v", err)
+			}
+			if resShape.IsDynamic() {
+				t.Errorf("Expected concrete output shape, but got dynamic shape: %s", resShape)
+			}
+			if !resShape.EqualDimensions(shapes.Make(dtypes.Float32, 2, 5)) {
+				t.Errorf("Expected shape (2, 5), got %s", resShape)
+			}
+			gotData, err := testutil.FromBuffer(b, results[0])
+			if err != nil {
+				t.Fatalf("Failed converting output buffer: %+v", err)
+			}
+			wantData := [][]float32{{1, 2, 10, 20, 30}, {3, 4, 40, 50, 60}}
+			if ok, diff := testutil.IsEqual(wantData, gotData); !ok {
+				t.Errorf("Dynamic Concatenate result mismatch (-want +got):\n%s", diff)
+			}
+		})
 	})
 
 	t.Run("Scatter", func(t *testing.T) {

--- a/support/backendtest/special.go
+++ b/support/backendtest/special.go
@@ -323,6 +323,62 @@ func TestSpecialOps(t *testing.T, b compute.Backend) {
 				t.Errorf("Full reduction mismatch:\n%s", diff)
 			}
 		})
+
+		t.Run("DynamicShapeReduction", func(t *testing.T) {
+			testutil.SkipIfMissing(t, b, compute.OpTypeReduceSum)
+			builder := b.Builder("test_dynamic_reduce")
+			mainFn := builder.Main()
+			// Shape (batch, seq, 4) dynamic
+			sInput := shapes.MakeDynamic(dtypes.Float32, []int{shapes.DynamicDim, shapes.DynamicDim, 4}, []string{"batch", "seq", ""})
+			pInput, err := mainFn.Parameter("input", sInput, nil)
+			if err != nil {
+				t.Fatalf("Failed creating parameter: %+v", err)
+			}
+			// Reduce along axis 1 ("seq") -> output shape should be (batch, 4) dynamic
+			outVal, err := mainFn.ReduceSum(pInput, 1)
+			if err != nil {
+				t.Fatalf("Failed creating ReduceSum node: %+v", err)
+			}
+			if err := mainFn.Return([]compute.Value{outVal}, nil); err != nil {
+				t.Fatalf("Failed returning output: %+v", err)
+			}
+			exec, err := builder.Compile()
+			if err != nil {
+				t.Fatalf("Failed compiling graph: %+v", err)
+			}
+
+			// Concrete input shape: (2, 3, 4)
+			bufInput, err := b.BufferFromFlatData(0, []float32{
+				1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+				4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6,
+			}, shapes.Make(dtypes.Float32, 2, 3, 4))
+			if err != nil {
+				t.Fatalf("Failed creating input buffer: %+v", err)
+			}
+
+			results, err := exec.Execute([]compute.Buffer{bufInput}, []bool{false}, 0)
+			if err != nil {
+				t.Fatalf("Failed executing graph: %+v", err)
+			}
+			resShape, err := results[0].Shape()
+			if err != nil {
+				t.Fatalf("Failed getting result shape: %+v", err)
+			}
+			if resShape.IsDynamic() {
+				t.Errorf("Expected concrete output shape, got dynamic shape: %s", resShape)
+			}
+			if !resShape.EqualDimensions(shapes.Make(dtypes.Float32, 2, 4)) {
+				t.Errorf("Expected shape (2, 4), got %s", resShape)
+			}
+			gotData, err := testutil.FromBuffer(b, results[0])
+			if err != nil {
+				t.Fatalf("Failed converting output buffer: %+v", err)
+			}
+			wantData := [][]float32{{6, 6, 6, 6}, {15, 15, 15, 15}}
+			if ok, diff := testutil.IsEqual(wantData, gotData); !ok {
+				t.Errorf("Dynamic reduce result mismatch (-want +got):\n%s", diff)
+			}
+		})
 	})
 
 	t.Run("ReduceBitwise", func(t *testing.T) {


### PR DESCRIPTION
### Summary of Changes

- **Dynamic Output Shape Materialization**:
  - Updated `gobackend` execution for `binaryOps`, `Concatenate`, and `Reduce` operations to ensure that when output node shapes are dynamic, the concrete shapes are resolved using input buffer dimensions before buffer allocation.
  - Guaranteed `Buffer.RawShape` is always concrete and non-dynamic during execution.

- **Symbolic Axis Naming for `Concatenate`**:
  - Defined `shapes.SymbolicAxisPrefix = "="`.
  - Constructed symbolic dynamic axis names for `Concatenate` (`=term1+term2`) with terms alphabetically sorted.
  - Propagates `shapes.AnonymousAxis` (`"?"`) if any input operand has an anonymous dynamic axis.
  - Updated `Shape.Resolve` and `Shape.ResolvePartial` to parse and resolve composite sum expressions (e.g., `=10+batch`).

- **Backend Compliance Tests**:
  - Added tests under `support/backendtest` for `binaryOps`, `Concatenate`, and `Reduce` operations with dynamic shapes.

- **Documentation**:
  - Updated `docs/CHANGELOG.md` with entry for today (2026-08-02).