### PR TITLE
Fix race condition in testutil.FromBuffer and clarify Buffer.Data ownership

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -31,7 +31,11 @@ type Buffer interface {
 	ToFlatData(flat any) error
 
 	// Data returns a slice pointing to the buffer storage memory directly.
-	// This only works if the backend's HasSharedBuffer is true.
+	// This only works if the backend's HasSharedBuffers is true.
+	//
+	// And the returned flat data is only valid while the Buffer is alive.
+	// If the Buffer is finalized, the flat data returned may no longer be valid.
+	// For shared buffers, the memory is not necessarily managed by Go.
 	Data() (flat any, err error)
 
 	// CopyToDevice copies the buffer to the deviceNum.

--- a/support/testutil/buffers.go
+++ b/support/testutil/buffers.go
@@ -65,17 +65,9 @@ func FromBuffer(backend compute.Backend, buf compute.Buffer) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	var flat any
-	if backend.HasSharedBuffers() {
-		flat, err = buf.Data()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		flat = dtypes.MakeAnySlice(shape.DType, shape.Size())
-		if err := buf.ToFlatData(flat); err != nil {
-			return nil, err
-		}
+	flat := dtypes.MakeAnySlice(shape.DType, shape.Size())
+	if err := buf.ToFlatData(flat); err != nil {
+		return nil, err
 	}
 
 	if shape.Rank() == 0 {


### PR DESCRIPTION
## Summary
- **Test race condition fix**: In `testutil.FromBuffer`, avoid directly borrowing memory via `buf.Data()` on backends with shared buffers (`HasSharedBuffers() == true`). Instead, always copy into a newly allocated slice via `buf.ToFlatData(...)` to avoid race conditions or accessing memory after the buffer is finalized.
- **Documentation**: Clarify in `Buffer.Data()` docstring that returned flat data is only valid while the `Buffer` is alive and note that shared buffer memory is not necessarily managed by Go.