### PR TITLE
Implement SelectAndScatter and parallelize ConvGeneral, SelectAndScatter, and ReduceWindow

### DIFF
--- a/internal/gobackend/capabilities.go
+++ b/internal/gobackend/capabilities.go
@@ -151,8 +151,8 @@ var Capabilities = compute.Capabilities{
 		compute.OpTypeQuantizedEmbeddingLookup:       true,
 
 		// TODO: not implemented yet:
-		// compute.OpTypeSelectAndScatterMax: true,
-		// compute.OpTypeSelectAndScatterMin: true,
+		compute.OpTypeSelectAndScatterMax: true,
+		compute.OpTypeSelectAndScatterMin: true,
 		// compute.OpTypeSelectAndScatterSum: true,
 		// compute.OpTypeDynamicSlice: true,
 		// compute.OpTypeDynamicUpdateSlice: true,

--- a/internal/gobackend/ops/convgeneral_exec_base.go
+++ b/internal/gobackend/ops/convgeneral_exec_base.go
@@ -3,8 +3,9 @@
 package ops
 
 import (
+	"sync"
 	//alt:half|full_half "github.com/gomlx/compute/dtypes/gotype"
-	"github.com/gomlx/compute/internal/gobackend" //alt:base|full
+	"github.com/gomlx/compute/internal/gobackend"
 )
 
 // This file serves the "base" version of the `execConv*` functions, as well as a template.
@@ -66,72 +67,193 @@ func execConvNoDilationGeneric[T gobackend.PODNumericConstraints](plan convGener
 	kernelSpatialAxes := axes.KernelSpatial
 	kernelNumInputChannels := kernelShape.Dimensions[kernelInputChannelsAxis]
 
-	// Indices we'll be iterating over.
-	var outputFlatIdx int
-
-	// Indices and strides: note we don't use an inputIndices because we only keep an inputFlatIndex.
-	outputIndices := make([]int, rank)
-	kernelIndices := make([]int, rank)
-
 	inputStrides := inputShape.Strides()
 	kernelStrides := kernelShape.Strides()
+	outputStrides := outputShape.Strides()
+	outputDimensions := outputShape.Dimensions
 
-	// Loop sequentially over all output positions:
-	for outputFlatIdx, outputIndices = range outputShape.IterOn(outputIndices) {
-		batchIdx := outputIndices[outputBatchAxis]
-		outputChannel := outputIndices[outputChannelsAxis]
-		//alt:full|full_half if batchGroupCount > 1 {
-		//alt:full|full_half subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup
-		//alt:full|full_half batchIdx = subBatchIdx*outputBatchSize + batchIdx
-		//alt:full|full_half }
-		baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+	spatialRank := len(axes.KernelSpatial)
 
-		// Loop over the kernel spatial axes, with the outputChannel given by the output loop.
-		kernelIndices[kernelOutputChannelsAxis] = outputChannel
-		var outputValue T //alt:base|full
-		//alt:half|full_half var outputValue float32
-		var kernelFlatIdx int
-	kernelLoop:
-		for kernelFlatIdx, kernelIndices = range kernelShape.IterOnAxes(kernelSpatialAxes, kernelStrides, kernelIndices) {
-			// Calculate the corresponding position in the input.
-			inputFlatIdx := baseInputFlatIdx
-			for spatialIdx, kernelSpatialAxis := range axes.KernelSpatial {
-				kernelIdx := kernelIndices[kernelSpatialAxis]
-				//alt:full|full_half kernelDilation := kernelDilations[spatialIdx]
-				//alt:full|full_half kernelIdx *= kernelDilation
-				outputSpatialAxis := outputSpatialAxes[spatialIdx]
-				outputIdx := outputIndices[outputSpatialAxis]
-				inputIdx := outputIdx*convStrides[spatialIdx] + kernelIdx - paddings[spatialIdx][0]
-				//alt:full|full_half inputDilation := inputDilations[spatialIdx]
-				if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] { //alt:base|half
-					//alt:full|full_half if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] || (inputDilation > 1 && inputIdx%inputDilation != 0) {
-					// Index is in the padded area, we can move to the next kernel position.
-					continue kernelLoop
-				}
-				//alt:full|full_half inputIdx /= inputDilation // Make the dilated index back to the original input.
-				inputFlatIdx += inputIdx * inputSpatialStrides[spatialIdx]
-			}
+	runChunk := func(startFlatIdx, endFlatIdx int) {
+		outputIndices := make([]int, rank)
+		kernelIndices := make([]int, rank)
 
-			// Accumulate over all the kernel/input channels.
-			inputChannelStride := inputStrides[inputChannelsAxis]
-			kernelChannelStride := kernelStrides[kernelInputChannelsAxis]
-			//alt:full|full_half if channelGroupCount > 1 {
-			//alt:full|full_half featureGroup := outputChannel / numOutputChannelsPerGroup
-			//alt:full|full_half inputFlatIdx += inputChannelStride * (featureGroup*kernelNumInputChannels)
-			//alt:full|full_half }
-			for range kernelNumInputChannels {
-				inputValue := inputFlat[inputFlatIdx]
-				kernelValue := kernelFlat[kernelFlatIdx]
-				outputValue += inputValue * kernelValue //alt:base|full
-				//alt:half|full_half outputValue += inputValue.Float32() * kernelValue.Float32()
-				inputFlatIdx += inputChannelStride
-				kernelFlatIdx += kernelChannelStride
-			}
+		remainder := startFlatIdx
+		for i := 0; i < rank; i++ {
+			outputIndices[i] = remainder / outputStrides[i]
+			remainder %= outputStrides[i]
 		}
 
-		// Update output with accumulated value from the convolution of the kernel at this position.
-		outputFlat[outputFlatIdx] = outputValue //alt:base|full
-		//alt:half|full_half P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue)
+		if spatialRank == 2 {
+			kH := kernelShape.Dimensions[kernelSpatialAxes[0]]
+			kW := kernelShape.Dimensions[kernelSpatialAxes[1]]
+			kHStride := kernelStrides[kernelSpatialAxes[0]]
+			kWStride := kernelStrides[kernelSpatialAxes[1]]
+			inSpatialStride0 := inputSpatialStrides[0]
+			inSpatialStride1 := inputSpatialStrides[1]
+			pad0 := paddings[0][0]
+			pad1 := paddings[1][0]
+			stride0 := convStrides[0]
+			stride1 := convStrides[1]
+			inDim0 := inputSpatialDims[0]
+			inDim1 := inputSpatialDims[1]
+			outSpatialAxis0 := outputSpatialAxes[0]
+			outSpatialAxis1 := outputSpatialAxes[1]
+			kOutChanStride := kernelStrides[kernelOutputChannelsAxis]
+			inChanStride := inputStrides[inputChannelsAxis]
+			kInChanStride := kernelStrides[kernelInputChannelsAxis]
+
+			for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+				batchIdx := outputIndices[outputBatchAxis]
+				outputChannel := outputIndices[outputChannelsAxis]
+				//alt:full|full_half if batchGroupCount > 1 {
+				//alt:full|full_half subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup
+				//alt:full|full_half batchIdx = subBatchIdx*outputBatchSize + batchIdx
+				//alt:full|full_half }
+				baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+				baseKernelFlatIdx := outputChannel * kOutChanStride
+
+				var outputValue T //alt:base|full
+				//alt:half|full_half var outputValue float32
+
+				outIdx0 := outputIndices[outSpatialAxis0]
+				outIdx1 := outputIndices[outSpatialAxis1]
+
+				for ky := 0; ky < kH; ky++ {
+					kyEffective := ky
+					//alt:full|full_half kyEffective *= kernelDilations[0]
+					inputIdx0 := outIdx0*stride0 + kyEffective - pad0
+					if inputIdx0 < 0 || inputIdx0 >= inDim0 { //alt:base|half
+						//alt:full|full_half if inputIdx0 < 0 || inputIdx0 >= inDim0 || (inputDilations[0] > 1 && inputIdx0%inputDilations[0] != 0) {
+						continue
+					}
+					//alt:full|full_half inputIdx0 /= inputDilations[0]
+
+					offset0 := baseInputFlatIdx + inputIdx0*inSpatialStride0
+					kOffset0 := baseKernelFlatIdx + ky*kHStride
+
+					for kx := 0; kx < kW; kx++ {
+						kxEffective := kx
+						//alt:full|full_half kxEffective *= kernelDilations[1]
+						inputIdx1 := outIdx1*stride1 + kxEffective - pad1
+						if inputIdx1 < 0 || inputIdx1 >= inDim1 { //alt:base|half
+							//alt:full|full_half if inputIdx1 < 0 || inputIdx1 >= inDim1 || (inputDilations[1] > 1 && inputIdx1%inputDilations[1] != 0) {
+							continue
+						}
+						//alt:full|full_half inputIdx1 /= inputDilations[1]
+
+						inFlatIdx := offset0 + inputIdx1*inSpatialStride1
+						kFlatIdx := kOffset0 + kx*kWStride
+
+						//alt:full|full_half if channelGroupCount > 1 {
+						//alt:full|full_half featureGroup := outputChannel / numOutputChannelsPerGroup
+						//alt:full|full_half inFlatIdx += inChanStride * (featureGroup*kernelNumInputChannels)
+						//alt:full|full_half }
+
+						for c := 0; c < kernelNumInputChannels; c++ {
+							inputValue := inputFlat[inFlatIdx+c*inChanStride]
+							kernelValue := kernelFlat[kFlatIdx+c*kInChanStride]
+							outputValue += inputValue * kernelValue //alt:base|full
+							//alt:half|full_half outputValue += inputValue.Float32() * kernelValue.Float32()
+						}
+					}
+				}
+
+				outputFlat[outputFlatIdx] = outputValue //alt:base|full
+				//alt:half|full_half P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue)
+
+				for i := rank - 1; i >= 0; i-- {
+					outputIndices[i]++
+					if outputIndices[i] < outputDimensions[i] {
+						break
+					}
+					outputIndices[i] = 0
+				}
+			}
+			return
+		}
+
+		for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+			batchIdx := outputIndices[outputBatchAxis]
+			outputChannel := outputIndices[outputChannelsAxis]
+			//alt:full|full_half if batchGroupCount > 1 {
+			//alt:full|full_half subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup
+			//alt:full|full_half batchIdx = subBatchIdx*outputBatchSize + batchIdx
+			//alt:full|full_half }
+			baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+
+			kernelIndices[kernelOutputChannelsAxis] = outputChannel
+			var outputValue T //alt:base|full
+			//alt:half|full_half var outputValue float32
+			var kernelFlatIdx int
+		kernelLoop:
+			for kernelFlatIdx, kernelIndices = range kernelShape.IterOnAxes(kernelSpatialAxes, kernelStrides, kernelIndices) {
+				inputFlatIdx := baseInputFlatIdx
+				for spatialIdx, kernelSpatialAxis := range axes.KernelSpatial {
+					kernelIdx := kernelIndices[kernelSpatialAxis]
+					//alt:full|full_half kernelDilation := kernelDilations[spatialIdx]
+					//alt:full|full_half kernelIdx *= kernelDilation
+					outputSpatialAxis := outputSpatialAxes[spatialIdx]
+					outputIdx := outputIndices[outputSpatialAxis]
+					inputIdx := outputIdx*convStrides[spatialIdx] + kernelIdx - paddings[spatialIdx][0]
+					//alt:full|full_half inputDilation := inputDilations[spatialIdx]
+					if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] { //alt:base|half
+						//alt:full|full_half if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] || (inputDilation > 1 && inputIdx%inputDilation != 0) {
+						continue kernelLoop
+					}
+					//alt:full|full_half inputIdx /= inputDilation
+					inputFlatIdx += inputIdx * inputSpatialStrides[spatialIdx]
+				}
+
+				inputChannelStride := inputStrides[inputChannelsAxis]
+				kernelChannelStride := kernelStrides[kernelInputChannelsAxis]
+				//alt:full|full_half if channelGroupCount > 1 {
+				//alt:full|full_half featureGroup := outputChannel / numOutputChannelsPerGroup
+				//alt:full|full_half inputFlatIdx += inputChannelStride * (featureGroup*kernelNumInputChannels)
+				//alt:full|full_half }
+				for range kernelNumInputChannels {
+					inputValue := inputFlat[inputFlatIdx]
+					kernelValue := kernelFlat[kernelFlatIdx]
+					outputValue += inputValue * kernelValue //alt:base|full
+					//alt:half|full_half outputValue += inputValue.Float32() * kernelValue.Float32()
+					inputFlatIdx += inputChannelStride
+					kernelFlatIdx += kernelChannelStride
+				}
+			}
+
+			outputFlat[outputFlatIdx] = outputValue //alt:base|full
+			//alt:half|full_half P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue)
+
+			for i := rank - 1; i >= 0; i-- {
+				outputIndices[i]++
+				if outputIndices[i] < outputDimensions[i] {
+					break
+				}
+				outputIndices[i] = 0
+			}
+		}
 	}
