### PR TITLE
Support and validate tests in WASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ some of the example models to benchmark your backend against some of the others.
   - `GOMLX_NO_AUTO_INSTALL`: if set to `1`, GoMLX will not automatically install PJRTs when running on a system without them.
   - `XLA_FLAGS`: optional controls for XLA backend. It should be set to a semicolon (";") separated list of options. If you set to `--help` 
     the backend will print out some help for all options. There is also a description on the page [XLA Flags Guidance](https://openxla.org/xla/flags_guidance).
+
+## WebAssembly (WASM) Support
+
+The "go" backend is well supported in WASM environment.
+
+It passes all compliance tests:
+
+```go
+GOOS=js GOARCH=wasm go test  -exec wasmbrowsertest ./... -count=1 -v
+```

--- a/internal/gobackend/workerspool/workerspool_test.go
+++ b/internal/gobackend/workerspool/workerspool_test.go
@@ -60,7 +60,7 @@ func TestPool_Saturate(t *testing.T) {
 		runtime.Gosched()
 		count.Add(1)
 	})
-	if started.Load() <= 1 {
+	if runtime.GOMAXPROCS(0) > 1 && started.Load() <= 1 {
 		t.Errorf("Expected more than 1 started task for unlimited parallelism, got %d", started.Load())
 	}
 	if count.Load() != started.Load() {


### PR DESCRIPTION
## Summary
- **Workerspool Test**: Updated `TestPool_Saturate` in `internal/gobackend/workerspool` to handle environments where `runtime.GOMAXPROCS(0) == 1` (e.g. single-threaded WebAssembly / JS runtime) when asserting task saturation.
- **Documentation**: Added WebAssembly (WASM) support section and test command instructions to `README.md`.

## Verification
Validated all package tests and compliance tests passing on WebAssembly:
```bash
GOOS=js GOARCH=wasm go test -exec wasmbrowsertest ./... -count=1
```