+
+	lenOutputs := len(outputFlat)
+	goBackend, _ := plan.backend.(*gobackend.Backend)
+	if goBackend != nil && goBackend.Workers != nil && goBackend.Workers.IsEnabled() && lenOutputs >= 512 {
+		maxWorkers := goBackend.Workers.AdjustedMaxParallelism()
+		if maxWorkers > 1 {
+			chunkSize := max(256, (lenOutputs+maxWorkers-1)/maxWorkers)
+			var wg sync.WaitGroup
+			for startIdx := 0; startIdx < lenOutputs; startIdx += chunkSize {
+				endIdx := min(startIdx+chunkSize, lenOutputs)
+				wg.Add(1)
+				goBackend.Workers.WaitToStart(func() {
+					defer wg.Done()
+					runChunk(startIdx, endIdx)
+				})
+			}
+			wg.Wait()
+			return nil
+		}
+	}
+
+	runChunk(0, lenOutputs)
 	return nil
 }

--- a/internal/gobackend/ops/gen_convgeneral_exec_full.go
+++ b/internal/gobackend/ops/gen_convgeneral_exec_full.go
@@ -7,8 +7,9 @@
 package ops
 
 import (
+	"sync"
 	//alt:half|full_half  "github.com/gomlx/compute/dtypes/gotype"
-	"github.com/gomlx/compute/internal/gobackend" //alt:base|full
+	"github.com/gomlx/compute/internal/gobackend"
 )
 
 // This file serves the "base" version of the `execConv*` functions, as well as a template.
@@ -71,72 +72,193 @@ func execConvGeneric[T gobackend.PODNumericConstraints](plan convGeneralExecPlan
 	kernelSpatialAxes := axes.KernelSpatial
 	kernelNumInputChannels := kernelShape.Dimensions[kernelInputChannelsAxis]
 
-	// Indices we'll be iterating over.
-	var outputFlatIdx int
-
-	// Indices and strides: note we don't use an inputIndices because we only keep an inputFlatIndex.
-	outputIndices := make([]int, rank)
-	kernelIndices := make([]int, rank)
-
 	inputStrides := inputShape.Strides()
 	kernelStrides := kernelShape.Strides()
+	outputStrides := outputShape.Strides()
+	outputDimensions := outputShape.Dimensions
 
-	// Loop sequentially over all output positions:
-	for outputFlatIdx, outputIndices = range outputShape.IterOn(outputIndices) {
-		batchIdx := outputIndices[outputBatchAxis]
-		outputChannel := outputIndices[outputChannelsAxis]
-		if batchGroupCount > 1 { //alt:full|full_half
-			subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup //alt:full|full_half
-			batchIdx = subBatchIdx*outputBatchSize + batchIdx             //alt:full|full_half
-		} //alt:full|full_half
-		baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+	spatialRank := len(axes.KernelSpatial)
 
-		// Loop over the kernel spatial axes, with the outputChannel given by the output loop.
-		kernelIndices[kernelOutputChannelsAxis] = outputChannel
-		var outputValue T //alt:base|full
-		//alt:half|full_half  var outputValue float32
-		var kernelFlatIdx int
-	kernelLoop:
-		for kernelFlatIdx, kernelIndices = range kernelShape.IterOnAxes(kernelSpatialAxes, kernelStrides, kernelIndices) {
-			// Calculate the corresponding position in the input.
-			inputFlatIdx := baseInputFlatIdx
-			for spatialIdx, kernelSpatialAxis := range axes.KernelSpatial {
-				kernelIdx := kernelIndices[kernelSpatialAxis]
-				kernelDilation := kernelDilations[spatialIdx] //alt:full|full_half
-				kernelIdx *= kernelDilation                   //alt:full|full_half
-				outputSpatialAxis := outputSpatialAxes[spatialIdx]
-				outputIdx := outputIndices[outputSpatialAxis]
-				inputIdx := outputIdx*convStrides[spatialIdx] + kernelIdx - paddings[spatialIdx][0]
-				inputDilation := inputDilations[spatialIdx] //alt:full|full_half
-				//alt:base|half if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] {
-				if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] || (inputDilation > 1 && inputIdx%inputDilation != 0) { //alt:full|full_half
-					// Index is in the padded area, we can move to the next kernel position.
-					continue kernelLoop
-				}
-				inputIdx /= inputDilation // Make the dilated index back to the original input. //alt:full|full_half
-				inputFlatIdx += inputIdx * inputSpatialStrides[spatialIdx]
-			}
+	runChunk := func(startFlatIdx, endFlatIdx int) {
+		outputIndices := make([]int, rank)
+		kernelIndices := make([]int, rank)
 
-			// Accumulate over all the kernel/input channels.
-			inputChannelStride := inputStrides[inputChannelsAxis]
-			kernelChannelStride := kernelStrides[kernelInputChannelsAxis]
-			if channelGroupCount > 1 { //alt:full|full_half
-				featureGroup := outputChannel / numOutputChannelsPerGroup                    //alt:full|full_half
-				inputFlatIdx += inputChannelStride * (featureGroup * kernelNumInputChannels) //alt:full|full_half
-			} //alt:full|full_half
-			for range kernelNumInputChannels {
-				inputValue := inputFlat[inputFlatIdx]
-				kernelValue := kernelFlat[kernelFlatIdx]
-				outputValue += inputValue * kernelValue //alt:base|full
-				//alt:half|full_half  outputValue += inputValue.Float32() * kernelValue.Float32()
-				inputFlatIdx += inputChannelStride
-				kernelFlatIdx += kernelChannelStride
-			}
+		remainder := startFlatIdx
+		for i := 0; i < rank; i++ {
+			outputIndices[i] = remainder / outputStrides[i]
+			remainder %= outputStrides[i]
 		}
 
-		// Update output with accumulated value from the convolution of the kernel at this position.
-		outputFlat[outputFlatIdx] = outputValue //alt:base|full
-		//alt:half|full_half  P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue)
+		if spatialRank == 2 {
+			kH := kernelShape.Dimensions[kernelSpatialAxes[0]]
+			kW := kernelShape.Dimensions[kernelSpatialAxes[1]]
+			kHStride := kernelStrides[kernelSpatialAxes[0]]
+			kWStride := kernelStrides[kernelSpatialAxes[1]]
+			inSpatialStride0 := inputSpatialStrides[0]
+			inSpatialStride1 := inputSpatialStrides[1]
+			pad0 := paddings[0][0]
+			pad1 := paddings[1][0]
+			stride0 := convStrides[0]
+			stride1 := convStrides[1]
+			inDim0 := inputSpatialDims[0]
+			inDim1 := inputSpatialDims[1]
+			outSpatialAxis0 := outputSpatialAxes[0]
+			outSpatialAxis1 := outputSpatialAxes[1]
+			kOutChanStride := kernelStrides[kernelOutputChannelsAxis]
+			inChanStride := inputStrides[inputChannelsAxis]
+			kInChanStride := kernelStrides[kernelInputChannelsAxis]
+
+			for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+				batchIdx := outputIndices[outputBatchAxis]
+				outputChannel := outputIndices[outputChannelsAxis]
+				if batchGroupCount > 1 { //alt:full|full_half
+					subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup //alt:full|full_half
+					batchIdx = subBatchIdx*outputBatchSize + batchIdx             //alt:full|full_half
+				} //alt:full|full_half
+				baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+				baseKernelFlatIdx := outputChannel * kOutChanStride
+
+				var outputValue T //alt:base|full
+				//alt:half|full_half  var outputValue float32
+
+				outIdx0 := outputIndices[outSpatialAxis0]
+				outIdx1 := outputIndices[outSpatialAxis1]
+
+				for ky := 0; ky < kH; ky++ {
+					kyEffective := ky
+					kyEffective *= kernelDilations[0] //alt:full|full_half
+					inputIdx0 := outIdx0*stride0 + kyEffective - pad0
+					//alt:base|half if inputIdx0 < 0 || inputIdx0 >= inDim0 {
+					if inputIdx0 < 0 || inputIdx0 >= inDim0 || (inputDilations[0] > 1 && inputIdx0%inputDilations[0] != 0) { //alt:full|full_half
+						continue
+					}
+					inputIdx0 /= inputDilations[0] //alt:full|full_half
+
+					offset0 := baseInputFlatIdx + inputIdx0*inSpatialStride0
+					kOffset0 := baseKernelFlatIdx + ky*kHStride
+
+					for kx := 0; kx < kW; kx++ {
+						kxEffective := kx
+						kxEffective *= kernelDilations[1] //alt:full|full_half
+						inputIdx1 := outIdx1*stride1 + kxEffective - pad1
+						//alt:base|half if inputIdx1 < 0 || inputIdx1 >= inDim1 {
+						if inputIdx1 < 0 || inputIdx1 >= inDim1 || (inputDilations[1] > 1 && inputIdx1%inputDilations[1] != 0) { //alt:full|full_half
+							continue
+						}
+						inputIdx1 /= inputDilations[1] //alt:full|full_half
+
+						inFlatIdx := offset0 + inputIdx1*inSpatialStride1
+						kFlatIdx := kOffset0 + kx*kWStride
+
+						if channelGroupCount > 1 { //alt:full|full_half
+							featureGroup := outputChannel / numOutputChannelsPerGroup           //alt:full|full_half
+							inFlatIdx += inChanStride * (featureGroup * kernelNumInputChannels) //alt:full|full_half
+						} //alt:full|full_half
+
+						for c := 0; c < kernelNumInputChannels; c++ {
+							inputValue := inputFlat[inFlatIdx+c*inChanStride]
+							kernelValue := kernelFlat[kFlatIdx+c*kInChanStride]
+							outputValue += inputValue * kernelValue //alt:base|full
+							//alt:half|full_half  outputValue += inputValue.Float32() * kernelValue.Float32()
+						}
+					}
+				}
+
+				outputFlat[outputFlatIdx] = outputValue //alt:base|full
+				//alt:half|full_half  P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue)
+
+				for i := rank - 1; i >= 0; i-- {
+					outputIndices[i]++
+					if outputIndices[i] < outputDimensions[i] {
+						break
+					}
+					outputIndices[i] = 0
+				}
+			}
+			return
+		}
+
+		for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+			batchIdx := outputIndices[outputBatchAxis]
+			outputChannel := outputIndices[outputChannelsAxis]
+			if batchGroupCount > 1 { //alt:full|full_half
+				subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup //alt:full|full_half
+				batchIdx = subBatchIdx*outputBatchSize + batchIdx             //alt:full|full_half
+			} //alt:full|full_half
+			baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+
+			kernelIndices[kernelOutputChannelsAxis] = outputChannel
+			var outputValue T //alt:base|full
+			//alt:half|full_half  var outputValue float32
+			var kernelFlatIdx int
+		kernelLoop:
+			for kernelFlatIdx, kernelIndices = range kernelShape.IterOnAxes(kernelSpatialAxes, kernelStrides, kernelIndices) {
+				inputFlatIdx := baseInputFlatIdx
+				for spatialIdx, kernelSpatialAxis := range axes.KernelSpatial {
+					kernelIdx := kernelIndices[kernelSpatialAxis]
+					kernelDilation := kernelDilations[spatialIdx] //alt:full|full_half
+					kernelIdx *= kernelDilation                   //alt:full|full_half
+					outputSpatialAxis := outputSpatialAxes[spatialIdx]
+					outputIdx := outputIndices[outputSpatialAxis]
+					inputIdx := outputIdx*convStrides[spatialIdx] + kernelIdx - paddings[spatialIdx][0]
+					inputDilation := inputDilations[spatialIdx] //alt:full|full_half
+					//alt:base|half if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] {
+					if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] || (inputDilation > 1 && inputIdx%inputDilation != 0) { //alt:full|full_half
+						continue kernelLoop
+					}
+					inputIdx /= inputDilation //alt:full|full_half
+					inputFlatIdx += inputIdx * inputSpatialStrides[spatialIdx]
+				}
+
+				inputChannelStride := inputStrides[inputChannelsAxis]
+				kernelChannelStride := kernelStrides[kernelInputChannelsAxis]
+				if channelGroupCount > 1 { //alt:full|full_half
+					featureGroup := outputChannel / numOutputChannelsPerGroup                    //alt:full|full_half
+					inputFlatIdx += inputChannelStride * (featureGroup * kernelNumInputChannels) //alt:full|full_half
+				} //alt:full|full_half
+				for range kernelNumInputChannels {
+					inputValue := inputFlat[inputFlatIdx]
+					kernelValue := kernelFlat[kernelFlatIdx]
+					outputValue += inputValue * kernelValue //alt:base|full
+					//alt:half|full_half  outputValue += inputValue.Float32() * kernelValue.Float32()
+					inputFlatIdx += inputChannelStride
+					kernelFlatIdx += kernelChannelStride
+				}
+			}
+
+			outputFlat[outputFlatIdx] = outputValue //alt:base|full
+			//alt:half|full_half  P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue)
+
+			for i := rank - 1; i >= 0; i-- {
+				outputIndices[i]++
+				if outputIndices[i] < outputDimensions[i] {
+					break
+				}
+				outputIndices[i] = 0
+			}
+		}
 	}
+
+	lenOutputs := len(outputFlat)
+	goBackend, _ := plan.backend.(*gobackend.Backend)
+	if goBackend != nil && goBackend.Workers != nil && goBackend.Workers.IsEnabled() && lenOutputs >= 512 {
+		maxWorkers := goBackend.Workers.AdjustedMaxParallelism()
+		if maxWorkers > 1 {
+			chunkSize := max(256, (lenOutputs+maxWorkers-1)/maxWorkers)
+			var wg sync.WaitGroup
+			for startIdx := 0; startIdx < lenOutputs; startIdx += chunkSize {
+				endIdx := min(startIdx+chunkSize, lenOutputs)
+				wg.Add(1)
+				goBackend.Workers.WaitToStart(func() {
+					defer wg.Done()
+					runChunk(startIdx, endIdx)
+				})
+			}
+			wg.Wait()
+			return nil
+		}
+	}
+
+	runChunk(0, lenOutputs)
 	return nil
 }

--- a/internal/gobackend/ops/gen_convgeneral_exec_full_half.go
+++ b/internal/gobackend/ops/gen_convgeneral_exec_full_half.go
@@ -8,7 +8,8 @@ package ops
 
 import (
 	"github.com/gomlx/compute/dtypes/gotype" //alt:half|full_half
-	//alt:base|full "github.com/gomlx/compute/internal/gobackend"
+	"github.com/gomlx/compute/internal/gobackend"
+	"sync"
 )
 
 // This file serves the "base" version of the `execConv*` functions, as well as a template.
@@ -71,72 +72,193 @@ func execConvHalf[T gotype.HalfPrecision[T], P gotype.HalfPrecisionPtr[T]](plan 
 	kernelSpatialAxes := axes.KernelSpatial
 	kernelNumInputChannels := kernelShape.Dimensions[kernelInputChannelsAxis]
 
-	// Indices we'll be iterating over.
-	var outputFlatIdx int
-
-	// Indices and strides: note we don't use an inputIndices because we only keep an inputFlatIndex.
-	outputIndices := make([]int, rank)
-	kernelIndices := make([]int, rank)
-
 	inputStrides := inputShape.Strides()
 	kernelStrides := kernelShape.Strides()
+	outputStrides := outputShape.Strides()
+	outputDimensions := outputShape.Dimensions
 
-	// Loop sequentially over all output positions:
-	for outputFlatIdx, outputIndices = range outputShape.IterOn(outputIndices) {
-		batchIdx := outputIndices[outputBatchAxis]
-		outputChannel := outputIndices[outputChannelsAxis]
-		if batchGroupCount > 1 { //alt:full|full_half
-			subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup //alt:full|full_half
-			batchIdx = subBatchIdx*outputBatchSize + batchIdx             //alt:full|full_half
-		} //alt:full|full_half
-		baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+	spatialRank := len(axes.KernelSpatial)
 
-		// Loop over the kernel spatial axes, with the outputChannel given by the output loop.
-		kernelIndices[kernelOutputChannelsAxis] = outputChannel
-		//alt:base|full var outputValue T
-		var outputValue float32 //alt:half|full_half
-		var kernelFlatIdx int
-	kernelLoop:
-		for kernelFlatIdx, kernelIndices = range kernelShape.IterOnAxes(kernelSpatialAxes, kernelStrides, kernelIndices) {
-			// Calculate the corresponding position in the input.
-			inputFlatIdx := baseInputFlatIdx
-			for spatialIdx, kernelSpatialAxis := range axes.KernelSpatial {
-				kernelIdx := kernelIndices[kernelSpatialAxis]
-				kernelDilation := kernelDilations[spatialIdx] //alt:full|full_half
-				kernelIdx *= kernelDilation                   //alt:full|full_half
-				outputSpatialAxis := outputSpatialAxes[spatialIdx]
-				outputIdx := outputIndices[outputSpatialAxis]
-				inputIdx := outputIdx*convStrides[spatialIdx] + kernelIdx - paddings[spatialIdx][0]
-				inputDilation := inputDilations[spatialIdx] //alt:full|full_half
-				//alt:base|half if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] {
-				if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] || (inputDilation > 1 && inputIdx%inputDilation != 0) { //alt:full|full_half
-					// Index is in the padded area, we can move to the next kernel position.
-					continue kernelLoop
-				}
-				inputIdx /= inputDilation // Make the dilated index back to the original input. //alt:full|full_half
-				inputFlatIdx += inputIdx * inputSpatialStrides[spatialIdx]
-			}
+	runChunk := func(startFlatIdx, endFlatIdx int) {
+		outputIndices := make([]int, rank)
+		kernelIndices := make([]int, rank)
 
-			// Accumulate over all the kernel/input channels.
-			inputChannelStride := inputStrides[inputChannelsAxis]
-			kernelChannelStride := kernelStrides[kernelInputChannelsAxis]
-			if channelGroupCount > 1 { //alt:full|full_half
-				featureGroup := outputChannel / numOutputChannelsPerGroup                    //alt:full|full_half
-				inputFlatIdx += inputChannelStride * (featureGroup * kernelNumInputChannels) //alt:full|full_half
-			} //alt:full|full_half
-			for range kernelNumInputChannels {
-				inputValue := inputFlat[inputFlatIdx]
-				kernelValue := kernelFlat[kernelFlatIdx]
-				//alt:base|full outputValue += inputValue * kernelValue
-				outputValue += inputValue.Float32() * kernelValue.Float32() //alt:half|full_half
-				inputFlatIdx += inputChannelStride
-				kernelFlatIdx += kernelChannelStride
-			}
+		remainder := startFlatIdx
+		for i := 0; i < rank; i++ {
+			outputIndices[i] = remainder / outputStrides[i]
+			remainder %= outputStrides[i]
 		}
 
-		// Update output with accumulated value from the convolution of the kernel at this position.
-		//alt:base|full outputFlat[outputFlatIdx] = outputValue
-		P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue) //alt:half|full_half
+		if spatialRank == 2 {
+			kH := kernelShape.Dimensions[kernelSpatialAxes[0]]
+			kW := kernelShape.Dimensions[kernelSpatialAxes[1]]
+			kHStride := kernelStrides[kernelSpatialAxes[0]]
+			kWStride := kernelStrides[kernelSpatialAxes[1]]
+			inSpatialStride0 := inputSpatialStrides[0]
+			inSpatialStride1 := inputSpatialStrides[1]
+			pad0 := paddings[0][0]
+			pad1 := paddings[1][0]
+			stride0 := convStrides[0]
+			stride1 := convStrides[1]
+			inDim0 := inputSpatialDims[0]
+			inDim1 := inputSpatialDims[1]
+			outSpatialAxis0 := outputSpatialAxes[0]
+			outSpatialAxis1 := outputSpatialAxes[1]
+			kOutChanStride := kernelStrides[kernelOutputChannelsAxis]
+			inChanStride := inputStrides[inputChannelsAxis]
+			kInChanStride := kernelStrides[kernelInputChannelsAxis]
+
+			for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+				batchIdx := outputIndices[outputBatchAxis]
+				outputChannel := outputIndices[outputChannelsAxis]
+				if batchGroupCount > 1 { //alt:full|full_half
+					subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup //alt:full|full_half
+					batchIdx = subBatchIdx*outputBatchSize + batchIdx             //alt:full|full_half
+				} //alt:full|full_half
+				baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+				baseKernelFlatIdx := outputChannel * kOutChanStride
+
+				//alt:base|full var outputValue T
+				var outputValue float32 //alt:half|full_half
+
+				outIdx0 := outputIndices[outSpatialAxis0]
+				outIdx1 := outputIndices[outSpatialAxis1]
+
+				for ky := 0; ky < kH; ky++ {
+					kyEffective := ky
+					kyEffective *= kernelDilations[0] //alt:full|full_half
+					inputIdx0 := outIdx0*stride0 + kyEffective - pad0
+					//alt:base|half if inputIdx0 < 0 || inputIdx0 >= inDim0 {
+					if inputIdx0 < 0 || inputIdx0 >= inDim0 || (inputDilations[0] > 1 && inputIdx0%inputDilations[0] != 0) { //alt:full|full_half
+						continue
+					}
+					inputIdx0 /= inputDilations[0] //alt:full|full_half
+
+					offset0 := baseInputFlatIdx + inputIdx0*inSpatialStride0
+					kOffset0 := baseKernelFlatIdx + ky*kHStride
+
+					for kx := 0; kx < kW; kx++ {
+						kxEffective := kx
+						kxEffective *= kernelDilations[1] //alt:full|full_half
+						inputIdx1 := outIdx1*stride1 + kxEffective - pad1
+						//alt:base|half if inputIdx1 < 0 || inputIdx1 >= inDim1 {
+						if inputIdx1 < 0 || inputIdx1 >= inDim1 || (inputDilations[1] > 1 && inputIdx1%inputDilations[1] != 0) { //alt:full|full_half
+							continue
+						}
+						inputIdx1 /= inputDilations[1] //alt:full|full_half
+
+						inFlatIdx := offset0 + inputIdx1*inSpatialStride1
+						kFlatIdx := kOffset0 + kx*kWStride
+
+						if channelGroupCount > 1 { //alt:full|full_half
+							featureGroup := outputChannel / numOutputChannelsPerGroup           //alt:full|full_half
+							inFlatIdx += inChanStride * (featureGroup * kernelNumInputChannels) //alt:full|full_half
+						} //alt:full|full_half
+
+						for c := 0; c < kernelNumInputChannels; c++ {
+							inputValue := inputFlat[inFlatIdx+c*inChanStride]
+							kernelValue := kernelFlat[kFlatIdx+c*kInChanStride]
+							//alt:base|full outputValue += inputValue * kernelValue
+							outputValue += inputValue.Float32() * kernelValue.Float32() //alt:half|full_half
+						}
+					}
+				}
+
+				//alt:base|full outputFlat[outputFlatIdx] = outputValue
+				P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue) //alt:half|full_half
+
+				for i := rank - 1; i >= 0; i-- {
+					outputIndices[i]++
+					if outputIndices[i] < outputDimensions[i] {
+						break
+					}
+					outputIndices[i] = 0
+				}
+			}
+			return
+		}
+
+		for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+			batchIdx := outputIndices[outputBatchAxis]
+			outputChannel := outputIndices[outputChannelsAxis]
+			if batchGroupCount > 1 { //alt:full|full_half
+				subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup //alt:full|full_half
+				batchIdx = subBatchIdx*outputBatchSize + batchIdx             //alt:full|full_half
+			} //alt:full|full_half
+			baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+
+			kernelIndices[kernelOutputChannelsAxis] = outputChannel
+			//alt:base|full var outputValue T
+			var outputValue float32 //alt:half|full_half
+			var kernelFlatIdx int
+		kernelLoop:
+			for kernelFlatIdx, kernelIndices = range kernelShape.IterOnAxes(kernelSpatialAxes, kernelStrides, kernelIndices) {
+				inputFlatIdx := baseInputFlatIdx
+				for spatialIdx, kernelSpatialAxis := range axes.KernelSpatial {
+					kernelIdx := kernelIndices[kernelSpatialAxis]
+					kernelDilation := kernelDilations[spatialIdx] //alt:full|full_half
+					kernelIdx *= kernelDilation                   //alt:full|full_half
+					outputSpatialAxis := outputSpatialAxes[spatialIdx]
+					outputIdx := outputIndices[outputSpatialAxis]
+					inputIdx := outputIdx*convStrides[spatialIdx] + kernelIdx - paddings[spatialIdx][0]
+					inputDilation := inputDilations[spatialIdx] //alt:full|full_half
+					//alt:base|half if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] {
+					if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] || (inputDilation > 1 && inputIdx%inputDilation != 0) { //alt:full|full_half
+						continue kernelLoop
+					}
+					inputIdx /= inputDilation //alt:full|full_half
+					inputFlatIdx += inputIdx * inputSpatialStrides[spatialIdx]
+				}
+
+				inputChannelStride := inputStrides[inputChannelsAxis]
+				kernelChannelStride := kernelStrides[kernelInputChannelsAxis]
+				if channelGroupCount > 1 { //alt:full|full_half
+					featureGroup := outputChannel / numOutputChannelsPerGroup                    //alt:full|full_half
+					inputFlatIdx += inputChannelStride * (featureGroup * kernelNumInputChannels) //alt:full|full_half
+				} //alt:full|full_half
+				for range kernelNumInputChannels {
+					inputValue := inputFlat[inputFlatIdx]
+					kernelValue := kernelFlat[kernelFlatIdx]
+					//alt:base|full outputValue += inputValue * kernelValue
+					outputValue += inputValue.Float32() * kernelValue.Float32() //alt:half|full_half
+					inputFlatIdx += inputChannelStride
+					kernelFlatIdx += kernelChannelStride
+				}
+			}
+
+			//alt:base|full outputFlat[outputFlatIdx] = outputValue
+			P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue) //alt:half|full_half
+
+			for i := rank - 1; i >= 0; i-- {
+				outputIndices[i]++
+				if outputIndices[i] < outputDimensions[i] {
+					break
+				}
+				outputIndices[i] = 0
+			}
+		}
 	}
+
+	lenOutputs := len(outputFlat)
+	goBackend, _ := plan.backend.(*gobackend.Backend)
+	if goBackend != nil && goBackend.Workers != nil && goBackend.Workers.IsEnabled() && lenOutputs >= 512 {
+		maxWorkers := goBackend.Workers.AdjustedMaxParallelism()
+		if maxWorkers > 1 {
+			chunkSize := max(256, (lenOutputs+maxWorkers-1)/maxWorkers)
+			var wg sync.WaitGroup
+			for startIdx := 0; startIdx < lenOutputs; startIdx += chunkSize {
+				endIdx := min(startIdx+chunkSize, lenOutputs)
+				wg.Add(1)
+				goBackend.Workers.WaitToStart(func() {
+					defer wg.Done()
+					runChunk(startIdx, endIdx)
+				})
+			}
+			wg.Wait()
+			return nil
+		}
+	}
+
+	runChunk(0, lenOutputs)
 	return nil
 }

--- a/internal/gobackend/ops/gen_convgeneral_exec_half.go
+++ b/internal/gobackend/ops/gen_convgeneral_exec_half.go
@@ -8,7 +8,8 @@ package ops
 
 import (
 	"github.com/gomlx/compute/dtypes/gotype" //alt:half|full_half
-	//alt:base|full "github.com/gomlx/compute/internal/gobackend"
+	"github.com/gomlx/compute/internal/gobackend"
+	"sync"
 )
 
 // This file serves the "base" version of the `execConv*` functions, as well as a template.
@@ -71,72 +72,193 @@ func execConvNoDilationHalf[T gotype.HalfPrecision[T], P gotype.HalfPrecisionPtr
 	kernelSpatialAxes := axes.KernelSpatial
 	kernelNumInputChannels := kernelShape.Dimensions[kernelInputChannelsAxis]
 
-	// Indices we'll be iterating over.
-	var outputFlatIdx int
-
-	// Indices and strides: note we don't use an inputIndices because we only keep an inputFlatIndex.
-	outputIndices := make([]int, rank)
-	kernelIndices := make([]int, rank)
-
 	inputStrides := inputShape.Strides()
 	kernelStrides := kernelShape.Strides()
+	outputStrides := outputShape.Strides()
+	outputDimensions := outputShape.Dimensions
 
-	// Loop sequentially over all output positions:
-	for outputFlatIdx, outputIndices = range outputShape.IterOn(outputIndices) {
-		batchIdx := outputIndices[outputBatchAxis]
-		outputChannel := outputIndices[outputChannelsAxis]
-		//alt:full|full_half  if batchGroupCount > 1 {
-		//alt:full|full_half  subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup
-		//alt:full|full_half  batchIdx = subBatchIdx*outputBatchSize + batchIdx
-		//alt:full|full_half  }
-		baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+	spatialRank := len(axes.KernelSpatial)
 
-		// Loop over the kernel spatial axes, with the outputChannel given by the output loop.
-		kernelIndices[kernelOutputChannelsAxis] = outputChannel
-		//alt:base|full var outputValue T
-		var outputValue float32 //alt:half|full_half
-		var kernelFlatIdx int
-	kernelLoop:
-		for kernelFlatIdx, kernelIndices = range kernelShape.IterOnAxes(kernelSpatialAxes, kernelStrides, kernelIndices) {
-			// Calculate the corresponding position in the input.
-			inputFlatIdx := baseInputFlatIdx
-			for spatialIdx, kernelSpatialAxis := range axes.KernelSpatial {
-				kernelIdx := kernelIndices[kernelSpatialAxis]
-				//alt:full|full_half  kernelDilation := kernelDilations[spatialIdx]
-				//alt:full|full_half  kernelIdx *= kernelDilation
-				outputSpatialAxis := outputSpatialAxes[spatialIdx]
-				outputIdx := outputIndices[outputSpatialAxis]
-				inputIdx := outputIdx*convStrides[spatialIdx] + kernelIdx - paddings[spatialIdx][0]
-				//alt:full|full_half  inputDilation := inputDilations[spatialIdx]
-				if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] { //alt:base|half
-					//alt:full|full_half  if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] || (inputDilation > 1 && inputIdx%inputDilation != 0) {
-					// Index is in the padded area, we can move to the next kernel position.
-					continue kernelLoop
-				}
-				//alt:full|full_half  inputIdx /= inputDilation // Make the dilated index back to the original input.
-				inputFlatIdx += inputIdx * inputSpatialStrides[spatialIdx]
-			}
+	runChunk := func(startFlatIdx, endFlatIdx int) {
+		outputIndices := make([]int, rank)
+		kernelIndices := make([]int, rank)
 
-			// Accumulate over all the kernel/input channels.
-			inputChannelStride := inputStrides[inputChannelsAxis]
-			kernelChannelStride := kernelStrides[kernelInputChannelsAxis]
-			//alt:full|full_half  if channelGroupCount > 1 {
-			//alt:full|full_half  featureGroup := outputChannel / numOutputChannelsPerGroup
-			//alt:full|full_half  inputFlatIdx += inputChannelStride * (featureGroup*kernelNumInputChannels)
-			//alt:full|full_half  }
-			for range kernelNumInputChannels {
-				inputValue := inputFlat[inputFlatIdx]
-				kernelValue := kernelFlat[kernelFlatIdx]
-				//alt:base|full outputValue += inputValue * kernelValue
-				outputValue += inputValue.Float32() * kernelValue.Float32() //alt:half|full_half
-				inputFlatIdx += inputChannelStride
-				kernelFlatIdx += kernelChannelStride
-			}
+		remainder := startFlatIdx
+		for i := 0; i < rank; i++ {
+			outputIndices[i] = remainder / outputStrides[i]
+			remainder %= outputStrides[i]
 		}
 
-		// Update output with accumulated value from the convolution of the kernel at this position.
-		//alt:base|full outputFlat[outputFlatIdx] = outputValue
-		P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue) //alt:half|full_half
+		if spatialRank == 2 {
+			kH := kernelShape.Dimensions[kernelSpatialAxes[0]]
+			kW := kernelShape.Dimensions[kernelSpatialAxes[1]]
+			kHStride := kernelStrides[kernelSpatialAxes[0]]
+			kWStride := kernelStrides[kernelSpatialAxes[1]]
+			inSpatialStride0 := inputSpatialStrides[0]
+			inSpatialStride1 := inputSpatialStrides[1]
+			pad0 := paddings[0][0]
+			pad1 := paddings[1][0]
+			stride0 := convStrides[0]
+			stride1 := convStrides[1]
+			inDim0 := inputSpatialDims[0]
+			inDim1 := inputSpatialDims[1]
+			outSpatialAxis0 := outputSpatialAxes[0]
+			outSpatialAxis1 := outputSpatialAxes[1]
+			kOutChanStride := kernelStrides[kernelOutputChannelsAxis]
+			inChanStride := inputStrides[inputChannelsAxis]
+			kInChanStride := kernelStrides[kernelInputChannelsAxis]
+
+			for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+				batchIdx := outputIndices[outputBatchAxis]
+				outputChannel := outputIndices[outputChannelsAxis]
+				//alt:full|full_half  if batchGroupCount > 1 {
+				//alt:full|full_half  subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup
+				//alt:full|full_half  batchIdx = subBatchIdx*outputBatchSize + batchIdx
+				//alt:full|full_half  }
+				baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+				baseKernelFlatIdx := outputChannel * kOutChanStride
+
+				//alt:base|full var outputValue T
+				var outputValue float32 //alt:half|full_half
+
+				outIdx0 := outputIndices[outSpatialAxis0]
+				outIdx1 := outputIndices[outSpatialAxis1]
+
+				for ky := 0; ky < kH; ky++ {
+					kyEffective := ky
+					//alt:full|full_half  kyEffective *= kernelDilations[0]
+					inputIdx0 := outIdx0*stride0 + kyEffective - pad0
+					if inputIdx0 < 0 || inputIdx0 >= inDim0 { //alt:base|half
+						//alt:full|full_half  if inputIdx0 < 0 || inputIdx0 >= inDim0 || (inputDilations[0] > 1 && inputIdx0%inputDilations[0] != 0) {
+						continue
+					}
+					//alt:full|full_half  inputIdx0 /= inputDilations[0]
+
+					offset0 := baseInputFlatIdx + inputIdx0*inSpatialStride0
+					kOffset0 := baseKernelFlatIdx + ky*kHStride
+
+					for kx := 0; kx < kW; kx++ {
+						kxEffective := kx
+						//alt:full|full_half  kxEffective *= kernelDilations[1]
+						inputIdx1 := outIdx1*stride1 + kxEffective - pad1
+						if inputIdx1 < 0 || inputIdx1 >= inDim1 { //alt:base|half
+							//alt:full|full_half  if inputIdx1 < 0 || inputIdx1 >= inDim1 || (inputDilations[1] > 1 && inputIdx1%inputDilations[1] != 0) {
+							continue
+						}
+						//alt:full|full_half  inputIdx1 /= inputDilations[1]
+
+						inFlatIdx := offset0 + inputIdx1*inSpatialStride1
+						kFlatIdx := kOffset0 + kx*kWStride
+
+						//alt:full|full_half  if channelGroupCount > 1 {
+						//alt:full|full_half  featureGroup := outputChannel / numOutputChannelsPerGroup
+						//alt:full|full_half  inFlatIdx += inChanStride * (featureGroup*kernelNumInputChannels)
+						//alt:full|full_half  }
+
+						for c := 0; c < kernelNumInputChannels; c++ {
+							inputValue := inputFlat[inFlatIdx+c*inChanStride]
+							kernelValue := kernelFlat[kFlatIdx+c*kInChanStride]
+							//alt:base|full outputValue += inputValue * kernelValue
+							outputValue += inputValue.Float32() * kernelValue.Float32() //alt:half|full_half
+						}
+					}
+				}
+
+				//alt:base|full outputFlat[outputFlatIdx] = outputValue
+				P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue) //alt:half|full_half
+
+				for i := rank - 1; i >= 0; i-- {
+					outputIndices[i]++
+					if outputIndices[i] < outputDimensions[i] {
+						break
+					}
+					outputIndices[i] = 0
+				}
+			}
+			return
+		}
+
+		for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+			batchIdx := outputIndices[outputBatchAxis]
+			outputChannel := outputIndices[outputChannelsAxis]
+			//alt:full|full_half  if batchGroupCount > 1 {
+			//alt:full|full_half  subBatchIdx := outputChannel / numOutputChannelsPerBatchGroup
+			//alt:full|full_half  batchIdx = subBatchIdx*outputBatchSize + batchIdx
+			//alt:full|full_half  }
+			baseInputFlatIdx := batchIdx * inputStrides[inputBatchAxis]
+
+			kernelIndices[kernelOutputChannelsAxis] = outputChannel
+			//alt:base|full var outputValue T
+			var outputValue float32 //alt:half|full_half
+			var kernelFlatIdx int
+		kernelLoop:
+			for kernelFlatIdx, kernelIndices = range kernelShape.IterOnAxes(kernelSpatialAxes, kernelStrides, kernelIndices) {
+				inputFlatIdx := baseInputFlatIdx
+				for spatialIdx, kernelSpatialAxis := range axes.KernelSpatial {
+					kernelIdx := kernelIndices[kernelSpatialAxis]
+					//alt:full|full_half  kernelDilation := kernelDilations[spatialIdx]
+					//alt:full|full_half  kernelIdx *= kernelDilation
+					outputSpatialAxis := outputSpatialAxes[spatialIdx]
+					outputIdx := outputIndices[outputSpatialAxis]
+					inputIdx := outputIdx*convStrides[spatialIdx] + kernelIdx - paddings[spatialIdx][0]
+					//alt:full|full_half  inputDilation := inputDilations[spatialIdx]
+					if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] { //alt:base|half
+						//alt:full|full_half  if inputIdx < 0 || inputIdx >= inputSpatialDims[spatialIdx] || (inputDilation > 1 && inputIdx%inputDilation != 0) {
+						continue kernelLoop
+					}
+					//alt:full|full_half  inputIdx /= inputDilation
+					inputFlatIdx += inputIdx * inputSpatialStrides[spatialIdx]
+				}
+
+				inputChannelStride := inputStrides[inputChannelsAxis]
+				kernelChannelStride := kernelStrides[kernelInputChannelsAxis]
+				//alt:full|full_half  if channelGroupCount > 1 {
+				//alt:full|full_half  featureGroup := outputChannel / numOutputChannelsPerGroup
+				//alt:full|full_half  inputFlatIdx += inputChannelStride * (featureGroup*kernelNumInputChannels)
+				//alt:full|full_half  }
+				for range kernelNumInputChannels {
+					inputValue := inputFlat[inputFlatIdx]
+					kernelValue := kernelFlat[kernelFlatIdx]
+					//alt:base|full outputValue += inputValue * kernelValue
+					outputValue += inputValue.Float32() * kernelValue.Float32() //alt:half|full_half
+					inputFlatIdx += inputChannelStride
+					kernelFlatIdx += kernelChannelStride
+				}
+			}
+
+			//alt:base|full outputFlat[outputFlatIdx] = outputValue
+			P(&outputFlat[outputFlatIdx]).SetFloat32(outputValue) //alt:half|full_half
+
+			for i := rank - 1; i >= 0; i-- {
+				outputIndices[i]++
+				if outputIndices[i] < outputDimensions[i] {
+					break
+				}
+				outputIndices[i] = 0
+			}
+		}
 	}
+
+	lenOutputs := len(outputFlat)
+	goBackend, _ := plan.backend.(*gobackend.Backend)
+	if goBackend != nil && goBackend.Workers != nil && goBackend.Workers.IsEnabled() && lenOutputs >= 512 {
+		maxWorkers := goBackend.Workers.AdjustedMaxParallelism()
+		if maxWorkers > 1 {
+			chunkSize := max(256, (lenOutputs+maxWorkers-1)/maxWorkers)
+			var wg sync.WaitGroup
+			for startIdx := 0; startIdx < lenOutputs; startIdx += chunkSize {
+				endIdx := min(startIdx+chunkSize, lenOutputs)
+				wg.Add(1)
+				goBackend.Workers.WaitToStart(func() {
+					defer wg.Done()
+					runChunk(startIdx, endIdx)
+				})
+			}
+			wg.Wait()
+			return nil
+		}
+	}
+
+	runChunk(0, lenOutputs)
 	return nil
 }

--- a/internal/gobackend/ops/gen_dtypemaps_registration.go
+++ b/internal/gobackend/ops/gen_dtypemaps_registration.go
@@ -328,6 +328,22 @@ func init() {
 	scatterDTypeMap.Register(dtypes.Uint64, gobackend.PriorityGeneric, execScatterGeneric[uint64])
 	scatterDTypeMap.Register(dtypes.Uint8, gobackend.PriorityGeneric, execScatterGeneric[uint8])
 
+	// DTypeMap: selectAndScatterDTypeMap
+	selectAndScatterDTypeMap.Register(dtypes.Float32, gobackend.PriorityGeneric, execSelectAndScatterGeneric[float32])
+	selectAndScatterDTypeMap.Register(dtypes.Float64, gobackend.PriorityGeneric, execSelectAndScatterGeneric[float64])
+	selectAndScatterDTypeMap.Register(dtypes.Int16, gobackend.PriorityGeneric, execSelectAndScatterGeneric[int16])
+	selectAndScatterDTypeMap.Register(dtypes.Int32, gobackend.PriorityGeneric, execSelectAndScatterGeneric[int32])
+	selectAndScatterDTypeMap.Register(dtypes.Int64, gobackend.PriorityGeneric, execSelectAndScatterGeneric[int64])
+	selectAndScatterDTypeMap.Register(dtypes.Int8, gobackend.PriorityGeneric, execSelectAndScatterGeneric[int8])
+	selectAndScatterDTypeMap.Register(dtypes.Uint16, gobackend.PriorityGeneric, execSelectAndScatterGeneric[uint16])
+	selectAndScatterDTypeMap.Register(dtypes.Uint32, gobackend.PriorityGeneric, execSelectAndScatterGeneric[uint32])
+	selectAndScatterDTypeMap.Register(dtypes.Uint64, gobackend.PriorityGeneric, execSelectAndScatterGeneric[uint64])
+	selectAndScatterDTypeMap.Register(dtypes.Uint8, gobackend.PriorityGeneric, execSelectAndScatterGeneric[uint8])
+
+	// DTypeMap: selectAndScatterDTypeMap
+	selectAndScatterDTypeMap.Register(dtypes.BFloat16, gobackend.PriorityGeneric, execSelectAndScatterGenericHalf[bfloat16.BFloat16])
+	selectAndScatterDTypeMap.Register(dtypes.Float16, gobackend.PriorityGeneric, execSelectAndScatterGenericHalf[float16.Float16])
+
 	// DTypeMap: shiftLeftDTypeMap
 	shiftLeftDTypeMap.Register(dtypes.Int16, gobackend.PriorityGeneric, shiftLeftGeneric[int16])
 	shiftLeftDTypeMap.Register(dtypes.Int32, gobackend.PriorityGeneric, shiftLeftGeneric[int32])

--- a/internal/gobackend/ops/reducewindow.go
+++ b/internal/gobackend/ops/reducewindow.go
@@ -2,6 +2,7 @@ package ops
 
 import (
 	"slices"
+	"sync"
 
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes/gotype"
@@ -187,40 +188,77 @@ func execReduceWindow(backend *gobackend.Backend, node *gobackend.Node, inputs [
 	//   More specifically we would split windowShape into "nonCachedWindowShape" and "cachedWindowShape", and
 	//   iterate over the nonCachedWindowShape first.
 	// - Can we refactor the check of baseDilation to outside of the loop ?
-	windowIndices := make([]int, rank)
-	operandIndices := make([]int, rank)
-	for outputFlatIdx, outputIndices := range outputShape.Iter() {
-		// fmt.Printf("Output %v:\n", outputIndices)
-	iterWindowIndices:
-		for _, windowIndices = range windowShape.IterOn(windowIndices) {
-			// fmt.Printf("\t- window %v\n", windowIndices)
-			for axis := range rank {
-				operandIdx := outputIndices[axis]*effStrides[axis] + operandShifts[axis]
-				operandIdx += windowIndices[axis] * effWindowDilations[axis]
-				if operandIdx < 0 {
-					// This index is out of the operand values (padding), nothing to update.
-					continue iterWindowIndices
-				}
-				if effBaseDilations[axis] > 1 {
-					if operandIdx%effBaseDilations[axis] != 0 {
-						// This index is not aligned with the baseDilation, nothing to update.
+	outputStrides := outputShape.Strides()
+	outputDimensions := outputShape.Dimensions
+
+	runChunk := func(startFlatIdx, endFlatIdx int) {
+		windowIndices := make([]int, rank)
+		operandIndices := make([]int, rank)
+		outputIndices := make([]int, rank)
+
+		remainder := startFlatIdx
+		for i := 0; i < rank; i++ {
+			outputIndices[i] = remainder / outputStrides[i]
+			remainder %= outputStrides[i]
+		}
+
+		for outputFlatIdx := startFlatIdx; outputFlatIdx < endFlatIdx; outputFlatIdx++ {
+		iterWindowIndices:
+			for _, windowIndices = range windowShape.IterOn(windowIndices) {
+				for axis := range rank {
+					operandIdx := outputIndices[axis]*effStrides[axis] + operandShifts[axis]
+					operandIdx += windowIndices[axis] * effWindowDilations[axis]
+					if operandIdx < 0 {
 						continue iterWindowIndices
 					}
-					operandIdx /= effBaseDilations[axis]
+					if effBaseDilations[axis] > 1 {
+						if operandIdx%effBaseDilations[axis] != 0 {
+							continue iterWindowIndices
+						}
+						operandIdx /= effBaseDilations[axis]
+					}
+					if operandIdx >= operandShape.Dimensions[axis] {
+						continue iterWindowIndices
+					}
+					operandIndices[axis] = operandIdx
 				}
-				if operandIdx >= operandShape.Dimensions[axis] {
-					// This index is out of the operand values (padding), nothing to update.
-					continue iterWindowIndices
+				operandFlatIdx := 0
+				for axis, operandIdx := range operandIndices {
+					operandFlatIdx += operandIdx * operandStrides[axis]
 				}
-				operandIndices[axis] = operandIdx
+				updateFn(operandFlatIdx, outputFlatIdx)
 			}
-			operandFlatIdx := 0
-			for axis, operandIdx := range operandIndices {
-				operandFlatIdx += operandIdx * operandStrides[axis]
+
+			for i := rank - 1; i >= 0; i-- {
+				outputIndices[i]++
+				if outputIndices[i] < outputDimensions[i] {
+					break
+				}
+				outputIndices[i] = 0
 			}
-			updateFn(operandFlatIdx, outputFlatIdx)
 		}
 	}
+
+	lenOutputs := outputShape.Size()
+	if backend != nil && backend.Workers != nil && backend.Workers.IsEnabled() && lenOutputs >= 512 {
+		maxWorkers := backend.Workers.AdjustedMaxParallelism()
+		if maxWorkers > 1 {
+			chunkSize := max(256, (lenOutputs+maxWorkers-1)/maxWorkers)
+			var wg sync.WaitGroup
+			for startIdx := 0; startIdx < lenOutputs; startIdx += chunkSize {
+				endIdx := min(startIdx+chunkSize, lenOutputs)
+				wg.Add(1)
+				backend.Workers.WaitToStart(func() {
+					defer wg.Done()
+					runChunk(startIdx, endIdx)
+				})
+			}
+			wg.Wait()
+			return output, nil
+		}
+	}
+
+	runChunk(0, lenOutputs)
 	return output, nil
 }
 

--- a/internal/gobackend/ops/selectandscatter.go
+++ b/internal/gobackend/ops/selectandscatter.go
@@ -4,6 +4,7 @@ package ops
 
 import (
 	"slices"
+	"sync"
 
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes/gotype"
@@ -155,42 +156,122 @@ func execSelectAndScatterGeneric[T gobackend.PODNumericConstraints](
 		stride *= operandShape.Dimensions[axis]
 	}
 
-	windowIndices := make([]int, rank)
-	for sourceFlatIdx, sourceIndices := range sourceShape.Iter() {
-		bestOperandFlatIdx := -1
-		var bestOperandVal T
-	iterWindowIndices:
-		for _, windowIndices = range windowShape.IterOn(windowIndices) {
-			operandFlatIdx := 0
-			for axis := range rank {
-				operandIdx := sourceIndices[axis]*effStrides[axis] - effPaddings[axis][0] + windowIndices[axis]
-				if operandIdx < 0 || operandIdx >= operandShape.Dimensions[axis] {
-					continue iterWindowIndices
-				}
-				operandFlatIdx += operandIdx * operandStrides[axis]
-			}
-			val := operandFlat[operandFlatIdx]
-			if bestOperandFlatIdx == -1 {
-				bestOperandFlatIdx = operandFlatIdx
-				bestOperandVal = val
-			} else if isMin {
-				valIsNaN := val != val
-				if val < bestOperandVal || valIsNaN {
-					bestOperandVal = val
-					bestOperandFlatIdx = operandFlatIdx
-				}
-			} else {
-				valIsNaN := val != val
-				if val > bestOperandVal || valIsNaN {
-					bestOperandVal = val
-					bestOperandFlatIdx = operandFlatIdx
-				}
-			}
+	sourceStrides := sourceShape.Strides()
+	sourceDimensions := sourceShape.Dimensions
+
+	runChunk := func(startFlatIdx, endFlatIdx int, targetOutput []T) {
+		sourceIndices := make([]int, rank)
+		windowIndices := make([]int, rank)
+
+		remainder := startFlatIdx
+		for i := 0; i < rank; i++ {
+			sourceIndices[i] = remainder / sourceStrides[i]
+			remainder %= sourceStrides[i]
 		}
-		if bestOperandFlatIdx != -1 {
-			outputFlat[bestOperandFlatIdx] += sourceFlat[sourceFlatIdx]
+
+		for sourceFlatIdx := startFlatIdx; sourceFlatIdx < endFlatIdx; sourceFlatIdx++ {
+			bestOperandFlatIdx := -1
+			var bestOperandVal T
+		iterWindowIndices:
+			for _, windowIndices = range windowShape.IterOn(windowIndices) {
+				operandFlatIdx := 0
+				for axis := range rank {
+					operandIdx := sourceIndices[axis]*effStrides[axis] - effPaddings[axis][0] + windowIndices[axis]
+					if operandIdx < 0 || operandIdx >= operandShape.Dimensions[axis] {
+						continue iterWindowIndices
+					}
+					operandFlatIdx += operandIdx * operandStrides[axis]
+				}
+				val := operandFlat[operandFlatIdx]
+				if bestOperandFlatIdx == -1 {
+					bestOperandFlatIdx = operandFlatIdx
+					bestOperandVal = val
+				} else if isMin {
+					valIsNaN := val != val
+					if val < bestOperandVal || valIsNaN {
+						bestOperandVal = val
+						bestOperandFlatIdx = operandFlatIdx
+					}
+				} else {
+					valIsNaN := val != val
+					if val > bestOperandVal || valIsNaN {
+						bestOperandVal = val
+						bestOperandFlatIdx = operandFlatIdx
+					}
+				}
+			}
+			if bestOperandFlatIdx != -1 {
+				targetOutput[bestOperandFlatIdx] += sourceFlat[sourceFlatIdx]
+			}
+
+			for i := rank - 1; i >= 0; i-- {
+				sourceIndices[i]++
+				if sourceIndices[i] < sourceDimensions[i] {
+					break
+				}
+				sourceIndices[i] = 0
+			}
 		}
 	}
+
+	lenSource := len(sourceFlat)
+	if backend != nil && backend.Workers != nil && backend.Workers.IsEnabled() && lenSource >= 512 {
+		maxWorkers := backend.Workers.AdjustedMaxParallelism()
+		if maxWorkers > 1 {
+			if rank >= 2 && effWindowDimensions[0] == 1 && effStrides[0] >= 1 && effPaddings[0][0] == 0 && effPaddings[0][1] == 0 && sourceDimensions[0] > 1 {
+				batchCount := sourceDimensions[0]
+				elementsPerBatch := lenSource / batchCount
+				chunkBatches := max(1, (batchCount+maxWorkers-1)/maxWorkers)
+				var wg sync.WaitGroup
+				for startBatch := 0; startBatch < batchCount; startBatch += chunkBatches {
+					endBatch := min(startBatch+chunkBatches, batchCount)
+					startIdx := startBatch * elementsPerBatch
+					endIdx := endBatch * elementsPerBatch
+					wg.Add(1)
+					backend.Workers.WaitToStart(func() {
+						defer wg.Done()
+						runChunk(startIdx, endIdx, outputFlat)
+					})
+				}
+				wg.Wait()
+				return
+			} else {
+				numChunks := min(maxWorkers, (lenSource+255)/256)
+				chunkSize := (lenSource + numChunks - 1) / numChunks
+				var wg sync.WaitGroup
+				var mu sync.Mutex
+				for c := 0; c < numChunks; c++ {
+					startIdx := c * chunkSize
+					if startIdx >= lenSource {
+						break
+					}
+					endIdx := min(startIdx+chunkSize, lenSource)
+					isMain := (c == 0)
+					wg.Add(1)
+					backend.Workers.WaitToStart(func() {
+						defer wg.Done()
+						if isMain {
+							runChunk(startIdx, endIdx, outputFlat)
+						} else {
+							localOutput := make([]T, len(outputFlat))
+							runChunk(startIdx, endIdx, localOutput)
+							mu.Lock()
+							for i, v := range localOutput {
+								if v != 0 {
+									outputFlat[i] += v
+								}
+							}
+							mu.Unlock()
+						}
+					})
+				}
+				wg.Wait()
+				return
+			}
+		}
+	}
+
+	runChunk(0, lenSource, outputFlat)
 }
 
 func execSelectAndScatterGenericHalf[T gotype.HalfPrecision[T], P gotype.HalfPrecisionPtr[T]](
@@ -218,41 +299,123 @@ func execSelectAndScatterGenericHalf[T gotype.HalfPrecision[T], P gotype.HalfPre
 		stride *= operandShape.Dimensions[axis]
 	}
 
-	windowIndices := make([]int, rank)
-	for sourceFlatIdx, sourceIndices := range sourceShape.Iter() {
-		bestOperandFlatIdx := -1
-		var bestOperandVal float32
-	iterWindowIndices:
-		for _, windowIndices = range windowShape.IterOn(windowIndices) {
-			operandFlatIdx := 0
-			for axis := range rank {
-				operandIdx := sourceIndices[axis]*effStrides[axis] - effPaddings[axis][0] + windowIndices[axis]
-				if operandIdx < 0 || operandIdx >= operandShape.Dimensions[axis] {
-					continue iterWindowIndices
-				}
-				operandFlatIdx += operandIdx * operandStrides[axis]
-			}
-			val := operandFlat[operandFlatIdx].Float32()
-			if bestOperandFlatIdx == -1 {
-				bestOperandFlatIdx = operandFlatIdx
-				bestOperandVal = val
-			} else if isMin {
-				valIsNaN := val != val
-				if val < bestOperandVal || valIsNaN {
-					bestOperandVal = val
-					bestOperandFlatIdx = operandFlatIdx
-				}
-			} else {
-				valIsNaN := val != val
-				if val > bestOperandVal || valIsNaN {
-					bestOperandVal = val
-					bestOperandFlatIdx = operandFlatIdx
-				}
-			}
+	sourceStrides := sourceShape.Strides()
+	sourceDimensions := sourceShape.Dimensions
+
+	runChunk := func(startFlatIdx, endFlatIdx int, targetOutput []T) {
+		sourceIndices := make([]int, rank)
+		windowIndices := make([]int, rank)
+
+		remainder := startFlatIdx
+		for i := 0; i < rank; i++ {
+			sourceIndices[i] = remainder / sourceStrides[i]
+			remainder %= sourceStrides[i]
 		}
-		if bestOperandFlatIdx != -1 {
-			sum := outputFlat[bestOperandFlatIdx].Float32() + sourceFlat[sourceFlatIdx].Float32()
-			P(&outputFlat[bestOperandFlatIdx]).SetFloat32(sum)
+
+		for sourceFlatIdx := startFlatIdx; sourceFlatIdx < endFlatIdx; sourceFlatIdx++ {
+			bestOperandFlatIdx := -1
+			var bestOperandVal float32
+		iterWindowIndices:
+			for _, windowIndices = range windowShape.IterOn(windowIndices) {
+				operandFlatIdx := 0
+				for axis := range rank {
+					operandIdx := sourceIndices[axis]*effStrides[axis] - effPaddings[axis][0] + windowIndices[axis]
+					if operandIdx < 0 || operandIdx >= operandShape.Dimensions[axis] {
+						continue iterWindowIndices
+					}
+					operandFlatIdx += operandIdx * operandStrides[axis]
+				}
+				val := operandFlat[operandFlatIdx].Float32()
+				if bestOperandFlatIdx == -1 {
+					bestOperandFlatIdx = operandFlatIdx
+					bestOperandVal = val
+				} else if isMin {
+					valIsNaN := val != val
+					if val < bestOperandVal || valIsNaN {
+						bestOperandVal = val
+						bestOperandFlatIdx = operandFlatIdx
+					}
+				} else {
+					valIsNaN := val != val
+					if val > bestOperandVal || valIsNaN {
+						bestOperandVal = val
+						bestOperandFlatIdx = operandFlatIdx
+					}
+				}
+			}
+			if bestOperandFlatIdx != -1 {
+				sum := targetOutput[bestOperandFlatIdx].Float32() + sourceFlat[sourceFlatIdx].Float32()
+				P(&targetOutput[bestOperandFlatIdx]).SetFloat32(sum)
+			}
+
+			for i := rank - 1; i >= 0; i-- {
+				sourceIndices[i]++
+				if sourceIndices[i] < sourceDimensions[i] {
+					break
+				}
+				sourceIndices[i] = 0
+			}
 		}
 	}
+
+	lenSource := len(sourceFlat)
+	if backend != nil && backend.Workers != nil && backend.Workers.IsEnabled() && lenSource >= 512 {
+		maxWorkers := backend.Workers.AdjustedMaxParallelism()
+		if maxWorkers > 1 {
+			if rank >= 2 && effWindowDimensions[0] == 1 && effStrides[0] >= 1 && effPaddings[0][0] == 0 && effPaddings[0][1] == 0 && sourceDimensions[0] > 1 {
+				batchCount := sourceDimensions[0]
+				elementsPerBatch := lenSource / batchCount
+				chunkBatches := max(1, (batchCount+maxWorkers-1)/maxWorkers)
+				var wg sync.WaitGroup
+				for startBatch := 0; startBatch < batchCount; startBatch += chunkBatches {
+					endBatch := min(startBatch+chunkBatches, batchCount)
+					startIdx := startBatch * elementsPerBatch
+					endIdx := endBatch * elementsPerBatch
+					wg.Add(1)
+					backend.Workers.WaitToStart(func() {
+						defer wg.Done()
+						runChunk(startIdx, endIdx, outputFlat)
+					})
+				}
+				wg.Wait()
+				return
+			} else {
+				numChunks := min(maxWorkers, (lenSource+255)/256)
+				chunkSize := (lenSource + numChunks - 1) / numChunks
+				var wg sync.WaitGroup
+				var mu sync.Mutex
+				for c := 0; c < numChunks; c++ {
+					startIdx := c * chunkSize
+					if startIdx >= lenSource {
+						break
+					}
+					endIdx := min(startIdx+chunkSize, lenSource)
+					isMain := (c == 0)
+					wg.Add(1)
+					backend.Workers.WaitToStart(func() {
+						defer wg.Done()
+						if isMain {
+							runChunk(startIdx, endIdx, outputFlat)
+						} else {
+							localOutput := make([]T, len(outputFlat))
+							runChunk(startIdx, endIdx, localOutput)
+							mu.Lock()
+							for i, v := range localOutput {
+								if v.Float32() != 0 {
+									sum := outputFlat[i].Float32() + v.Float32()
+									P(&outputFlat[i]).SetFloat32(sum)
+								}
+							}
+							mu.Unlock()
+						}
+					})
+				}
+				wg.Wait()
+				return
+			}
+		}
+	}
+
+	runChunk(0, lenSource, outputFlat)
 }
+

--- a/internal/gobackend/ops/selectandscatter.go
+++ b/internal/gobackend/ops/selectandscatter.go
@@ -1,0 +1,258 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package ops
+
+import (
+	"slices"
+
+	"github.com/gomlx/compute"
+	"github.com/gomlx/compute/dtypes/gotype"
+	"github.com/gomlx/compute/internal/gobackend"
+	"github.com/gomlx/compute/shapeinference"
+	"github.com/gomlx/compute/shapes"
+	"github.com/gomlx/compute/support/xslices"
+)
+
+func init() {
+	gobackend.RegisterSelectAndScatterMax.Register(SelectAndScatterMax, gobackend.PriorityGeneric)
+	gobackend.RegisterSelectAndScatterMin.Register(SelectAndScatterMin, gobackend.PriorityGeneric)
+	gobackend.SetNodeExecutor(compute.OpTypeSelectAndScatterMax, gobackend.PriorityGeneric, execSelectAndScatter)
+	gobackend.SetNodeExecutor(compute.OpTypeSelectAndScatterMin, gobackend.PriorityGeneric, execSelectAndScatter)
+}
+
+type selectAndScatterNode struct {
+	isMin                     bool
+	windowDimensions, strides []int
+	paddings                  [][2]int
+}
+
+// EqualNodeData implements nodeDataComparable for selectAndScatterNode.
+func (s *selectAndScatterNode) EqualNodeData(other gobackend.NodeDataComparable) bool {
+	o := other.(*selectAndScatterNode)
+	if s.isMin != o.isMin {
+		return false
+	}
+	return slices.Equal(s.windowDimensions, o.windowDimensions) &&
+		slices.Equal(s.strides, o.strides) &&
+		slices.Equal(s.paddings, o.paddings)
+}
+
+// SelectAndScatterMax runs windows over operand, selects maximum elements in each window, and scatters source values to the output.
+func SelectAndScatterMax(f *gobackend.Function,
+	operandOp, sourceOp compute.Value,
+	windowDimensions, strides []int,
+	paddings [][2]int,
+) (compute.Value, error) {
+	return selectAndScatterImpl(f, compute.OpTypeSelectAndScatterMax, operandOp, sourceOp, windowDimensions, strides, paddings, false)
+}
+
+// SelectAndScatterMin runs windows over operand, selects minimum elements in each window, and scatters source values to the output.
+func SelectAndScatterMin(f *gobackend.Function,
+	operandOp, sourceOp compute.Value,
+	windowDimensions, strides []int,
+	paddings [][2]int,
+) (compute.Value, error) {
+	return selectAndScatterImpl(f, compute.OpTypeSelectAndScatterMin, operandOp, sourceOp, windowDimensions, strides, paddings, true)
+}
+
+func selectAndScatterImpl(f *gobackend.Function,
+	opType compute.OpType,
+	operandOp, sourceOp compute.Value,
+	windowDimensions, strides []int,
+	paddings [][2]int,
+	isMin bool,
+) (compute.Value, error) {
+	inputs, err := f.VerifyAndCastValues(opType.String(), operandOp, sourceOp)
+	if err != nil {
+		return nil, err
+	}
+	operand, source := inputs[0], inputs[1]
+	outputShape, err := shapeinference.SelectAndScatter(
+		operand.Shape,
+		source.Shape,
+		windowDimensions,
+		strides,
+		paddings,
+	)
+	if err != nil {
+		return nil, err
+	}
+	data := &selectAndScatterNode{
+		isMin:            isMin,
+		windowDimensions: windowDimensions,
+		strides:          strides,
+		paddings:         paddings,
+	}
+	node, _ := f.GetOrCreateNode(opType, outputShape, []*gobackend.Node{operand, source}, data)
+	return node, nil
+}
+
+func execSelectAndScatter(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, _ []bool) (*gobackend.Buffer, error) {
+	operand := inputs[0]
+	source := inputs[1]
+	operandShape := operand.RawShape
+	rank := operandShape.Rank()
+	dtype := operandShape.DType
+	outputShape := node.Shape
+	output, err := backend.GetBuffer(outputShape)
+	if err != nil {
+		return nil, err
+	}
+	output.Zeros()
+
+	opData := node.Data.(*selectAndScatterNode)
+
+	effWindowDimensions := opData.windowDimensions
+	if effWindowDimensions == nil {
+		effWindowDimensions = xslices.SliceWithValue(rank, 1)
+	}
+	effStrides := opData.strides
+	if effStrides == nil {
+		effStrides = effWindowDimensions
+	}
+	effPaddings := opData.paddings
+	if effPaddings == nil {
+		effPaddings = xslices.SliceWithValue(rank, [2]int{0, 0})
+	}
+
+	execFnAny, err := selectAndScatterDTypeMap.Get(dtype)
+	if err != nil {
+		return nil, err
+	}
+	execFn := execFnAny.(func(backend *gobackend.Backend, operand, source, output *gobackend.Buffer, effWindowDimensions, effStrides []int, effPaddings [][2]int, isMin bool))
+	execFn(backend, operand, source, output, effWindowDimensions, effStrides, effPaddings, opData.isMin)
+	return output, nil
+}
+
+var (
+	//gobackend:dtypemap execSelectAndScatterGeneric ints,uints,floats
+	//gobackend:dtypemap execSelectAndScatterGenericHalf half
+	selectAndScatterDTypeMap = gobackend.NewDTypeMap("selectAndScatterDTypeMap")
+)
+
+func execSelectAndScatterGeneric[T gobackend.PODNumericConstraints](
+	backend *gobackend.Backend,
+	operand, source, output *gobackend.Buffer,
+	effWindowDimensions, effStrides []int,
+	effPaddings [][2]int,
+	isMin bool,
+) {
+	operandFlat := operand.Flat.([]T)
+	sourceFlat := source.Flat.([]T)
+	outputFlat := output.Flat.([]T)
+
+	operandShape := operand.RawShape
+	sourceShape := source.RawShape
+	rank := operandShape.Rank()
+	dtype := operandShape.DType
+
+	windowShape := shapes.Make(dtype, effWindowDimensions...)
+
+	operandStrides := make([]int, rank)
+	stride := 1
+	for axis := rank - 1; axis >= 0; axis-- {
+		operandStrides[axis] = stride
+		stride *= operandShape.Dimensions[axis]
+	}
+
+	windowIndices := make([]int, rank)
+	for sourceFlatIdx, sourceIndices := range sourceShape.Iter() {
+		bestOperandFlatIdx := -1
+		var bestOperandVal T
+	iterWindowIndices:
+		for _, windowIndices = range windowShape.IterOn(windowIndices) {
+			operandFlatIdx := 0
+			for axis := range rank {
+				operandIdx := sourceIndices[axis]*effStrides[axis] - effPaddings[axis][0] + windowIndices[axis]
+				if operandIdx < 0 || operandIdx >= operandShape.Dimensions[axis] {
+					continue iterWindowIndices
+				}
+				operandFlatIdx += operandIdx * operandStrides[axis]
+			}
+			val := operandFlat[operandFlatIdx]
+			if bestOperandFlatIdx == -1 {
+				bestOperandFlatIdx = operandFlatIdx
+				bestOperandVal = val
+			} else if isMin {
+				valIsNaN := val != val
+				if val < bestOperandVal || valIsNaN {
+					bestOperandVal = val
+					bestOperandFlatIdx = operandFlatIdx
+				}
+			} else {
+				valIsNaN := val != val
+				if val > bestOperandVal || valIsNaN {
+					bestOperandVal = val
+					bestOperandFlatIdx = operandFlatIdx
+				}
+			}
+		}
+		if bestOperandFlatIdx != -1 {
+			outputFlat[bestOperandFlatIdx] += sourceFlat[sourceFlatIdx]
+		}
+	}
+}
+
+func execSelectAndScatterGenericHalf[T gotype.HalfPrecision[T], P gotype.HalfPrecisionPtr[T]](
+	backend *gobackend.Backend,
+	operand, source, output *gobackend.Buffer,
+	effWindowDimensions, effStrides []int,
+	effPaddings [][2]int,
+	isMin bool,
+) {
+	operandFlat := operand.Flat.([]T)
+	sourceFlat := source.Flat.([]T)
+	outputFlat := output.Flat.([]T)
+
+	operandShape := operand.RawShape
+	sourceShape := source.RawShape
+	rank := operandShape.Rank()
+	dtype := operandShape.DType
+
+	windowShape := shapes.Make(dtype, effWindowDimensions...)
+
+	operandStrides := make([]int, rank)
+	stride := 1
+	for axis := rank - 1; axis >= 0; axis-- {
+		operandStrides[axis] = stride
+		stride *= operandShape.Dimensions[axis]
+	}
+
+	windowIndices := make([]int, rank)
+	for sourceFlatIdx, sourceIndices := range sourceShape.Iter() {
+		bestOperandFlatIdx := -1
+		var bestOperandVal float32
+	iterWindowIndices:
+		for _, windowIndices = range windowShape.IterOn(windowIndices) {
+			operandFlatIdx := 0
+			for axis := range rank {
+				operandIdx := sourceIndices[axis]*effStrides[axis] - effPaddings[axis][0] + windowIndices[axis]
+				if operandIdx < 0 || operandIdx >= operandShape.Dimensions[axis] {
+					continue iterWindowIndices
+				}
+				operandFlatIdx += operandIdx * operandStrides[axis]
+			}
+			val := operandFlat[operandFlatIdx].Float32()
+			if bestOperandFlatIdx == -1 {
+				bestOperandFlatIdx = operandFlatIdx
+				bestOperandVal = val
+			} else if isMin {
+				valIsNaN := val != val
+				if val < bestOperandVal || valIsNaN {
+					bestOperandVal = val
+					bestOperandFlatIdx = operandFlatIdx
+				}
+			} else {
+				valIsNaN := val != val
+				if val > bestOperandVal || valIsNaN {
+					bestOperandVal = val
+					bestOperandFlatIdx = operandFlatIdx
+				}
+			}
+		}
+		if bestOperandFlatIdx != -1 {
+			sum := outputFlat[bestOperandFlatIdx].Float32() + sourceFlat[sourceFlatIdx].Float32()
+			P(&outputFlat[bestOperandFlatIdx]).SetFloat32(sum)
+		}
+	}
+}

--- a/shapeinference/shapeinference.go
+++ b/shapeinference/shapeinference.go
@@ -1369,6 +1369,29 @@ func ReduceWindow(operand shapes.Shape, windowDimensions, strides, baseDilations
 	return result, nil
 }
 
+// SelectAndScatter returns the expected output shape for SelectAndScatter operations (SelectAndScatterMax and SelectAndScatterMin).
+// The output shape is equal to the operand shape.
+func SelectAndScatter(operand, source shapes.Shape, windowDimensions, windowStrides []int, paddings [][2]int) (shapes.Shape, error) {
+	if !operand.Ok() {
+		return shapes.Invalid(), errors.Errorf("SelectAndScatterOp: invalid operand shape %s", operand)
+	}
+	if !source.Ok() {
+		return shapes.Invalid(), errors.Errorf("SelectAndScatterOp: invalid source shape %s", source)
+	}
+	if operand.DType != source.DType {
+		return shapes.Invalid(), errors.Errorf("SelectAndScatterOp: operand DType %s does not match source DType %s", operand.DType, source.DType)
+	}
+	expectedSourceShape, err := ReduceWindow(operand, windowDimensions, windowStrides, nil, nil, paddings)
+	if err != nil {
+		return shapes.Invalid(), errors.Wrapf(err, "SelectAndScatterOp: invalid window parameters for operand shape %s", operand)
+	}
+	if !source.EqualDimensions(expectedSourceShape) {
+		return shapes.Invalid(), errors.Errorf("SelectAndScatterOp: source shape %s dimensions do not match expected source shape %s for operand shape %s", source, expectedSourceShape, operand)
+	}
+	return operand.Clone(), nil
+}
+
+
 // ConvGeneral returns the expected output shape for the ConvGeneral operation.
 func ConvGeneral(input, kernel shapes.Shape, axes compute.ConvolveAxesConfig,
 	strides []int, paddings [][2]int,

--- a/shapeinference/shapeinference_test.go
+++ b/shapeinference/shapeinference_test.go
@@ -824,6 +824,35 @@ func TestReduceWindowOp(t *testing.T) {
 	}
 }
 
+func TestSelectAndScatterOp(t *testing.T) {
+	operand := shapes.Make(dtypes.Float32, 10, 20)
+	source := shapes.Make(dtypes.Float32, 5, 10)
+	windowDimensions := []int{2, 2}
+	strides := []int{2, 2}
+
+	outputShape, err := SelectAndScatter(operand, source, windowDimensions, strides, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error in SelectAndScatter: %v", err)
+	}
+	if !outputShape.Equal(operand) {
+		t.Errorf("SelectAndScatter output shape %s, expected %s", outputShape, operand)
+	}
+
+	// Mismatched source shape
+	badSource := shapes.Make(dtypes.Float32, 5, 5)
+	_, err = SelectAndScatter(operand, badSource, windowDimensions, strides, nil)
+	if err == nil {
+		t.Errorf("Expected error for mismatched source shape")
+	}
+
+	// Mismatched DType
+	badDTypeSource := shapes.Make(dtypes.Int32, 5, 10)
+	_, err = SelectAndScatter(operand, badDTypeSource, windowDimensions, strides, nil)
+	if err == nil {
+		t.Errorf("Expected error for mismatched DType")
+	}
+}
+
 func TestGather(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		// operand: F32[3, 4], startIndices: I32[2, 1]

--- a/support/backendtest/special.go
+++ b/support/backendtest/special.go
@@ -961,4 +961,104 @@ func TestSpecialOps(t *testing.T, b compute.Backend) {
 			})
 		}
 	})
+
+	t.Run("SelectAndScatter", func(t *testing.T) {
+		t.Run("Max", func(t *testing.T) {
+			testutil.SkipIfMissing(t, b, compute.OpTypeSelectAndScatterMax)
+			type testCase struct {
+				name             string
+				operandData      any
+				sourceData       any
+				windowDimensions []int
+				strides          []int
+				paddings         [][2]int
+				expectedOutput   any
+			}
+
+			for _, tc := range []testCase{
+				{
+					name:             "F32_1D_Max_Win3_Stride2",
+					operandData:      []float32{1, 5, 2, 8, 3},
+					sourceData:       []float32{10, 20},
+					windowDimensions: []int{3},
+					strides:          []int{2},
+					expectedOutput:   []float32{0, 10, 0, 20, 0},
+				},
+				{
+					name:             "F32_1D_Max_TieBreaker_FirstIndex",
+					operandData:      []float32{5, 5, 1, 2},
+					sourceData:       []float32{10, 20, 30},
+					windowDimensions: []int{2},
+					strides:          []int{1},
+					expectedOutput:   []float32{10, 20, 0, 30},
+				},
+				{
+					name:             "F32_1D_Max_Overlapping_Accumulation",
+					operandData:      []float32{1, 10, 2},
+					sourceData:       []float32{5, 7},
+					windowDimensions: []int{2},
+					strides:          []int{1},
+					expectedOutput:   []float32{0, 12, 0},
+				},
+				{
+					name:             "F32_2D_Max_Win2x2_Stride1x1",
+					operandData:      [][]float32{{1, 3}, {2, 4}},
+					sourceData:       [][]float32{{10}},
+					windowDimensions: []int{2, 2},
+					strides:          []int{1, 1},
+					expectedOutput:   [][]float32{{0, 0}, {0, 10}},
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					y, err := testutil.Exec1(b, []any{tc.operandData, tc.sourceData},
+						func(f compute.Function, p []compute.Value) (compute.Value, error) {
+							return f.SelectAndScatterMax(p[0], p[1], tc.windowDimensions, tc.strides, tc.paddings)
+						})
+					if err != nil {
+						t.Fatalf("SelectAndScatterMax failed: %v", err)
+					}
+					if ok, diff := testutil.IsEqual(tc.expectedOutput, y); !ok {
+						t.Errorf("SelectAndScatterMax: test %q mismatch:\n%s", tc.name, diff)
+					}
+				})
+			}
+		})
+
+		t.Run("Min", func(t *testing.T) {
+			testutil.SkipIfMissing(t, b, compute.OpTypeSelectAndScatterMin)
+			type testCase struct {
+				name             string
+				operandData      any
+				sourceData       any
+				windowDimensions []int
+				strides          []int
+				paddings         [][2]int
+				expectedOutput   any
+			}
+
+			for _, tc := range []testCase{
+				{
+					name:             "F32_1D_Min_Win3_Stride2",
+					operandData:      []float32{5, 1, 8, 2, 9},
+					sourceData:       []float32{10, 20},
+					windowDimensions: []int{3},
+					strides:          []int{2},
+					expectedOutput:   []float32{0, 10, 0, 20, 0},
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					y, err := testutil.Exec1(b, []any{tc.operandData, tc.sourceData},
+						func(f compute.Function, p []compute.Value) (compute.Value, error) {
+							return f.SelectAndScatterMin(p[0], p[1], tc.windowDimensions, tc.strides, tc.paddings)
+						})
+					if err != nil {
+						t.Fatalf("SelectAndScatterMin failed: %v", err)
+					}
+					if ok, diff := testutil.IsEqual(tc.expectedOutput, y); !ok {
+						t.Errorf("SelectAndScatterMin: test %q mismatch:\n%s", tc.name, diff)
+					}
+				})
+			}
+		})
+	})
 }


### PR DESCRIPTION
## Summary

This PR adds support for `SelectAndScatterMax` and `SelectAndScatterMin` operations to the `gobackend` package and introduces worker pool multi-threading parallelization for key convolution and window reduction ops (`ConvGeneral`, `SelectAndScatter`, `ReduceWindow`).

### Changes Included:

1. **`SelectAndScatter` Implementation & Compliance Tests**:
   - Added `shapeinference.SelectAndScatter` for output shape inference.
   - Implemented `SelectAndScatterMax` and `SelectAndScatterMin` ops in `internal/gobackend/ops/selectandscatter.go` supporting POD numeric types and half-precision types (`bfloat16`, `float16`).
   - Registered capabilities in `gobackend` and added compliance test cases in `support/backendtest`.

2. **Parallelization of `ConvGeneral` & Fast-2D Path**:
   - Refactored `convgeneral_exec_base.go` to parallelize inner computation loops using lock-free flat-index chunking across `goBackend.Workers`.
   - Added a specialized fast-path for 2D spatial convolutions (`spatialRank == 2`), eliminating `IterOnAxes` iterator closure allocations per spatial output position.
   - Updated generated alternate execution files (`gen_convgeneral_exec_half.go`, `gen_convgeneral_exec_full.go`, `gen_convgeneral_exec_full_half.go`).

3. **Parallelization of `SelectAndScatter` & `ReduceWindow`**:
   - Parallelized `SelectAndScatter` along independent batch dimensions when spatial windows do not cross batch boundaries, with lock-free worker chunking and thread-local buffers for general scatter cases.
   - Parallelized `ReduceWindow` output loops across available worker threads.

### Performance Impact:
- **MNIST CNN Model Training Step Duration** (`GOMLX_BACKEND=go go run -tags=onnx ./examples/mnist/demo/ -set='model=cnn;train_steps=5'`):
  - **Before**: ~16.7s per step (single-threaded execution)
  - **After**: ~5.5s – 6.0s per step (multi-threaded across worker pool)