### PR TITLE
Update SIMD implementation to Go 1.27 (simd/archsimd API)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -115,18 +115,18 @@ Normal code files are prefixed with the following copyright line:
 
 Auto-generated files don't need a copyright, but should include a comment with the tool use to generate them.
 
-## How to use SIMD in Go with archsimd
+## How to use SIMD in Go with archsimd and simd
 
-Go 1.26 introduced experimental SIMD support through the `simd/archsimd` package. This allows for writing architecture-independent SIMD code while still leveraging specialized hardware instructions (like AVX-512 on x86).
+Go 1.26 introduced experimental SIMD support, and Go 1.27 updated it with the `simd` (high-level, architecture-independent) and `simd/archsimd` (low-level, direct hardware registers) packages.
 
-### Enabling archsimd
+### Enabling SIMD
 
-To use archsimd, you must:
-1. Use a compatible Go version (1.25+).
+To use Go SIMD, you must:
+1. Use a compatible Go version (1.26+ or 1.27+).
 2. Set the environment variable `GOEXPERIMENT=simd` during build and test.
-3. Use the `//go:build goexperiment.simd` build tag in your files.
+3. Use the `//go:build goexperiment.simd` build tag in your files (along with architecture tags like `amd64` when using `archsimd`).
 
-### Common Vector Types
+### Common Vector Types in `simd/archsimd`
 
 Vectors are named by their element type and the number of elements. They usually come in three widths:
 
@@ -138,6 +138,13 @@ Vectors are named by their element type and the number of elements. They usually
 
 Other types include `Float64x2/x4/x8`, `Uint64x2/x4/x8`, and corresponding `Mask` types (e.g., `Mask32x16`).
 
+### Go 1.27 Load/Store API Conventions
+
+In Go 1.27 `simd/archsimd`:
+- **Slices**: `archsimd.Load<Type>(slice []T)` and `vec.Store(slice []T)` load and store directly to/from slices.
+- **Fixed Arrays / Pointers**: `archsimd.Load<Type>Array(ptr *[N]T)` and `vec.StoreArray(ptr *[N]T)` load and store to/from fixed-size array pointers. Use this for raw pointer operations and microkernels (e.g. GEMM).
+- **Pairwise operations**: Pairwise reductions use `ConcatAddPairs`, `ConcatSubPairs`, and `ConcatAddPairsGrouped` (renamed from `AddPairs`/`SubPairs`).
+
 ### Basic Usage Example
 
 ```go
@@ -147,12 +154,23 @@ package mypackage
 
 import "simd/archsimd"
 
-func AddSlices(a, b, res []float32) {
+// AddSlicesUsingSlices uses slice-based Load/Store.
+func AddSlicesUsingSlices(a, b, res []float32) {
     for i := 0; i < len(a); i += 16 {
-        va := archsimd.LoadFloat32x16((*[16]float32)(&a[i]))
-        vb := archsimd.LoadFloat32x16((*[16]float32)(&b[i]))
+        va := archsimd.LoadFloat32x16(a[i : i+16])
+        vb := archsimd.LoadFloat32x16(b[i : i+16])
         vres := va.Add(vb)
-        vres.Store((*[16]float32)(&res[i]))
+        vres.Store(res[i : i+16])
+    }
+}
+
+// AddSlicesUsingArrays uses array-pointer-based Load/Store (zero slice header overhead).
+func AddSlicesUsingArrays(a, b, res []float32) {
+    for i := 0; i < len(a); i += 16 {
+        va := archsimd.LoadFloat32x16Array((*[16]float32)(&a[i]))
+        vb := archsimd.LoadFloat32x16Array((*[16]float32)(&b[i]))
+        vres := va.Add(vb)
+        vres.StoreArray((*[16]float32)(&res[i]))
     }
 }
 ```

--- a/dtypes/bfloat16/avx2.go
+++ b/dtypes/bfloat16/avx2.go
@@ -32,6 +32,6 @@ func (v BFloat16x16) ToFloat32() (lo, hi archsimd.Float32x8) {
 // Only available if archsimd.X86.AVX2() returns true at runtime -- indicating AVX2 is available.
 // If not available, don't use this, it will crash!
 func LoadBFloat16x16(ptr *[16]BFloat16) BFloat16x16 {
-	vec := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(ptr)))
+	vec := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(ptr))[:])
 	return BFloat16x16(vec)
 }

--- a/dtypes/bfloat16/avx2_test.go
+++ b/dtypes/bfloat16/avx2_test.go
@@ -23,8 +23,8 @@ func TestBFloat16x16ToFloat32(t *testing.T) {
 	v := LoadBFloat16x16(&bf16s)
 	loF32s, hiF32s := v.ToFloat32()
 	var f32s [16]float32
-	loF32s.StoreSlice(f32s[0:8])
-	hiF32s.StoreSlice(f32s[8:16])
+	loF32s.Store(f32s[0:8])
+	hiF32s.Store(f32s[8:16])
 	fmt.Printf("- Got:      %v\n", f32s)
 	for i, v := range f32s {
 		// Due to lack of precision, we allow for a difference of 1.

--- a/dtypes/bfloat16/avx512.go
+++ b/dtypes/bfloat16/avx512.go
@@ -32,6 +32,6 @@ func (v BFloat16x32) ToFloat32() (lo, hi archsimd.Float32x16) {
 // Only available if archsimd.X86.AVX512() returns true at runtime -- indicating AVX512 is available.
 // If not available, don't use this, it will crash!
 func LoadBFloat16x32(ptr *[32]BFloat16) BFloat16x32 {
-	vec := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(ptr)))
+	vec := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(ptr))[:])
 	return BFloat16x32(vec)
 }

--- a/dtypes/bfloat16/avx512_test.go
+++ b/dtypes/bfloat16/avx512_test.go
@@ -23,8 +23,8 @@ func TestBFloat16x32ToFloat32(t *testing.T) {
 	v := LoadBFloat16x32(&bf16s)
 	loF32s, hiF32s := v.ToFloat32()
 	var f32s [32]float32
-	loF32s.StoreSlice(f32s[0:16])
-	hiF32s.StoreSlice(f32s[16:32])
+	loF32s.Store(f32s[0:16])
+	hiF32s.Store(f32s[16:32])
 	fmt.Printf("- Got:      %v\n", f32s)
 	for i, v := range f32s {
 		// Due to lack of precision, we allow for a difference of 1.

--- a/dtypes/float16/avx2.go
+++ b/dtypes/float16/avx2.go
@@ -16,7 +16,7 @@ import (
 // Only available if archsimd.X86.AVX2() returns true at runtime -- indicating AVX2 is available.
 // If not available, don't use this, it will crash!
 func LoadFloat16x16(ptr *[16]Float16) Float16x16 {
-	vec := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(ptr)))
+	vec := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(ptr))[:])
 	return Float16x16(vec)
 }
 

--- a/dtypes/float16/avx2_test.go
+++ b/dtypes/float16/avx2_test.go
@@ -23,8 +23,8 @@ func TestFloat16x16ToFloat32(t *testing.T) {
 	v := LoadFloat16x16(&f16s)
 	loF32s, hiF32s := v.ToFloat32()
 	var f32s [16]float32
-	loF32s.StoreSlice(f32s[0:8])
-	hiF32s.StoreSlice(f32s[8:16])
+	loF32s.Store(f32s[0:8])
+	hiF32s.Store(f32s[8:16])
 	fmt.Printf("- Got:      %v\n", f32s)
 	for i, v := range f32s {
 		// Due to lack of precision, we allow for a difference of 1.
@@ -62,8 +62,8 @@ func TestFloat16x16SpecialValues(t *testing.T) {
 	v := LoadFloat16x16(&f16s)
 	loF32s, hiF32s := v.ToFloat32()
 	var got [16]float32
-	loF32s.StoreSlice(got[0:8])
-	hiF32s.StoreSlice(got[8:16])
+	loF32s.Store(got[0:8])
+	hiF32s.Store(got[8:16])
 
 	for i := range f16s {
 		want := f16s[i].Float32()

--- a/dtypes/float16/avx512.go
+++ b/dtypes/float16/avx512.go
@@ -16,7 +16,7 @@ import (
 // Only available if archsimd.X86.AVX512() returns true at runtime -- indicating AVX512 is available.
 // If not available, don't use this, it will crash!
 func LoadFloat16x32(ptr *[32]Float16) Float16x32 {
-	vec := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(ptr)))
+	vec := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(ptr))[:])
 	return Float16x32(vec)
 }
 

--- a/dtypes/float16/avx512_test.go
+++ b/dtypes/float16/avx512_test.go
@@ -23,8 +23,8 @@ func TestFloat16x32ToFloat32(t *testing.T) {
 	v := LoadFloat16x32(&f16s)
 	loF32s, hiF32s := v.ToFloat32()
 	var f32s [32]float32
-	loF32s.StoreSlice(f32s[0:16])
-	hiF32s.StoreSlice(f32s[16:32])
+	loF32s.Store(f32s[0:16])
+	hiF32s.Store(f32s[16:32])
 	fmt.Printf("- Got:      %v\n", f32s)
 	for i, v := range f32s {
 		// Due to lack of precision, we allow for a difference of 1.
@@ -62,8 +62,8 @@ func TestFloat16x32SpecialValues(t *testing.T) {
 	v := LoadFloat16x32(&f16s)
 	loF32s, hiF32s := v.ToFloat32()
 	var got [32]float32
-	loF32s.StoreSlice(got[0:16])
-	hiF32s.StoreSlice(got[16:32])
+	loF32s.Store(got[0:16])
+	hiF32s.Store(got[16:32])
 
 	for i := range f16s {
 		want := f16s[i].Float32()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gomlx/compute
 
-go 1.26
+go 1.27
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/internal/gobackend/dot/matmul/avx2.go
+++ b/internal/gobackend/dot/matmul/avx2.go
@@ -78,7 +78,7 @@ func registerAVX2(forTests bool) {
 // avx2ReduceSumFloat32x8 performs a horizontal reduction of a Float32x8 vector.
 func avx2ReduceSumFloat32x8(x8 archsimd.Float32x8) float32 {
 	x4 := x8.GetHi().Add(x8.GetLo())
-	x4sum := x4.AddPairs(x4)
+	x4sum := x4.ConcatAddPairs(x4)
 	return x4sum.GetElem(0) + x4sum.GetElem(1)
 }
 
@@ -113,14 +113,14 @@ func avx2PackRHSNonTransposed[T gotype.ScalarNotComplex](
 		for ; stripColIdx+kernelColsBytes <= copyColsBytesAll; stripColIdx += kernelColsBytes {
 			rhsPtr := rhsBasePtr + uintptr(rhsRowStart)*rhsStrideBytes + rhsColStartBytes + stripColIdx
 			for range contractingRows {
-				v0 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rhsPtr)))
-				v1 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rhsPtr + 32)))
-				v2 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rhsPtr + 64)))
-				v3 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rhsPtr + 96)))
-				v0.Store((*[32]uint8)(unsafe.Pointer(panelPtr)))
-				v1.Store((*[32]uint8)(unsafe.Pointer(panelPtr + 32)))
-				v2.Store((*[32]uint8)(unsafe.Pointer(panelPtr + 64)))
-				v3.Store((*[32]uint8)(unsafe.Pointer(panelPtr + 96)))
+				v0 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rhsPtr)))
+				v1 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rhsPtr + 32)))
+				v2 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rhsPtr + 64)))
+				v3 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rhsPtr + 96)))
+				v0.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr)))
+				v1.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr + 32)))
+				v2.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr + 64)))
+				v3.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr + 96)))
 				panelPtr += kernelColsBytes
 				rhsPtr += rhsStrideBytes
 			}
@@ -129,10 +129,10 @@ func avx2PackRHSNonTransposed[T gotype.ScalarNotComplex](
 		for ; stripColIdx+kernelColsBytes <= copyColsBytesAll; stripColIdx += kernelColsBytes {
 			rhsPtr := rhsBasePtr + uintptr(rhsRowStart)*rhsStrideBytes + rhsColStartBytes + stripColIdx
 			for range contractingRows {
-				v0 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rhsPtr)))
-				v1 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rhsPtr + 32)))
-				v0.Store((*[32]uint8)(unsafe.Pointer(panelPtr)))
-				v1.Store((*[32]uint8)(unsafe.Pointer(panelPtr + 32)))
+				v0 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rhsPtr)))
+				v1 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rhsPtr + 32)))
+				v0.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr)))
+				v1.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr + 32)))
 				panelPtr += kernelColsBytes
 				rhsPtr += rhsStrideBytes
 			}
@@ -141,8 +141,8 @@ func avx2PackRHSNonTransposed[T gotype.ScalarNotComplex](
 		for ; stripColIdx+kernelColsBytes <= copyColsBytesAll; stripColIdx += kernelColsBytes {
 			rhsPtr := rhsBasePtr + uintptr(rhsRowStart)*rhsStrideBytes + rhsColStartBytes + stripColIdx
 			for range contractingRows {
-				v0 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rhsPtr)))
-				v0.Store((*[32]uint8)(unsafe.Pointer(panelPtr)))
+				v0 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rhsPtr)))
+				v0.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr)))
 				panelPtr += kernelColsBytes
 				rhsPtr += rhsStrideBytes
 			}
@@ -153,8 +153,8 @@ func avx2PackRHSNonTransposed[T gotype.ScalarNotComplex](
 			for range contractingRows {
 				rowRhsPtr := rhsPtr
 				for kernelColIdx := uintptr(0); kernelColIdx < kernelColsBytes; kernelColIdx += 32 {
-					v0 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rowRhsPtr)))
-					v0.Store((*[32]uint8)(unsafe.Pointer(panelPtr)))
+					v0 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rowRhsPtr)))
+					v0.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr)))
 					panelPtr += 32
 					rowRhsPtr += 32
 				}
@@ -173,8 +173,8 @@ func avx2PackRHSNonTransposed[T gotype.ScalarNotComplex](
 		rhsPtr := rhsStripStartPtr
 		colByteIdx := uintptr(0)
 		for ; colByteIdx+32 <= copyColsBytes; colByteIdx += 32 {
-			v0 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(rhsPtr)))
-			v0.Store((*[32]uint8)(unsafe.Pointer(panelPtr)))
+			v0 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(rhsPtr)))
+			v0.StoreArray((*[32]uint8)(unsafe.Pointer(panelPtr)))
 			rhsPtr += 32
 			panelPtr += 32
 		}
@@ -224,39 +224,39 @@ func avx2PackLHSKernelRows4[T gotype.ScalarNotComplex](
 		lhsRow3Ptr := lhsRow2Ptr + lhsStrideBytes
 
 		for ; colByteIdx+32 <= contractingColsBytes; colByteIdx += 32 {
-			v0 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(lhsRow0Ptr)))
-			v1 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(lhsRow1Ptr)))
-			v2 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(lhsRow2Ptr)))
-			v3 := archsimd.LoadUint8x32((*[32]uint8)(unsafe.Pointer(lhsRow3Ptr)))
+			v0 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(lhsRow0Ptr)))
+			v1 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(lhsRow1Ptr)))
+			v2 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(lhsRow2Ptr)))
+			v3 := archsimd.LoadUint8x32Array((*[32]uint8)(unsafe.Pointer(lhsRow3Ptr)))
 
 			switch bytesPerElement {
 			case 4:
 				t0, t1, t2, t3 := avx2Transpose4x8x32bits(v0.AsUint32x8(), v1.AsUint32x8(), v2.AsUint32x8(), v3.AsUint32x8())
-				t0.Store((*[8]uint32)(unsafe.Pointer(panelPtr)))
-				t1.Store((*[8]uint32)(unsafe.Pointer(panelPtr + 32)))
-				t2.Store((*[8]uint32)(unsafe.Pointer(panelPtr + 64)))
-				t3.Store((*[8]uint32)(unsafe.Pointer(panelPtr + 96)))
+				t0.StoreArray((*[8]uint32)(unsafe.Pointer(panelPtr)))
+				t1.StoreArray((*[8]uint32)(unsafe.Pointer(panelPtr + 32)))
+				t2.StoreArray((*[8]uint32)(unsafe.Pointer(panelPtr + 64)))
+				t3.StoreArray((*[8]uint32)(unsafe.Pointer(panelPtr + 96)))
 				panelPtr += 128
 			case 8:
 				t0, t1, t2, t3 := avx2Transpose4x4x64bits(v0.AsUint64x4(), v1.AsUint64x4(), v2.AsUint64x4(), v3.AsUint64x4())
-				t0.Store((*[4]uint64)(unsafe.Pointer(panelPtr)))
-				t1.Store((*[4]uint64)(unsafe.Pointer(panelPtr + 32)))
-				t2.Store((*[4]uint64)(unsafe.Pointer(panelPtr + 64)))
-				t3.Store((*[4]uint64)(unsafe.Pointer(panelPtr + 96)))
+				t0.StoreArray((*[4]uint64)(unsafe.Pointer(panelPtr)))
+				t1.StoreArray((*[4]uint64)(unsafe.Pointer(panelPtr + 32)))
+				t2.StoreArray((*[4]uint64)(unsafe.Pointer(panelPtr + 64)))
+				t3.StoreArray((*[4]uint64)(unsafe.Pointer(panelPtr + 96)))
 				panelPtr += 128
 			case 2:
 				t0, t1, t2, t3 := avx2Transpose4x16x16bits(v0.AsUint16x16(), v1.AsUint16x16(), v2.AsUint16x16(), v3.AsUint16x16())
-				t0.Store((*[16]uint16)(unsafe.Pointer(panelPtr)))
-				t1.Store((*[16]uint16)(unsafe.Pointer(panelPtr + 32)))
-				t2.Store((*[16]uint16)(unsafe.Pointer(panelPtr + 64)))
-				t3.Store((*[16]uint16)(unsafe.Pointer(panelPtr + 96)))
+				t0.StoreArray((*[16]uint16)(unsafe.Pointer(panelPtr)))
+				t1.StoreArray((*[16]uint16)(unsafe.Pointer(panelPtr + 32)))
+				t2.StoreArray((*[16]uint16)(unsafe.Pointer(panelPtr + 64)))
+				t3.StoreArray((*[16]uint16)(unsafe.Pointer(panelPtr + 96)))
 				panelPtr += 128
 			case 1:
 				var tmp0, tmp1, tmp2, tmp3 [32]uint8
-				v0.Store(&tmp0)
-				v1.Store(&tmp1)
-				v2.Store(&tmp2)
-				v3.Store(&tmp3)
+				v0.StoreArray(&tmp0)
+				v1.StoreArray(&tmp1)
+				v2.StoreArray(&tmp2)
+				v3.StoreArray(&tmp3)
 				for i := uintptr(0); i < 32; i++ {
 					*(*uint8)(unsafe.Pointer(panelPtr)) = tmp0[i]
 					*(*uint8)(unsafe.Pointer(panelPtr + 1)) = tmp1[i]
@@ -350,8 +350,8 @@ func avx2ApplyPackedOutputFloat32(
 			outputColIdx := outputRowIdx
 			packedColIdx := packedRowIdx
 			for ; c+8 <= width; c += 8 {
-				packedVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(&packedOutput[packedColIdx])))
-				packedVal.Store((*[8]float32)(unsafe.Pointer(&output[outputColIdx])))
+				packedVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(&packedOutput[packedColIdx])))
+				packedVal.StoreArray((*[8]float32)(unsafe.Pointer(&output[outputColIdx])))
 				packedColIdx += 8
 				outputColIdx += 8
 			}
@@ -367,10 +367,10 @@ func avx2ApplyPackedOutputFloat32(
 			outputColIdx := outputRowIdx
 			packedColIdx := packedRowIdx
 			for ; c+8 <= width; c += 8 {
-				packedVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(&packedOutput[packedColIdx])))
-				outputVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(&output[outputColIdx])))
+				packedVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(&packedOutput[packedColIdx])))
+				outputVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(&output[outputColIdx])))
 				outputVal = packedVal.Add(outputVal)
-				outputVal.Store((*[8]float32)(unsafe.Pointer(&output[outputColIdx])))
+				outputVal.StoreArray((*[8]float32)(unsafe.Pointer(&output[outputColIdx])))
 				packedColIdx += 8
 				outputColIdx += 8
 			}
@@ -400,8 +400,8 @@ func avx2ApplyPackedOutputFloat64(
 			outputColIdx := outputRowIdx
 			packedColIdx := packedRowIdx
 			for ; c+4 <= width; c += 4 {
-				packedVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(&packedOutput[packedColIdx])))
-				packedVal.Store((*[4]float64)(unsafe.Pointer(&output[outputColIdx])))
+				packedVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(&packedOutput[packedColIdx])))
+				packedVal.StoreArray((*[4]float64)(unsafe.Pointer(&output[outputColIdx])))
 				packedColIdx += 4
 				outputColIdx += 4
 			}
@@ -417,10 +417,10 @@ func avx2ApplyPackedOutputFloat64(
 			outputColIdx := outputRowIdx
 			packedColIdx := packedRowIdx
 			for ; c+4 <= width; c += 4 {
-				packedVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(&packedOutput[packedColIdx])))
-				outputVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(&output[outputColIdx])))
+				packedVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(&packedOutput[packedColIdx])))
+				outputVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(&output[outputColIdx])))
 				outputVal = packedVal.Add(outputVal)
-				outputVal.Store((*[4]float64)(unsafe.Pointer(&output[outputColIdx])))
+				outputVal.StoreArray((*[4]float64)(unsafe.Pointer(&output[outputColIdx])))
 				packedColIdx += 4
 				outputColIdx += 4
 			}

--- a/internal/gobackend/dot/matmul/avx2_internal_test.go
+++ b/internal/gobackend/dot/matmul/avx2_internal_test.go
@@ -22,18 +22,18 @@ func TestAVX2(t *testing.T) {
 			input[i] = uint64(i)
 		}
 
-		v0 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[0*4])))
-		v1 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[1*4])))
-		v2 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[2*4])))
-		v3 := archsimd.LoadUint64x4((*[4]uint64)(unsafe.Pointer(&input[3*4])))
+		v0 := archsimd.LoadUint64x4Array((*[4]uint64)(unsafe.Pointer(&input[0*4])))
+		v1 := archsimd.LoadUint64x4Array((*[4]uint64)(unsafe.Pointer(&input[1*4])))
+		v2 := archsimd.LoadUint64x4Array((*[4]uint64)(unsafe.Pointer(&input[2*4])))
+		v3 := archsimd.LoadUint64x4Array((*[4]uint64)(unsafe.Pointer(&input[3*4])))
 
 		q0, q1, q2, q3 := avx2Transpose4x4x64bits(v0, v1, v2, v3)
 
 		var output [4 * 4]uint64
-		q0.Store((*[4]uint64)(unsafe.Pointer(&output[0*4])))
-		q1.Store((*[4]uint64)(unsafe.Pointer(&output[1*4])))
-		q2.Store((*[4]uint64)(unsafe.Pointer(&output[2*4])))
-		q3.Store((*[4]uint64)(unsafe.Pointer(&output[3*4])))
+		q0.StoreArray((*[4]uint64)(unsafe.Pointer(&output[0*4])))
+		q1.StoreArray((*[4]uint64)(unsafe.Pointer(&output[1*4])))
+		q2.StoreArray((*[4]uint64)(unsafe.Pointer(&output[2*4])))
+		q3.StoreArray((*[4]uint64)(unsafe.Pointer(&output[3*4])))
 
 		for c := range 4 { // logical column
 			for r := range 4 { // logical row
@@ -52,18 +52,18 @@ func TestAVX2(t *testing.T) {
 			input[i] = uint32(i)
 		}
 
-		v0 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[0*8])))
-		v1 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[1*8])))
-		v2 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[2*8])))
-		v3 := archsimd.LoadUint32x8((*[8]uint32)(unsafe.Pointer(&input[3*8])))
+		v0 := archsimd.LoadUint32x8Array((*[8]uint32)(unsafe.Pointer(&input[0*8])))
+		v1 := archsimd.LoadUint32x8Array((*[8]uint32)(unsafe.Pointer(&input[1*8])))
+		v2 := archsimd.LoadUint32x8Array((*[8]uint32)(unsafe.Pointer(&input[2*8])))
+		v3 := archsimd.LoadUint32x8Array((*[8]uint32)(unsafe.Pointer(&input[3*8])))
 
 		q0, q1, q2, q3 := avx2Transpose4x8x32bits(v0, v1, v2, v3)
 
 		var output [4 * 8]uint32
-		q0.Store((*[8]uint32)(unsafe.Pointer(&output[0*8])))
-		q1.Store((*[8]uint32)(unsafe.Pointer(&output[1*8])))
-		q2.Store((*[8]uint32)(unsafe.Pointer(&output[2*8])))
-		q3.Store((*[8]uint32)(unsafe.Pointer(&output[3*8])))
+		q0.StoreArray((*[8]uint32)(unsafe.Pointer(&output[0*8])))
+		q1.StoreArray((*[8]uint32)(unsafe.Pointer(&output[1*8])))
+		q2.StoreArray((*[8]uint32)(unsafe.Pointer(&output[2*8])))
+		q3.StoreArray((*[8]uint32)(unsafe.Pointer(&output[3*8])))
 
 		for c := range 8 { // logical column
 			for r := range 4 { // logical row
@@ -82,18 +82,18 @@ func TestAVX2(t *testing.T) {
 			input[i] = uint16(i)
 		}
 
-		v0 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[0*16])))
-		v1 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[1*16])))
-		v2 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[2*16])))
-		v3 := archsimd.LoadUint16x16((*[16]uint16)(unsafe.Pointer(&input[3*16])))
+		v0 := archsimd.LoadUint16x16Array((*[16]uint16)(unsafe.Pointer(&input[0*16])))
+		v1 := archsimd.LoadUint16x16Array((*[16]uint16)(unsafe.Pointer(&input[1*16])))
+		v2 := archsimd.LoadUint16x16Array((*[16]uint16)(unsafe.Pointer(&input[2*16])))
+		v3 := archsimd.LoadUint16x16Array((*[16]uint16)(unsafe.Pointer(&input[3*16])))
 
 		q0, q1, q2, q3 := avx2Transpose4x16x16bits(v0, v1, v2, v3)
 
 		var output [4 * 16]uint16
-		q0.Store((*[16]uint16)(unsafe.Pointer(&output[0*16])))
-		q1.Store((*[16]uint16)(unsafe.Pointer(&output[1*16])))
-		q2.Store((*[16]uint16)(unsafe.Pointer(&output[2*16])))
-		q3.Store((*[16]uint16)(unsafe.Pointer(&output[3*16])))
+		q0.StoreArray((*[16]uint16)(unsafe.Pointer(&output[0*16])))
+		q1.StoreArray((*[16]uint16)(unsafe.Pointer(&output[1*16])))
+		q2.StoreArray((*[16]uint16)(unsafe.Pointer(&output[2*16])))
+		q3.StoreArray((*[16]uint16)(unsafe.Pointer(&output[3*16])))
 
 		for c := range 16 { // logical column
 			for r := range 4 { // logical row

--- a/internal/gobackend/dot/matmul/avx2_large.go
+++ b/internal/gobackend/dot/matmul/avx2_large.go
@@ -333,10 +333,10 @@ func avx2LargeKernelFloat32( //alt:f32
 				// Load RHS (Broadcasting/Streaming)
 				rhsPtr0 := unsafe.Pointer(rhsRowPtr + rOffset)
 				rhsPtr1 := unsafe.Pointer(rhsRowPtr + rOffset + rhsRegisterStride) //alt:f32|f64
-				rhsVec0 := archsimd.LoadFloat32x8((*[8]float32)(rhsPtr0))        //alt:f32
-				//alt:f64 rhsVec0 := archsimd.LoadFloat64x4((*[4]float64)(rhsPtr0))
-				rhsVec1 := archsimd.LoadFloat32x8((*[8]float32)(rhsPtr1)) //alt:f32
-				//alt:f64 rhsVec1 := archsimd.LoadFloat64x4((*[4]float64)(rhsPtr1))
+				rhsVec0 := archsimd.LoadFloat32x8Array((*[8]float32)(rhsPtr0))        //alt:f32
+				//alt:f64 rhsVec0 := archsimd.LoadFloat64x4Array((*[4]float64)(rhsPtr0))
+				rhsVec1 := archsimd.LoadFloat32x8Array((*[8]float32)(rhsPtr1)) //alt:f32
+				//alt:f64 rhsVec1 := archsimd.LoadFloat64x4Array((*[4]float64)(rhsPtr1))
 				//alt:bf16 rhsBF16 := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(rhsPtr0))
 				//alt:bf16 rhsVec0, rhsVec1 := rhsBF16.ToFloat32()
 				//alt:f16 rhsF16 := float16.LoadFloat16x16((*[16]float16.Float16)(rhsPtr0))
@@ -395,22 +395,22 @@ func avx2LargeKernelFloat32( //alt:f32
 			outputIdx3 := outputIdx0 + uintptr(3*outputStride*bytesPerOutputElement)
 			registerStride := uintptr(outputNumLanes * bytesPerOutputElement)
 
-			accum_lhs0_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs0_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
-			accum_lhs0_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs0_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
-			accum_lhs1_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs1_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
-			accum_lhs1_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs1_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
-			accum_lhs2_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs2_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
-			accum_lhs2_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs2_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
-			accum_lhs3_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs3_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
-			accum_lhs3_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs3_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
+			accum_lhs0_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs0_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
+			accum_lhs0_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs0_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
+			accum_lhs1_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs1_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
+			accum_lhs1_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs1_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
+			accum_lhs2_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs2_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
+			accum_lhs2_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs2_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
+			accum_lhs3_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs3_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
+			accum_lhs3_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs3_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
 		}
 	}
 }

--- a/internal/gobackend/dot/matmul/avx2_small.go
+++ b/internal/gobackend/dot/matmul/avx2_small.go
@@ -168,12 +168,12 @@ func avx2SmallFloat32( //alt:f32
 
 				col := 0
 				for ; col+2*outputVecWidth <= rhsCrossSize; col += 2 * outputVecWidth {
-					r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))                //alt:f32
-					r1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize))) //alt:f32
+					r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))                //alt:f32
+					r1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize))) //alt:f32
 					//alt:bf16 r0, r1 := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					//alt:f16 r0, r1 := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					//alt:f64 r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-					//alt:f64 r1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+					//alt:f64 r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64 r1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
 					outBase1 := outputBase + uintptr((row+1)*rhsCrossSize+col)*oSize
@@ -184,22 +184,22 @@ func avx2SmallFloat32( //alt:f32
 					//alt:f64 var o0_0, o0_1, o1_0, o1_1, o2_0, o2_1, o3_0, o3_1 archsimd.Float64x4
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-						o0_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-						o1_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-						o2_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-						o3_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						//alt:f64 o0_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64 o0_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64 o1_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64 o1_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64 o2_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64 o2_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64 o3_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3)))
-						//alt:f64 o3_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+						o0_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+						o0_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+						o1_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+						o2_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+						o3_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						//alt:f64 o0_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64 o0_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64 o1_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64 o1_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64 o2_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64 o2_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64 o3_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3)))
+						//alt:f64 o3_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 					} else {
 						zero := archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64 zero := archsimd.BroadcastFloat64x4(0.0)
@@ -218,29 +218,29 @@ func avx2SmallFloat32( //alt:f32
 					o3_0 = l3.MulAdd(r0, o3_0)
 					o3_1 = l3.MulAdd(r1, o3_1)
 
-					o0_0.Store((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-					o0_1.Store((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o1_0.Store((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-					o1_1.Store((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o2_0.Store((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-					o2_1.Store((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o3_0.Store((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-					o3_1.Store((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					//alt:f64 o0_0.Store((*[4]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64 o0_1.Store((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64 o1_0.Store((*[4]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64 o1_1.Store((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64 o2_0.Store((*[4]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64 o2_1.Store((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64 o3_0.Store((*[4]float64)(unsafe.Pointer(outBase3)))
-					//alt:f64 o3_1.Store((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+					o0_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+					o0_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+					o1_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+					o2_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+					o3_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					//alt:f64 o0_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64 o0_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64 o1_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64 o1_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64 o2_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64 o2_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64 o3_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase3)))
+					//alt:f64 o3_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 				}
 
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
-					r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f32
+					r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f32
 					//alt:bf16 r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					//alt:f16 r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					//alt:f64 r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64 r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
 					outBase1 := outputBase + uintptr((row+1)*rhsCrossSize+col)*oSize
@@ -251,14 +251,14 @@ func avx2SmallFloat32( //alt:f32
 					//alt:f64 var o0_0, o1_0, o2_0, o3_0 archsimd.Float64x4
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
-						//alt:f64 o0_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64 o1_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64 o2_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64 o3_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3)))
+						o0_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
+						//alt:f64 o0_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64 o1_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64 o2_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64 o3_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3)))
 					} else {
 						zero := archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64 zero := archsimd.BroadcastFloat64x4(0.0)
@@ -270,14 +270,14 @@ func avx2SmallFloat32( //alt:f32
 					o2_0 = l2.MulAdd(r0, o2_0)
 					o3_0 = l3.MulAdd(r0, o3_0)
 
-					o0_0.Store((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
-					o1_0.Store((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
-					o2_0.Store((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
-					o3_0.Store((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
-					//alt:f64 o0_0.Store((*[4]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64 o1_0.Store((*[4]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64 o2_0.Store((*[4]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64 o3_0.Store((*[4]float64)(unsafe.Pointer(outBase3)))
+					o0_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
+					//alt:f64 o0_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64 o1_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64 o2_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64 o3_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase3)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -345,26 +345,26 @@ func avx2SmallFloat32( //alt:f32
 
 				col := 0
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
-					r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f32
+					r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f32
 					//alt:bf16 r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					//alt:f16 r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					//alt:f64 r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64 r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 
 					outBase := outputBase + uintptr(row*rhsCrossSize+col)*oSize
 					var o0 archsimd.Float32x8 //alt:f32|bf16|f16
 					//alt:f64 var o0 archsimd.Float64x4
 
 					if k > 0 {
-						o0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-						//alt:f64 o0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase)))
+						o0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+						//alt:f64 o0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase)))
 					} else {
 						o0 = archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64 o0 = archsimd.BroadcastFloat64x4(0.0)
 					}
 
 					o0 = l0.MulAdd(r0, o0)
-					o0.Store((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-					//alt:f64 o0.Store((*[4]float64)(unsafe.Pointer(outBase)))
+					o0.StoreArray((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+					//alt:f64 o0.StoreArray((*[4]float64)(unsafe.Pointer(outBase)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -453,56 +453,56 @@ func avx2SmallFloat32Transposed( //alt:f32
 				//alt:f64 const vecWidth = 4
 
 				for ; k+4*vecWidth <= contractingSize; k += 4 * vecWidth {
-					l0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f32
+					l0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f32
 					//alt:bf16 l0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
 					//alt:f16 l0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
-					//alt:f64 l0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f32
+					//alt:f64 l0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f32
 					//alt:bf16 r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
 					//alt:f16 r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
-					//alt:f64 r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64 r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					acc = l0.MulAdd(r0, acc)
 
-					l1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f32
+					l1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f32
 					//alt:bf16 l1, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
 					//alt:f16 l1, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
-					//alt:f64 l1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
-					r1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f32
+					//alt:f64 l1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					r1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f32
 					//alt:bf16 r1, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
 					//alt:f16 r1, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
-					//alt:f64 r1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64 r1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					acc = l1.MulAdd(r1, acc)
 
-					l2 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f32
+					l2 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f32
 					//alt:bf16 l2, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
 					//alt:f16 l2, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
-					//alt:f64 l2 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
-					r2 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f32
+					//alt:f64 l2 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					r2 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f32
 					//alt:bf16 r2, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
 					//alt:f16 r2, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
-					//alt:f64 r2 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64 r2 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					acc = l2.MulAdd(r2, acc)
 
-					l3 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f32
+					l3 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f32
 					//alt:bf16 l3, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
 					//alt:f16 l3, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
-					//alt:f64 l3 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
-					r3 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f32
+					//alt:f64 l3 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					r3 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f32
 					//alt:bf16 r3, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
 					//alt:f16 r3, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
-					//alt:f64 r3 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64 r3 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					acc = l3.MulAdd(r3, acc)
 				}
 
 				for ; k+vecWidth <= contractingSize; k += vecWidth {
-					lVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f32
+					lVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f32
 					//alt:bf16 lVal, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
 					//alt:f16 lVal, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
-					//alt:f64 lVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					rVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f32
+					//alt:f64 lVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					rVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f32
 					//alt:bf16 rVal, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
 					//alt:f16 rVal, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
-					//alt:f64 rVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64 rVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					acc = lVal.MulAdd(rVal, acc)
 				}
 

--- a/internal/gobackend/dot/matmul/avx2_transpose.go
+++ b/internal/gobackend/dot/matmul/avx2_transpose.go
@@ -14,9 +14,9 @@ func avx2Transpose4x8x32bits(v0, v1, v2, v3 archsimd.Uint32x8) (row0to2, row2to4
 	t2 := v0.InterleaveHiGrouped(v1) // [a2 b2 a3 b3 | a6 b6 a7 b7]
 	t3 := v2.InterleaveHiGrouped(v3) // [c2 d2 c3 d3 | c6 d6 c7 d7]
 
-	idxLo := archsimd.LoadUint32x8(&[8]uint32{0, 1, 0, 1, 2, 3, 2, 3})
-	idxHi := archsimd.LoadUint32x8(&[8]uint32{4, 5, 4, 5, 6, 7, 6, 7})
-	mask := archsimd.LoadUint32x8(&[8]uint32{0, 0, 0xFFFFFFFF, 0xFFFFFFFF, 0, 0, 0xFFFFFFFF, 0xFFFFFFFF}).Greater(archsimd.BroadcastUint32x8(0))
+	idxLo := archsimd.LoadUint32x8Array(&[8]uint32{0, 1, 0, 1, 2, 3, 2, 3})
+	idxHi := archsimd.LoadUint32x8Array(&[8]uint32{4, 5, 4, 5, 6, 7, 6, 7})
+	mask := archsimd.LoadUint32x8Array(&[8]uint32{0, 0, 0xFFFFFFFF, 0xFFFFFFFF, 0, 0, 0xFFFFFFFF, 0xFFFFFFFF}).Greater(archsimd.BroadcastUint32x8(0))
 
 	row0to2 = t1.Permute(idxLo).Merge(t0.Permute(idxLo), mask)
 	row2to4 = t3.Permute(idxLo).Merge(t2.Permute(idxLo), mask)
@@ -43,9 +43,9 @@ func avx2Transpose4x16x16bits(v0, v1, v2, v3 archsimd.Uint16x16) (row0to4, row4t
 	y0 := t2_32.InterleaveLoGrouped(t3_32) // L:[a4 b4 c4 d4 a5 b5 c5 d5], H:[a12 b12 c12 d12 a13 b13 c13 d13]
 	y1 := t2_32.InterleaveHiGrouped(t3_32) // L:[a6 b6 c6 d6 a7 b7 c7 d7], H:[a14 b14 c14 d14 a15 b15 c15 d15]
 
-	idxLo := archsimd.LoadUint32x8(&[8]uint32{0, 1, 2, 3, 0, 1, 2, 3})
-	idxHi := archsimd.LoadUint32x8(&[8]uint32{4, 5, 6, 7, 4, 5, 6, 7})
-	maskLane1 := archsimd.LoadUint32x8(&[8]uint32{0, 0, 0, 0, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF}).Greater(archsimd.BroadcastUint32x8(0))
+	idxLo := archsimd.LoadUint32x8Array(&[8]uint32{0, 1, 2, 3, 0, 1, 2, 3})
+	idxHi := archsimd.LoadUint32x8Array(&[8]uint32{4, 5, 6, 7, 4, 5, 6, 7})
+	maskLane1 := archsimd.LoadUint32x8Array(&[8]uint32{0, 0, 0, 0, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF}).Greater(archsimd.BroadcastUint32x8(0))
 
 	row0to4 = x1.Permute(idxLo).Merge(x0.Permute(idxLo), maskLane1).AsUint16x16()
 	row8to12 = x1.Permute(idxHi).Merge(x0.Permute(idxHi), maskLane1).AsUint16x16()
@@ -62,9 +62,9 @@ func avx2Transpose4x4x64bits(v0, v1, v2, v3 archsimd.Uint64x4) (row0, row1, row2
 	x23_lo := v2.InterleaveLoGrouped(v3).AsUint32x8() // [c0 d0 c2 d2]
 	x23_hi := v2.InterleaveHiGrouped(v3).AsUint32x8() // [c1 d1 c3 d3]
 
-	idxLo := archsimd.LoadUint32x8(&[8]uint32{0, 1, 2, 3, 0, 1, 2, 3})
-	idxHi := archsimd.LoadUint32x8(&[8]uint32{4, 5, 6, 7, 4, 5, 6, 7})
-	maskLane1 := archsimd.LoadUint32x8(&[8]uint32{0, 0, 0, 0, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF}).Greater(archsimd.BroadcastUint32x8(0))
+	idxLo := archsimd.LoadUint32x8Array(&[8]uint32{0, 1, 2, 3, 0, 1, 2, 3})
+	idxHi := archsimd.LoadUint32x8Array(&[8]uint32{4, 5, 6, 7, 4, 5, 6, 7})
+	maskLane1 := archsimd.LoadUint32x8Array(&[8]uint32{0, 0, 0, 0, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF}).Greater(archsimd.BroadcastUint32x8(0))
 
 	row0 = x23_lo.Permute(idxLo).Merge(x01_lo.Permute(idxLo), maskLane1).AsUint64x4()
 	row1 = x23_hi.Permute(idxLo).Merge(x01_hi.Permute(idxLo), maskLane1).AsUint64x4()

--- a/internal/gobackend/dot/matmul/avx512.go
+++ b/internal/gobackend/dot/matmul/avx512.go
@@ -91,7 +91,7 @@ func registerAVX512(forTests bool) {
 func avx512ReduceSumFloat32x16(x16 archsimd.Float32x16) float32 {
 	x8 := x16.GetHi().Add(x16.GetLo())
 	x4 := x8.GetHi().Add(x8.GetLo())
-	x4sum := x4.AddPairs(x4)
+	x4sum := x4.ConcatAddPairs(x4)
 	return x4sum.GetElem(0) + x4sum.GetElem(1)
 }
 
@@ -132,8 +132,8 @@ func avx512ApplyPackedOutputFloat32(
 			packedColIdx := packedRowIdx
 			// Vectorized loop
 			for ; c+16 <= width; c += 16 {
-				packedVal := archsimd.LoadFloat32x16(castToArray16(&packedOutput[packedColIdx]))
-				packedVal.Store(castToArray16(&output[outputColIdx]))
+				packedVal := archsimd.LoadFloat32x16Array(castToArray16(&packedOutput[packedColIdx]))
+				packedVal.StoreArray(castToArray16(&output[outputColIdx]))
 				packedColIdx += 16
 				outputColIdx += 16
 			}
@@ -156,10 +156,10 @@ func avx512ApplyPackedOutputFloat32(
 			packedColIdx := packedRowIdx
 			// Vectorized loop
 			for ; c+16 <= width; c += 16 {
-				packedVal := archsimd.LoadFloat32x16(castToArray16(&packedOutput[packedColIdx]))
-				outputVal := archsimd.LoadFloat32x16(castToArray16(&output[outputColIdx]))
+				packedVal := archsimd.LoadFloat32x16Array(castToArray16(&packedOutput[packedColIdx]))
+				outputVal := archsimd.LoadFloat32x16Array(castToArray16(&output[outputColIdx]))
 				outputVal = packedVal.Add(outputVal)
-				outputVal.Store(castToArray16(&output[outputColIdx]))
+				outputVal.StoreArray(castToArray16(&output[outputColIdx]))
 				packedColIdx += 16
 				outputColIdx += 16
 			}
@@ -195,8 +195,8 @@ func avx512ApplyPackedOutputFloat64(
 			packedColIdx := packedRowIdx
 			// Vectorized loop
 			for ; c+8 <= width; c += 8 {
-				packedVal := archsimd.LoadFloat64x8(castToArray8(&packedOutput[packedColIdx]))
-				packedVal.Store(castToArray8(&output[outputColIdx]))
+				packedVal := archsimd.LoadFloat64x8Array(castToArray8(&packedOutput[packedColIdx]))
+				packedVal.StoreArray(castToArray8(&output[outputColIdx]))
 				packedColIdx += 8
 				outputColIdx += 8
 			}
@@ -219,10 +219,10 @@ func avx512ApplyPackedOutputFloat64(
 			packedColIdx := packedRowIdx
 			// Vectorized loop
 			for ; c+8 <= width; c += 8 {
-				packedVal := archsimd.LoadFloat64x8(castToArray8(&packedOutput[packedColIdx]))
-				outputVal := archsimd.LoadFloat64x8(castToArray8(&output[outputColIdx]))
+				packedVal := archsimd.LoadFloat64x8Array(castToArray8(&packedOutput[packedColIdx]))
+				outputVal := archsimd.LoadFloat64x8Array(castToArray8(&output[outputColIdx]))
 				outputVal = packedVal.Add(outputVal)
-				outputVal.Store(castToArray8(&output[outputColIdx]))
+				outputVal.StoreArray(castToArray8(&output[outputColIdx]))
 				packedColIdx += 8
 				outputColIdx += 8
 			}
@@ -281,14 +281,14 @@ func avx512PackRHSNonTransposed[T gotype.ScalarNotComplex](
 		for ; stripColIdx+kernelColsBytes <= copyColsBytesAll; stripColIdx += kernelColsBytes {
 			rhsPtr := rhsBasePtr + uintptr(rhsRowStart)*rhsStrideBytes + rhsColStartBytes + stripColIdx
 			for range contractingRows {
-				v0 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rhsPtr)))
-				v1 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rhsPtr + 64)))
-				v2 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rhsPtr + 128)))
-				v3 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rhsPtr + 192)))
-				v0.Store((*[64]uint8)(unsafe.Pointer(panelPtr)))
-				v1.Store((*[64]uint8)(unsafe.Pointer(panelPtr + 64)))
-				v2.Store((*[64]uint8)(unsafe.Pointer(panelPtr + 128)))
-				v3.Store((*[64]uint8)(unsafe.Pointer(panelPtr + 192)))
+				v0 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rhsPtr)))
+				v1 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rhsPtr + 64)))
+				v2 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rhsPtr + 128)))
+				v3 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rhsPtr + 192)))
+				v0.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr)))
+				v1.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr + 64)))
+				v2.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr + 128)))
+				v3.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr + 192)))
 				panelPtr += kernelColsBytes
 				rhsPtr += rhsStrideBytes
 			}
@@ -297,10 +297,10 @@ func avx512PackRHSNonTransposed[T gotype.ScalarNotComplex](
 		for ; stripColIdx+kernelColsBytes <= copyColsBytesAll; stripColIdx += kernelColsBytes {
 			rhsPtr := rhsBasePtr + uintptr(rhsRowStart)*rhsStrideBytes + rhsColStartBytes + stripColIdx
 			for range contractingRows {
-				v0 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rhsPtr)))
-				v1 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rhsPtr + 64)))
-				v0.Store((*[64]uint8)(unsafe.Pointer(panelPtr)))
-				v1.Store((*[64]uint8)(unsafe.Pointer(panelPtr + 64)))
+				v0 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rhsPtr)))
+				v1 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rhsPtr + 64)))
+				v0.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr)))
+				v1.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr + 64)))
 				panelPtr += kernelColsBytes
 				rhsPtr += rhsStrideBytes
 			}
@@ -309,8 +309,8 @@ func avx512PackRHSNonTransposed[T gotype.ScalarNotComplex](
 		for ; stripColIdx+kernelColsBytes <= copyColsBytesAll; stripColIdx += kernelColsBytes {
 			rhsPtr := rhsBasePtr + uintptr(rhsRowStart)*rhsStrideBytes + rhsColStartBytes + stripColIdx
 			for range contractingRows {
-				v0 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rhsPtr)))
-				v0.Store((*[64]uint8)(unsafe.Pointer(panelPtr)))
+				v0 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rhsPtr)))
+				v0.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr)))
 				panelPtr += kernelColsBytes
 				rhsPtr += rhsStrideBytes
 			}
@@ -323,8 +323,8 @@ func avx512PackRHSNonTransposed[T gotype.ScalarNotComplex](
 				rowRhsPtr := rhsPtr
 				// kernelColIdx is a multiple of 64, we checked at the start.
 				for kernelColIdx := uintptr(0); kernelColIdx < kernelColsBytes; kernelColIdx += 64 {
-					v0 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rowRhsPtr)))
-					v0.Store((*[64]uint8)(unsafe.Pointer(panelPtr)))
+					v0 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rowRhsPtr)))
+					v0.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr)))
 					panelPtr += 64
 					rowRhsPtr += 64
 				}
@@ -349,8 +349,8 @@ func avx512PackRHSNonTransposed[T gotype.ScalarNotComplex](
 		// Assuming copy() doesn't use AVX512, we copy 64 bytes at a time ourselves.
 		for ; colByteIdx+64 <= copyColsBytes; colByteIdx += 64 {
 			// Copy 64 bytes at a time.
-			v0 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(rhsPtr)))
-			v0.Store((*[64]uint8)(unsafe.Pointer(panelPtr)))
+			v0 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(rhsPtr)))
+			v0.StoreArray((*[64]uint8)(unsafe.Pointer(panelPtr)))
 			rhsPtr += 64
 			panelPtr += 64
 		}
@@ -419,42 +419,42 @@ func avx512PackLHSKernelRows4[T gotype.ScalarNotComplex](
 
 		// Vectorized loop over cols (64 bytes at a time)
 		for ; colByteIdx+64 <= contractingColsBytes; colByteIdx += 64 {
-			v0 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(lhsRow0Ptr)))
-			v1 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(lhsRow1Ptr)))
-			v2 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(lhsRow2Ptr)))
-			v3 := archsimd.LoadUint8x64((*[64]uint8)(unsafe.Pointer(lhsRow3Ptr)))
+			v0 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(lhsRow0Ptr)))
+			v1 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(lhsRow1Ptr)))
+			v2 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(lhsRow2Ptr)))
+			v3 := archsimd.LoadUint8x64Array((*[64]uint8)(unsafe.Pointer(lhsRow3Ptr)))
 
 			switch bytesPerElement {
 			case 4:
 				t0, t1, t2, t3 := avx512Transpose4x16x32bits(v0.AsUint32x16(), v1.AsUint32x16(), v2.AsUint32x16(), v3.AsUint32x16())
-				t0.Store((*[16]uint32)(unsafe.Pointer(panelPtr)))
-				t1.Store((*[16]uint32)(unsafe.Pointer(panelPtr + 64)))
-				t2.Store((*[16]uint32)(unsafe.Pointer(panelPtr + 128)))
-				t3.Store((*[16]uint32)(unsafe.Pointer(panelPtr + 192)))
+				t0.StoreArray((*[16]uint32)(unsafe.Pointer(panelPtr)))
+				t1.StoreArray((*[16]uint32)(unsafe.Pointer(panelPtr + 64)))
+				t2.StoreArray((*[16]uint32)(unsafe.Pointer(panelPtr + 128)))
+				t3.StoreArray((*[16]uint32)(unsafe.Pointer(panelPtr + 192)))
 
 				panelPtr += 256 // 4 x 16 x uint32
 
 			case 8:
 				t0, t1, t2, t3 := avx512Transpose4x8x64bits(v0.AsUint64x8(), v1.AsUint64x8(), v2.AsUint64x8(), v3.AsUint64x8())
-				t0.Store((*[8]uint64)(unsafe.Pointer(panelPtr)))
-				t1.Store((*[8]uint64)(unsafe.Pointer(panelPtr + 64)))
-				t2.Store((*[8]uint64)(unsafe.Pointer(panelPtr + 128)))
-				t3.Store((*[8]uint64)(unsafe.Pointer(panelPtr + 192)))
+				t0.StoreArray((*[8]uint64)(unsafe.Pointer(panelPtr)))
+				t1.StoreArray((*[8]uint64)(unsafe.Pointer(panelPtr + 64)))
+				t2.StoreArray((*[8]uint64)(unsafe.Pointer(panelPtr + 128)))
+				t3.StoreArray((*[8]uint64)(unsafe.Pointer(panelPtr + 192)))
 				panelPtr += 256
 			case 2:
 				t0, t1, t2, t3 := avx512Transpose4x32x16bits(v0.AsUint16x32(), v1.AsUint16x32(), v2.AsUint16x32(), v3.AsUint16x32())
-				t0.Store((*[32]uint16)(unsafe.Pointer(panelPtr)))
-				t1.Store((*[32]uint16)(unsafe.Pointer(panelPtr + 64)))
-				t2.Store((*[32]uint16)(unsafe.Pointer(panelPtr + 128)))
-				t3.Store((*[32]uint16)(unsafe.Pointer(panelPtr + 192)))
+				t0.StoreArray((*[32]uint16)(unsafe.Pointer(panelPtr)))
+				t1.StoreArray((*[32]uint16)(unsafe.Pointer(panelPtr + 64)))
+				t2.StoreArray((*[32]uint16)(unsafe.Pointer(panelPtr + 128)))
+				t3.StoreArray((*[32]uint16)(unsafe.Pointer(panelPtr + 192)))
 				panelPtr += 256 // 4 x 16 x uint32
 
 			case 1:
 				var tmp0, tmp1, tmp2, tmp3 [64]uint8
-				v0.Store(&tmp0)
-				v1.Store(&tmp1)
-				v2.Store(&tmp2)
-				v3.Store(&tmp3)
+				v0.StoreArray(&tmp0)
+				v1.StoreArray(&tmp1)
+				v2.StoreArray(&tmp2)
+				v3.StoreArray(&tmp3)
 				for i := uintptr(0); i < 64; i++ {
 					*(*uint8)(unsafe.Pointer(panelPtr)) = tmp0[i]
 					*(*uint8)(unsafe.Pointer(panelPtr + 1)) = tmp1[i]

--- a/internal/gobackend/dot/matmul/avx512_internal_test.go
+++ b/internal/gobackend/dot/matmul/avx512_internal_test.go
@@ -47,18 +47,18 @@ func TestAVX512(t *testing.T) {
 			input[i] = uint64(i)
 		}
 
-		v0 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[0*8])))
-		v1 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[1*8])))
-		v2 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[2*8])))
-		v3 := archsimd.LoadUint64x8((*[8]uint64)(unsafe.Pointer(&input[3*8])))
+		v0 := archsimd.LoadUint64x8Array((*[8]uint64)(unsafe.Pointer(&input[0*8])))
+		v1 := archsimd.LoadUint64x8Array((*[8]uint64)(unsafe.Pointer(&input[1*8])))
+		v2 := archsimd.LoadUint64x8Array((*[8]uint64)(unsafe.Pointer(&input[2*8])))
+		v3 := archsimd.LoadUint64x8Array((*[8]uint64)(unsafe.Pointer(&input[3*8])))
 
 		q0, q1, q2, q3 := avx512Transpose4x8x64bits(v0, v1, v2, v3)
 
 		var output [4 * 8]uint64
-		q0.Store((*[8]uint64)(unsafe.Pointer(&output[0*8])))
-		q1.Store((*[8]uint64)(unsafe.Pointer(&output[1*8])))
-		q2.Store((*[8]uint64)(unsafe.Pointer(&output[2*8])))
-		q3.Store((*[8]uint64)(unsafe.Pointer(&output[3*8])))
+		q0.StoreArray((*[8]uint64)(unsafe.Pointer(&output[0*8])))
+		q1.StoreArray((*[8]uint64)(unsafe.Pointer(&output[1*8])))
+		q2.StoreArray((*[8]uint64)(unsafe.Pointer(&output[2*8])))
+		q3.StoreArray((*[8]uint64)(unsafe.Pointer(&output[3*8])))
 
 		for c := range 8 { // logical column
 			for r := range 4 { // logical row
@@ -77,10 +77,10 @@ func TestAVX512(t *testing.T) {
 			input[i] = uint32(i)
 		}
 
-		v0 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[0*16])))
-		v1 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[1*16])))
-		v2 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[2*16])))
-		v3 := archsimd.LoadUint32x16((*[16]uint32)(unsafe.Pointer(&input[3*16])))
+		v0 := archsimd.LoadUint32x16Array((*[16]uint32)(unsafe.Pointer(&input[0*16])))
+		v1 := archsimd.LoadUint32x16Array((*[16]uint32)(unsafe.Pointer(&input[1*16])))
+		v2 := archsimd.LoadUint32x16Array((*[16]uint32)(unsafe.Pointer(&input[2*16])))
+		v3 := archsimd.LoadUint32x16Array((*[16]uint32)(unsafe.Pointer(&input[3*16])))
 
 		q0, q1, q2, q3 := avx512Transpose4x16x32bits(v0, v1, v2, v3)
 
@@ -95,10 +95,10 @@ func TestAVX512(t *testing.T) {
 		fmt.Printf("q3: [%s]\n", transposeIndicesFor4x16x32bits(q3))
 
 		var output [4 * 16]uint32
-		q0.Store((*[16]uint32)(unsafe.Pointer(&output[0*16])))
-		q1.Store((*[16]uint32)(unsafe.Pointer(&output[1*16])))
-		q2.Store((*[16]uint32)(unsafe.Pointer(&output[2*16])))
-		q3.Store((*[16]uint32)(unsafe.Pointer(&output[3*16])))
+		q0.StoreArray((*[16]uint32)(unsafe.Pointer(&output[0*16])))
+		q1.StoreArray((*[16]uint32)(unsafe.Pointer(&output[1*16])))
+		q2.StoreArray((*[16]uint32)(unsafe.Pointer(&output[2*16])))
+		q3.StoreArray((*[16]uint32)(unsafe.Pointer(&output[3*16])))
 
 		for c := range 16 { // logical column
 			for r := range 4 { // logical row
@@ -117,10 +117,10 @@ func TestAVX512(t *testing.T) {
 			input[i] = uint16(i)
 		}
 
-		v0 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[0*32])))
-		v1 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[1*32])))
-		v2 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[2*32])))
-		v3 := archsimd.LoadUint16x32((*[32]uint16)(unsafe.Pointer(&input[3*32])))
+		v0 := archsimd.LoadUint16x32Array((*[32]uint16)(unsafe.Pointer(&input[0*32])))
+		v1 := archsimd.LoadUint16x32Array((*[32]uint16)(unsafe.Pointer(&input[1*32])))
+		v2 := archsimd.LoadUint16x32Array((*[32]uint16)(unsafe.Pointer(&input[2*32])))
+		v3 := archsimd.LoadUint16x32Array((*[32]uint16)(unsafe.Pointer(&input[3*32])))
 
 		q0, q1, q2, q3 := avx512Transpose4x32x16bits(v0, v1, v2, v3)
 
@@ -135,10 +135,10 @@ func TestAVX512(t *testing.T) {
 		fmt.Printf("q3: [%s]\n", transposeIndicesFor4x32x16bits(q3))
 
 		var output [4 * 32]uint16
-		q0.Store((*[32]uint16)(unsafe.Pointer(&output[0*32])))
-		q1.Store((*[32]uint16)(unsafe.Pointer(&output[1*32])))
-		q2.Store((*[32]uint16)(unsafe.Pointer(&output[2*32])))
-		q3.Store((*[32]uint16)(unsafe.Pointer(&output[3*32])))
+		q0.StoreArray((*[32]uint16)(unsafe.Pointer(&output[0*32])))
+		q1.StoreArray((*[32]uint16)(unsafe.Pointer(&output[1*32])))
+		q2.StoreArray((*[32]uint16)(unsafe.Pointer(&output[2*32])))
+		q3.StoreArray((*[32]uint16)(unsafe.Pointer(&output[3*32])))
 
 		for c := range 32 { // logical column
 			for r := range 4 { // logical row
@@ -155,7 +155,7 @@ func TestAVX512(t *testing.T) {
 func transposeIndicesFor4x16x32bits(vec archsimd.Uint32x16) string {
 	var sb strings.Builder
 	var values [16]uint32
-	vec.Store(&values)
+	vec.StoreArray(&values)
 	for i, val := range values {
 		if i > 0 {
 			sb.WriteString(", ")
@@ -170,7 +170,7 @@ func transposeIndicesFor4x16x32bits(vec archsimd.Uint32x16) string {
 func transposeIndicesFor4x32x16bits(vec archsimd.Uint16x32) string {
 	var sb strings.Builder
 	var values [32]uint16
-	vec.Store(&values)
+	vec.StoreArray(&values)
 	for i, val := range values {
 		if i > 0 {
 			sb.WriteString(", ")

--- a/internal/gobackend/dot/matmul/avx512_large.go
+++ b/internal/gobackend/dot/matmul/avx512_large.go
@@ -341,10 +341,10 @@ func avx512LargeKernelFloat32( //alt:f32
 				// Load RHS (Broadcasting/Streaming)
 				rhsPtr0 := unsafe.Pointer(rhsRowPtr + rOffset)
 				rhsPtr1 := unsafe.Pointer(rhsRowPtr + rOffset + rhsRegisterStride) //alt:f32|f64
-				rhsVec0 := archsimd.LoadFloat32x16((*[16]float32)(rhsPtr0))        //alt:f32
-				//alt:f64 rhsVec0 := archsimd.LoadFloat64x8((*[8]float64)(rhsPtr0))
-				rhsVec1 := archsimd.LoadFloat32x16((*[16]float32)(rhsPtr1)) //alt:f32
-				//alt:f64 rhsVec1 := archsimd.LoadFloat64x8((*[8]float64)(rhsPtr1))
+				rhsVec0 := archsimd.LoadFloat32x16Array((*[16]float32)(rhsPtr0))        //alt:f32
+				//alt:f64 rhsVec0 := archsimd.LoadFloat64x8Array((*[8]float64)(rhsPtr0))
+				rhsVec1 := archsimd.LoadFloat32x16Array((*[16]float32)(rhsPtr1)) //alt:f32
+				//alt:f64 rhsVec1 := archsimd.LoadFloat64x8Array((*[8]float64)(rhsPtr1))
 				//alt:bf16 rhsBF16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(rhsPtr0))
 				//alt:bf16 rhsVec0, rhsVec1 := rhsBF16.ToFloat32()
 				//alt:f16 rhsF16 := float16.LoadFloat16x32((*[32]float16.Float16)(rhsPtr0))
@@ -403,22 +403,22 @@ func avx512LargeKernelFloat32( //alt:f32
 			outputIdx3 := outputIdx0 + uintptr(3*rhsPanelCols*bytesPerOutputElement)
 			registerStride := uintptr(outputNumLanes * bytesPerOutputElement) // It should be 64 bytes (512 bits) for AVX512.
 
-			accum_lhs0_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs0_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
-			accum_lhs0_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs0_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
-			accum_lhs1_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs1_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
-			accum_lhs1_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs1_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
-			accum_lhs2_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs2_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
-			accum_lhs2_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs2_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
-			accum_lhs3_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs3_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
-			accum_lhs3_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64 accum_lhs3_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
+			accum_lhs0_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs0_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
+			accum_lhs0_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs0_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
+			accum_lhs1_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs1_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
+			accum_lhs1_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs1_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
+			accum_lhs2_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs2_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
+			accum_lhs2_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs2_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
+			accum_lhs3_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs3_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
+			accum_lhs3_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64 accum_lhs3_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
 		}
 	}
 }

--- a/internal/gobackend/dot/matmul/avx512_small.go
+++ b/internal/gobackend/dot/matmul/avx512_small.go
@@ -180,14 +180,14 @@ func avx512SmallFloat32( //alt:f32
 					var r0, r1 archsimd.Float32x16 //alt:f32|bf16|f16
 					//alt:f64 var r0, r1 archsimd.Float64x8
 					{ //alt:f32|bf16|f16|f64
-						r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))                //alt:f32
-						r1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize))) //alt:f32
+						r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))                //alt:f32
+						r1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize))) //alt:f32
 						//alt:bf16 r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:bf16 r0, r1 = r0_bf16.ToFloat32()
 						//alt:f16 r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:f16 r0, r1 = r0_f16.ToFloat32()
-						//alt:f64 r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-						//alt:f64 r1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+						//alt:f64 r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f64 r1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 					} //alt:f32|bf16|f16|f64
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
@@ -199,22 +199,22 @@ func avx512SmallFloat32( //alt:f32
 					//alt:f64 var o0_0, o0_1, o1_0, o1_1, o2_0, o2_1, o3_0, o3_1 archsimd.Float64x8
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-						o0_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-						o1_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-						o2_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-						o3_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						//alt:f64 o0_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64 o0_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64 o1_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64 o1_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64 o2_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64 o2_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64 o3_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3)))
-						//alt:f64 o3_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+						o0_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+						o0_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+						o1_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+						o2_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+						o3_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						//alt:f64 o0_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64 o0_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64 o1_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64 o1_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64 o2_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64 o2_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64 o3_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3)))
+						//alt:f64 o3_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 					} else {
 						zero := archsimd.BroadcastFloat32x16(0.0) //alt:f32|bf16|f16
 						//alt:f64 zero := archsimd.BroadcastFloat64x8(0.0)
@@ -233,22 +233,22 @@ func avx512SmallFloat32( //alt:f32
 					o3_0 = l3.MulAdd(r0, o3_0) //alt:f32|bf16|f16|f64
 					o3_1 = l3.MulAdd(r1, o3_1) //alt:f32|bf16|f16|f64
 
-					o0_0.Store((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-					o0_1.Store((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o1_0.Store((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-					o1_1.Store((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o2_0.Store((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-					o2_1.Store((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o3_0.Store((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-					o3_1.Store((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					//alt:f64 o0_0.Store((*[8]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64 o0_1.Store((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64 o1_0.Store((*[8]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64 o1_1.Store((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64 o2_0.Store((*[8]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64 o2_1.Store((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64 o3_0.Store((*[8]float64)(unsafe.Pointer(outBase3)))
-					//alt:f64 o3_1.Store((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+					o0_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+					o0_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+					o1_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+					o2_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+					o3_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					//alt:f64 o0_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64 o0_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64 o1_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64 o1_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64 o2_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64 o2_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64 o3_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase3)))
+					//alt:f64 o3_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 				}
 
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth { //alt:f32
@@ -256,8 +256,8 @@ func avx512SmallFloat32( //alt:f32
 					var r0 archsimd.Float32x16 //alt:f32
 					//alt:f64 var r0 archsimd.Float64x8
 					{ //alt:f32|f64
-						r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f32
-						//alt:f64 r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f32
+						//alt:f64 r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					} //alt:f32|f64
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize //alt:f32|f64
@@ -269,14 +269,14 @@ func avx512SmallFloat32( //alt:f32
 					//alt:f64 var o0_0, o1_0, o2_0, o3_0 archsimd.Float64x8
 
 					if k > 0 { //alt:f32|f64
-						o0_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0))) //alt:f32
-						o1_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1))) //alt:f32
-						o2_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2))) //alt:f32
-						o3_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3))) //alt:f32
-						//alt:f64 o0_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64 o1_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64 o2_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64 o3_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3)))
+						o0_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0))) //alt:f32
+						o1_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1))) //alt:f32
+						o2_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2))) //alt:f32
+						o3_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3))) //alt:f32
+						//alt:f64 o0_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64 o1_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64 o2_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64 o3_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3)))
 					} else { //alt:f32|f64
 						zero := archsimd.BroadcastFloat32x16(0.0) //alt:f32
 						//alt:f64 zero := archsimd.BroadcastFloat64x8(0.0)
@@ -291,14 +291,14 @@ func avx512SmallFloat32( //alt:f32
 					o2_0 = l2.MulAdd(r0, o2_0) //alt:f32|f64
 					o3_0 = l3.MulAdd(r0, o3_0) //alt:f32|f64
 
-					o0_0.Store((*[16]float32)(unsafe.Pointer(outBase0))) //alt:f32
-					o1_0.Store((*[16]float32)(unsafe.Pointer(outBase1))) //alt:f32
-					o2_0.Store((*[16]float32)(unsafe.Pointer(outBase2))) //alt:f32
-					o3_0.Store((*[16]float32)(unsafe.Pointer(outBase3))) //alt:f32
-					//alt:f64 o0_0.Store((*[8]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64 o1_0.Store((*[8]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64 o2_0.Store((*[8]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64 o3_0.Store((*[8]float64)(unsafe.Pointer(outBase3)))
+					o0_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase0))) //alt:f32
+					o1_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase1))) //alt:f32
+					o2_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase2))) //alt:f32
+					o3_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase3))) //alt:f32
+					//alt:f64 o0_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64 o1_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64 o2_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64 o3_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase3)))
 				} //alt:f32|f64
 
 				for ; col < rhsCrossSize; col++ {
@@ -378,12 +378,12 @@ func avx512SmallFloat32( //alt:f32
 					//alt:bf16 var r1 archsimd.Float32x16
 					//alt:f16 var r1 archsimd.Float32x16
 					{ //alt:f32|bf16|f16|f64
-						r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f32
+						r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f32
 						//alt:bf16 r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:bf16 r0, r1 = r0_bf16.ToFloat32()
 						//alt:f16 r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:f16 r0, r1 = r0_f16.ToFloat32()
-						//alt:f64 r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f64 r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					} //alt:f32|bf16|f16|f64
 
 					outBase := outputBase + uintptr(row*rhsCrossSize+col)*oSize
@@ -393,10 +393,10 @@ func avx512SmallFloat32( //alt:f32
 					//alt:f16 var o1 archsimd.Float32x16
 
 					if k > 0 {
-						o0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-						//alt:f64 o0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase)))
-						//alt:bf16 o1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
-						//alt:f16 o1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+						o0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+						//alt:f64 o0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase)))
+						//alt:bf16 o1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+						//alt:f16 o1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
 					} else {
 						o0 = archsimd.BroadcastFloat32x16(0.0) //alt:f32|bf16|f16
 						//alt:f64 o0 = archsimd.BroadcastFloat64x8(0.0)
@@ -408,10 +408,10 @@ func avx512SmallFloat32( //alt:f32
 					//alt:bf16 o1 = l0.MulAdd(r1, o1)
 					//alt:f16 o1 = l0.MulAdd(r1, o1)
 
-					o0.Store((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-					//alt:f64 o0.Store((*[8]float64)(unsafe.Pointer(outBase)))
-					//alt:bf16 o1.Store((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
-					//alt:f16 o1.Store((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+					o0.StoreArray((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+					//alt:f64 o0.StoreArray((*[8]float64)(unsafe.Pointer(outBase)))
+					//alt:bf16 o1.StoreArray((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+					//alt:f16 o1.StoreArray((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -506,20 +506,20 @@ func avx512SmallFloat32Transposed( //alt:f32
 				// Unroll by 4 registers on the contracting size
 				for ; k+4*vecWidth <= contractingSize; k += 4 * vecWidth {
 					// Load LHS (contiguous)
-					l0 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f32
+					l0 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f32
 					//alt:bf16 l0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16 l0a, l0b := l0_bf16.ToFloat32()
 					//alt:f16 l0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:f16 l0a, l0b := l0_f16.ToFloat32()
-					//alt:f64 l0 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f64 l0 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 
 					// Load RHS (contiguous for Transposed)
-					r0 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f32
+					r0 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f32
 					//alt:bf16 r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16 r0a, r0b := r0_bf16.ToFloat32()
 					//alt:f16 r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:f16 r0a, r0b := r0_f16.ToFloat32()
-					//alt:f64 r0 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64 r0 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 
 					acc = l0.MulAdd(r0, acc) //alt:f32|f64
 					//alt:bf16 acc = l0a.MulAdd(r0a, acc)
@@ -527,54 +527,54 @@ func avx512SmallFloat32Transposed( //alt:f32
 					//alt:f16 acc = l0a.MulAdd(r0a, acc)
 					//alt:f16 acc = l0b.MulAdd(r0b, acc)
 
-					l1 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f32
+					l1 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f32
 					//alt:bf16 l1_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16 l1a, l1b := l1_bf16.ToFloat32()
 					//alt:f16 l1_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:f16 l1a, l1b := l1_f16.ToFloat32()
-					//alt:f64 l1 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
-					r1 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f32
+					//alt:f64 l1 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					r1 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f32
 					//alt:bf16 r1_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16 r1a, r1b := r1_bf16.ToFloat32()
 					//alt:f16 r1_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:f16 r1a, r1b := r1_f16.ToFloat32()
-					//alt:f64 r1 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64 r1 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					acc = l1.MulAdd(r1, acc) //alt:f32|f64
 					//alt:bf16 acc = l1a.MulAdd(r1a, acc)
 					//alt:bf16 acc = l1b.MulAdd(r1b, acc)
 					//alt:f16 acc = l1a.MulAdd(r1a, acc)
 					//alt:f16 acc = l1b.MulAdd(r1b, acc)
 
-					l2 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f32
+					l2 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f32
 					//alt:bf16 l2_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16 l2a, l2b := l2_bf16.ToFloat32()
 					//alt:f16 l2_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:f16 l2a, l2b := l2_f16.ToFloat32()
-					//alt:f64 l2 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
-					r2 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f32
+					//alt:f64 l2 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					r2 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f32
 					//alt:bf16 r2_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16 r2a, r2b := r2_bf16.ToFloat32()
 					//alt:f16 r2_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:f16 r2a, r2b := r2_f16.ToFloat32()
-					//alt:f64 r2 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64 r2 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					acc = l2.MulAdd(r2, acc) //alt:f32|f64
 					//alt:bf16 acc = l2a.MulAdd(r2a, acc)
 					//alt:bf16 acc = l2b.MulAdd(r2b, acc)
 					//alt:f16 acc = l2a.MulAdd(r2a, acc)
 					//alt:f16 acc = l2b.MulAdd(r2b, acc)
 
-					l3 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f32
+					l3 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f32
 					//alt:bf16 l3_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16 l3a, l3b := l3_bf16.ToFloat32()
 					//alt:f16 l3_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:f16 l3a, l3b := l3_f16.ToFloat32()
-					//alt:f64 l3 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
-					r3 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f32
+					//alt:f64 l3 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					r3 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f32
 					//alt:bf16 r3_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16 r3a, r3b := r3_bf16.ToFloat32()
 					//alt:f16 r3_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:f16 r3a, r3b := r3_f16.ToFloat32()
-					//alt:f64 r3 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64 r3 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					acc = l3.MulAdd(r3, acc) //alt:f32|f64
 					//alt:bf16 acc = l3a.MulAdd(r3a, acc)
 					//alt:bf16 acc = l3b.MulAdd(r3b, acc)
@@ -584,18 +584,18 @@ func avx512SmallFloat32Transposed( //alt:f32
 
 				// Remaining full vectors
 				for ; k+vecWidth <= contractingSize; k += vecWidth {
-					lVal := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f32
+					lVal := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f32
 					//alt:bf16 l_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16 la, lb := l_bf16.ToFloat32()
 					//alt:f16 l_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:f16 la, lb := l_f16.ToFloat32()
-					//alt:f64 lVal := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					rVal := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f32
+					//alt:f64 lVal := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					rVal := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f32
 					//alt:bf16 r_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16 ra, rb := r_bf16.ToFloat32()
 					//alt:f16 r_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:f16 ra, rb := r_f16.ToFloat32()
-					//alt:f64 rVal := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64 rVal := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					acc = lVal.MulAdd(rVal, acc) //alt:f32|f64
 					//alt:bf16 acc = la.MulAdd(ra, acc)
 					//alt:bf16 acc = lb.MulAdd(rb, acc)

--- a/internal/gobackend/dot/matmul/avx512_transpose.go
+++ b/internal/gobackend/dot/matmul/avx512_transpose.go
@@ -36,23 +36,23 @@ func avx512Transpose4x16x32bits(v0, v1, v2, v3 archsimd.Uint32x16) (row0to4, row
 		}
 	)
 	{
-		t00 := v0.ConcatPermute(v2, archsimd.LoadUint32x16(&t0Indices))
-		t01 := v1.ConcatPermute(v3, archsimd.LoadUint32x16(&t0Indices))
+		t00 := v0.ConcatPermute(v2, archsimd.LoadUint32x16Array(&t0Indices))
+		t01 := v1.ConcatPermute(v3, archsimd.LoadUint32x16Array(&t0Indices))
 		row0to4 = t00.InterleaveLoGrouped(t01)
 	}
 	{
-		t10 := v0.ConcatPermute(v2, archsimd.LoadUint32x16(&t1Indices))
-		t11 := v1.ConcatPermute(v3, archsimd.LoadUint32x16(&t1Indices))
+		t10 := v0.ConcatPermute(v2, archsimd.LoadUint32x16Array(&t1Indices))
+		t11 := v1.ConcatPermute(v3, archsimd.LoadUint32x16Array(&t1Indices))
 		row4to8 = t10.InterleaveLoGrouped(t11)
 	}
 	{
-		t20 := v0.ConcatPermute(v2, archsimd.LoadUint32x16(&t2Indices))
-		t21 := v1.ConcatPermute(v3, archsimd.LoadUint32x16(&t2Indices))
+		t20 := v0.ConcatPermute(v2, archsimd.LoadUint32x16Array(&t2Indices))
+		t21 := v1.ConcatPermute(v3, archsimd.LoadUint32x16Array(&t2Indices))
 		row8to12 = t20.InterleaveLoGrouped(t21)
 	}
 	{
-		t30 := v0.ConcatPermute(v2, archsimd.LoadUint32x16(&t3Indices))
-		t31 := v1.ConcatPermute(v3, archsimd.LoadUint32x16(&t3Indices))
+		t30 := v0.ConcatPermute(v2, archsimd.LoadUint32x16Array(&t3Indices))
+		t31 := v1.ConcatPermute(v3, archsimd.LoadUint32x16Array(&t3Indices))
 		row12to16 = t30.InterleaveLoGrouped(t31)
 	}
 	return
@@ -93,23 +93,23 @@ func avx512Transpose4x32x16bits(v0, v1, v2, v3 archsimd.Uint16x32) (row0to8, row
 		}
 	)
 	{
-		t00 := v0.ConcatPermute(v2, archsimd.LoadUint16x32(&t0Indices))
-		t01 := v1.ConcatPermute(v3, archsimd.LoadUint16x32(&t0Indices))
+		t00 := v0.ConcatPermute(v2, archsimd.LoadUint16x32Array(&t0Indices))
+		t01 := v1.ConcatPermute(v3, archsimd.LoadUint16x32Array(&t0Indices))
 		row0to8 = t00.InterleaveLoGrouped(t01)
 	}
 	{
-		t10 := v0.ConcatPermute(v2, archsimd.LoadUint16x32(&t1Indices))
-		t11 := v1.ConcatPermute(v3, archsimd.LoadUint16x32(&t1Indices))
+		t10 := v0.ConcatPermute(v2, archsimd.LoadUint16x32Array(&t1Indices))
+		t11 := v1.ConcatPermute(v3, archsimd.LoadUint16x32Array(&t1Indices))
 		row8to16 = t10.InterleaveLoGrouped(t11)
 	}
 	{
-		t20 := v0.ConcatPermute(v2, archsimd.LoadUint16x32(&t2Indices))
-		t21 := v1.ConcatPermute(v3, archsimd.LoadUint16x32(&t2Indices))
+		t20 := v0.ConcatPermute(v2, archsimd.LoadUint16x32Array(&t2Indices))
+		t21 := v1.ConcatPermute(v3, archsimd.LoadUint16x32Array(&t2Indices))
 		row16to24 = t20.InterleaveLoGrouped(t21)
 	}
 	{
-		t30 := v0.ConcatPermute(v2, archsimd.LoadUint16x32(&t3Indices))
-		t31 := v1.ConcatPermute(v3, archsimd.LoadUint16x32(&t3Indices))
+		t30 := v0.ConcatPermute(v2, archsimd.LoadUint16x32Array(&t3Indices))
+		t31 := v1.ConcatPermute(v3, archsimd.LoadUint16x32Array(&t3Indices))
 		row24to32 = t30.InterleaveLoGrouped(t31)
 	}
 	return
@@ -129,23 +129,23 @@ func avx512Transpose4x8x64bits(v0, v1, v2, v3 archsimd.Uint64x8) (row0to2, row2t
 		t3Indices = [8]uint64{6, 0, 14, 0, 7, 0, 15, 0}
 	)
 	{
-		t00 := v0.ConcatPermute(v2, archsimd.LoadUint64x8(&t0Indices))
-		t01 := v1.ConcatPermute(v3, archsimd.LoadUint64x8(&t0Indices))
+		t00 := v0.ConcatPermute(v2, archsimd.LoadUint64x8Array(&t0Indices))
+		t01 := v1.ConcatPermute(v3, archsimd.LoadUint64x8Array(&t0Indices))
 		row0to2 = t00.InterleaveLoGrouped(t01)
 	}
 	{
-		t10 := v0.ConcatPermute(v2, archsimd.LoadUint64x8(&t1Indices))
-		t11 := v1.ConcatPermute(v3, archsimd.LoadUint64x8(&t1Indices))
+		t10 := v0.ConcatPermute(v2, archsimd.LoadUint64x8Array(&t1Indices))
+		t11 := v1.ConcatPermute(v3, archsimd.LoadUint64x8Array(&t1Indices))
 		row2to4 = t10.InterleaveLoGrouped(t11)
 	}
 	{
-		t20 := v0.ConcatPermute(v2, archsimd.LoadUint64x8(&t2Indices))
-		t21 := v1.ConcatPermute(v3, archsimd.LoadUint64x8(&t2Indices))
+		t20 := v0.ConcatPermute(v2, archsimd.LoadUint64x8Array(&t2Indices))
+		t21 := v1.ConcatPermute(v3, archsimd.LoadUint64x8Array(&t2Indices))
 		row4to6 = t20.InterleaveLoGrouped(t21)
 	}
 	{
-		t30 := v0.ConcatPermute(v2, archsimd.LoadUint64x8(&t3Indices))
-		t31 := v1.ConcatPermute(v3, archsimd.LoadUint64x8(&t3Indices))
+		t30 := v0.ConcatPermute(v2, archsimd.LoadUint64x8Array(&t3Indices))
+		t31 := v1.ConcatPermute(v3, archsimd.LoadUint64x8Array(&t3Indices))
 		row6to8 = t30.InterleaveLoGrouped(t31)
 	}
 	return

--- a/internal/gobackend/dot/matmul/gen_avx2_large_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_bf16.go
@@ -340,10 +340,10 @@ func avx2LargeKernelBFloat16( //alt:bf16
 				// Load RHS (Broadcasting/Streaming)
 				rhsPtr0 := unsafe.Pointer(rhsRowPtr + rOffset)
 				//alt:f32|f64 rhsPtr1 := unsafe.Pointer(rhsRowPtr + rOffset + rhsRegisterStride)
-				//alt:f32 rhsVec0 := archsimd.LoadFloat32x8((*[8]float32)(rhsPtr0))
-				//alt:f64  rhsVec0 := archsimd.LoadFloat64x4((*[4]float64)(rhsPtr0))
-				//alt:f32 rhsVec1 := archsimd.LoadFloat32x8((*[8]float32)(rhsPtr1))
-				//alt:f64  rhsVec1 := archsimd.LoadFloat64x4((*[4]float64)(rhsPtr1))
+				//alt:f32 rhsVec0 := archsimd.LoadFloat32x8Array((*[8]float32)(rhsPtr0))
+				//alt:f64  rhsVec0 := archsimd.LoadFloat64x4Array((*[4]float64)(rhsPtr0))
+				//alt:f32 rhsVec1 := archsimd.LoadFloat32x8Array((*[8]float32)(rhsPtr1))
+				//alt:f64  rhsVec1 := archsimd.LoadFloat64x4Array((*[4]float64)(rhsPtr1))
 				rhsBF16 := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(rhsPtr0)) //alt:bf16
 				rhsVec0, rhsVec1 := rhsBF16.ToFloat32()                                //alt:bf16
 				//alt:f16  rhsF16 := float16.LoadFloat16x16((*[16]float16.Float16)(rhsPtr0))
@@ -402,22 +402,22 @@ func avx2LargeKernelBFloat16( //alt:bf16
 			outputIdx3 := outputIdx0 + uintptr(3*outputStride*bytesPerOutputElement)
 			registerStride := uintptr(outputNumLanes * bytesPerOutputElement)
 
-			accum_lhs0_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs0_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
-			accum_lhs0_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs0_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
-			accum_lhs1_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs1_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
-			accum_lhs1_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs1_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
-			accum_lhs2_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs2_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
-			accum_lhs2_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs2_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
-			accum_lhs3_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs3_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
-			accum_lhs3_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs3_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
+			accum_lhs0_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs0_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
+			accum_lhs0_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs0_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
+			accum_lhs1_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs1_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
+			accum_lhs1_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs1_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
+			accum_lhs2_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs2_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
+			accum_lhs2_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs2_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
+			accum_lhs3_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs3_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
+			accum_lhs3_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs3_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
 		}
 	}
 }

--- a/internal/gobackend/dot/matmul/gen_avx2_large_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_f16.go
@@ -340,10 +340,10 @@ func avx2LargeKernelFloat16( //alt:f16
 				// Load RHS (Broadcasting/Streaming)
 				rhsPtr0 := unsafe.Pointer(rhsRowPtr + rOffset)
 				//alt:f32|f64 rhsPtr1 := unsafe.Pointer(rhsRowPtr + rOffset + rhsRegisterStride)
-				//alt:f32 rhsVec0 := archsimd.LoadFloat32x8((*[8]float32)(rhsPtr0))
-				//alt:f64  rhsVec0 := archsimd.LoadFloat64x4((*[4]float64)(rhsPtr0))
-				//alt:f32 rhsVec1 := archsimd.LoadFloat32x8((*[8]float32)(rhsPtr1))
-				//alt:f64  rhsVec1 := archsimd.LoadFloat64x4((*[4]float64)(rhsPtr1))
+				//alt:f32 rhsVec0 := archsimd.LoadFloat32x8Array((*[8]float32)(rhsPtr0))
+				//alt:f64  rhsVec0 := archsimd.LoadFloat64x4Array((*[4]float64)(rhsPtr0))
+				//alt:f32 rhsVec1 := archsimd.LoadFloat32x8Array((*[8]float32)(rhsPtr1))
+				//alt:f64  rhsVec1 := archsimd.LoadFloat64x4Array((*[4]float64)(rhsPtr1))
 				//alt:bf16  rhsBF16 := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(rhsPtr0))
 				//alt:bf16  rhsVec0, rhsVec1 := rhsBF16.ToFloat32()
 				rhsF16 := float16.LoadFloat16x16((*[16]float16.Float16)(rhsPtr0)) //alt:f16
@@ -402,22 +402,22 @@ func avx2LargeKernelFloat16( //alt:f16
 			outputIdx3 := outputIdx0 + uintptr(3*outputStride*bytesPerOutputElement)
 			registerStride := uintptr(outputNumLanes * bytesPerOutputElement)
 
-			accum_lhs0_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs0_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
-			accum_lhs0_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs0_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
-			accum_lhs1_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs1_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
-			accum_lhs1_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs1_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
-			accum_lhs2_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs2_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
-			accum_lhs2_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs2_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
-			accum_lhs3_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs3_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
-			accum_lhs3_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs3_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
+			accum_lhs0_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs0_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
+			accum_lhs0_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs0_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
+			accum_lhs1_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs1_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
+			accum_lhs1_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs1_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
+			accum_lhs2_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs2_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
+			accum_lhs2_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs2_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
+			accum_lhs3_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs3_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
+			accum_lhs3_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs3_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
 		}
 	}
 }

--- a/internal/gobackend/dot/matmul/gen_avx2_large_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_f64.go
@@ -340,10 +340,10 @@ func avx2LargeKernelFloat64( //alt:f64
 				// Load RHS (Broadcasting/Streaming)
 				rhsPtr0 := unsafe.Pointer(rhsRowPtr + rOffset)
 				rhsPtr1 := unsafe.Pointer(rhsRowPtr + rOffset + rhsRegisterStride) //alt:f32|f64
-				//alt:f32 rhsVec0 := archsimd.LoadFloat32x8((*[8]float32)(rhsPtr0))
-				rhsVec0 := archsimd.LoadFloat64x4((*[4]float64)(rhsPtr0)) //alt:f64
-				//alt:f32 rhsVec1 := archsimd.LoadFloat32x8((*[8]float32)(rhsPtr1))
-				rhsVec1 := archsimd.LoadFloat64x4((*[4]float64)(rhsPtr1)) //alt:f64
+				//alt:f32 rhsVec0 := archsimd.LoadFloat32x8Array((*[8]float32)(rhsPtr0))
+				rhsVec0 := archsimd.LoadFloat64x4Array((*[4]float64)(rhsPtr0)) //alt:f64
+				//alt:f32 rhsVec1 := archsimd.LoadFloat32x8Array((*[8]float32)(rhsPtr1))
+				rhsVec1 := archsimd.LoadFloat64x4Array((*[4]float64)(rhsPtr1)) //alt:f64
 				//alt:bf16  rhsBF16 := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(rhsPtr0))
 				//alt:bf16  rhsVec0, rhsVec1 := rhsBF16.ToFloat32()
 				//alt:f16  rhsF16 := float16.LoadFloat16x16((*[16]float16.Float16)(rhsPtr0))
@@ -402,22 +402,22 @@ func avx2LargeKernelFloat64( //alt:f64
 			outputIdx3 := outputIdx0 + uintptr(3*outputStride*bytesPerOutputElement)
 			registerStride := uintptr(outputNumLanes * bytesPerOutputElement)
 
-			//alt:f32|bf16|f16 accum_lhs0_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0)))
-			accum_lhs0_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs0_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
-			accum_lhs0_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs1_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1)))
-			accum_lhs1_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs1_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
-			accum_lhs1_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs2_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2)))
-			accum_lhs2_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs2_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
-			accum_lhs2_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs3_rhs0.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3)))
-			accum_lhs3_rhs0.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs3_rhs1.Store((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
-			accum_lhs3_rhs1.Store((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs0_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0)))
+			accum_lhs0_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs0_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
+			accum_lhs0_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs1_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1)))
+			accum_lhs1_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs1_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
+			accum_lhs1_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs2_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2)))
+			accum_lhs2_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs2_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
+			accum_lhs2_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs3_rhs0.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3)))
+			accum_lhs3_rhs0.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs3_rhs1.StoreArray((*[8]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
+			accum_lhs3_rhs1.StoreArray((*[4]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f64
 		}
 	}
 }

--- a/internal/gobackend/dot/matmul/gen_avx2_small_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_small_bf16.go
@@ -174,12 +174,12 @@ func avx2SmallBFloat16( //alt:bf16
 
 				col := 0
 				for ; col+2*outputVecWidth <= rhsCrossSize; col += 2 * outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-					//alt:f32 r1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 					r0, r1 := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  r0, r1 := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					//alt:f64  r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-					//alt:f64  r1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64  r1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
 					outBase1 := outputBase + uintptr((row+1)*rhsCrossSize+col)*oSize
@@ -190,22 +190,22 @@ func avx2SmallBFloat16( //alt:bf16
 					//alt:f64  var o0_0, o0_1, o1_0, o1_1, o2_0, o2_1, o3_0, o3_1 archsimd.Float64x4
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-						o0_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-						o1_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-						o2_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-						o3_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						//alt:f64  o0_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64  o0_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o1_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64  o1_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o2_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64  o2_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o3_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3)))
-						//alt:f64  o3_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+						o0_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+						o0_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+						o1_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+						o2_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+						o3_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						//alt:f64  o0_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64  o0_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o1_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64  o1_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o2_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64  o2_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o3_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3)))
+						//alt:f64  o3_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 					} else {
 						zero := archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64  zero := archsimd.BroadcastFloat64x4(0.0)
@@ -224,29 +224,29 @@ func avx2SmallBFloat16( //alt:bf16
 					o3_0 = l3.MulAdd(r0, o3_0)
 					o3_1 = l3.MulAdd(r1, o3_1)
 
-					o0_0.Store((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-					o0_1.Store((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o1_0.Store((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-					o1_1.Store((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o2_0.Store((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-					o2_1.Store((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o3_0.Store((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-					o3_1.Store((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					//alt:f64  o0_0.Store((*[4]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64  o0_1.Store((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o1_0.Store((*[4]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64  o1_1.Store((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o2_0.Store((*[4]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64  o2_1.Store((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o3_0.Store((*[4]float64)(unsafe.Pointer(outBase3)))
-					//alt:f64  o3_1.Store((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+					o0_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+					o0_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+					o1_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+					o2_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+					o3_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					//alt:f64  o0_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64  o0_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o1_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64  o1_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o2_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64  o2_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o3_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase3)))
+					//alt:f64  o3_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 				}
 
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					//alt:f64  r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
 					outBase1 := outputBase + uintptr((row+1)*rhsCrossSize+col)*oSize
@@ -257,14 +257,14 @@ func avx2SmallBFloat16( //alt:bf16
 					//alt:f64  var o0_0, o1_0, o2_0, o3_0 archsimd.Float64x4
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
-						//alt:f64  o0_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64  o1_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64  o2_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64  o3_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3)))
+						o0_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
+						//alt:f64  o0_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64  o1_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64  o2_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64  o3_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3)))
 					} else {
 						zero := archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64  zero := archsimd.BroadcastFloat64x4(0.0)
@@ -276,14 +276,14 @@ func avx2SmallBFloat16( //alt:bf16
 					o2_0 = l2.MulAdd(r0, o2_0)
 					o3_0 = l3.MulAdd(r0, o3_0)
 
-					o0_0.Store((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
-					o1_0.Store((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
-					o2_0.Store((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
-					o3_0.Store((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
-					//alt:f64  o0_0.Store((*[4]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64  o1_0.Store((*[4]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64  o2_0.Store((*[4]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64  o3_0.Store((*[4]float64)(unsafe.Pointer(outBase3)))
+					o0_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
+					//alt:f64  o0_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64  o1_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64  o2_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64  o3_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase3)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -351,26 +351,26 @@ func avx2SmallBFloat16( //alt:bf16
 
 				col := 0
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					//alt:f64  r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 
 					outBase := outputBase + uintptr(row*rhsCrossSize+col)*oSize
 					var o0 archsimd.Float32x8 //alt:f32|bf16|f16
 					//alt:f64  var o0 archsimd.Float64x4
 
 					if k > 0 {
-						o0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-						//alt:f64  o0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase)))
+						o0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+						//alt:f64  o0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase)))
 					} else {
 						o0 = archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64  o0 = archsimd.BroadcastFloat64x4(0.0)
 					}
 
 					o0 = l0.MulAdd(r0, o0)
-					o0.Store((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-					//alt:f64  o0.Store((*[4]float64)(unsafe.Pointer(outBase)))
+					o0.StoreArray((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+					//alt:f64  o0.StoreArray((*[4]float64)(unsafe.Pointer(outBase)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -460,56 +460,56 @@ func avx2SmallBFloat16Transposed( //alt:bf16
 				//alt:f64  const vecWidth = 4
 
 				for ; k+4*vecWidth <= contractingSize; k += 4 * vecWidth {
-					//alt:f32 l0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 l0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					l0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  l0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
-					//alt:f64  l0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  l0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
-					//alt:f64  r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					acc = l0.MulAdd(r0, acc)
 
-					//alt:f32 l1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 l1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					l1, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  l1, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
-					//alt:f64  l1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
-					//alt:f32 r1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64  l1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 r1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					r1, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  r1, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
-					//alt:f64  r1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64  r1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					acc = l1.MulAdd(r1, acc)
 
-					//alt:f32 l2 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 l2 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					l2, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  l2, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
-					//alt:f64  l2 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
-					//alt:f32 r2 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64  l2 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 r2 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					r2, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  r2, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
-					//alt:f64  r2 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64  r2 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					acc = l2.MulAdd(r2, acc)
 
-					//alt:f32 l3 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 l3 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					l3, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  l3, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
-					//alt:f64  l3 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
-					//alt:f32 r3 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64  l3 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 r3 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					r3, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  r3, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
-					//alt:f64  r3 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64  r3 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					acc = l3.MulAdd(r3, acc)
 				}
 
 				for ; k+vecWidth <= contractingSize; k += vecWidth {
-					//alt:f32 lVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 lVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					lVal, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  lVal, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
-					//alt:f64  lVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					//alt:f32 rVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  lVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 rVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					rVal, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32() //alt:bf16
 					//alt:f16  rVal, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
-					//alt:f64  rVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  rVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					acc = lVal.MulAdd(rVal, acc)
 				}
 

--- a/internal/gobackend/dot/matmul/gen_avx2_small_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_small_f16.go
@@ -174,12 +174,12 @@ func avx2SmallFloat16( //alt:f16
 
 				col := 0
 				for ; col+2*outputVecWidth <= rhsCrossSize; col += 2 * outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-					//alt:f32 r1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 					//alt:bf16  r0, r1 := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					r0, r1 := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-					//alt:f64  r1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64  r1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
 					outBase1 := outputBase + uintptr((row+1)*rhsCrossSize+col)*oSize
@@ -190,22 +190,22 @@ func avx2SmallFloat16( //alt:f16
 					//alt:f64  var o0_0, o0_1, o1_0, o1_1, o2_0, o2_1, o3_0, o3_1 archsimd.Float64x4
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-						o0_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-						o1_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-						o2_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-						o3_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						//alt:f64  o0_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64  o0_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o1_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64  o1_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o2_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64  o2_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o3_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3)))
-						//alt:f64  o3_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+						o0_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+						o0_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+						o1_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+						o2_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+						o3_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						//alt:f64  o0_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64  o0_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o1_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64  o1_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o2_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64  o2_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o3_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3)))
+						//alt:f64  o3_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 					} else {
 						zero := archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64  zero := archsimd.BroadcastFloat64x4(0.0)
@@ -224,29 +224,29 @@ func avx2SmallFloat16( //alt:f16
 					o3_0 = l3.MulAdd(r0, o3_0)
 					o3_1 = l3.MulAdd(r1, o3_1)
 
-					o0_0.Store((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-					o0_1.Store((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o1_0.Store((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-					o1_1.Store((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o2_0.Store((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-					o2_1.Store((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o3_0.Store((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-					o3_1.Store((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					//alt:f64  o0_0.Store((*[4]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64  o0_1.Store((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o1_0.Store((*[4]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64  o1_1.Store((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o2_0.Store((*[4]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64  o2_1.Store((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o3_0.Store((*[4]float64)(unsafe.Pointer(outBase3)))
-					//alt:f64  o3_1.Store((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+					o0_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+					o0_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+					o1_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+					o2_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+					o3_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					//alt:f64  o0_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64  o0_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o1_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64  o1_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o2_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64  o2_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o3_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase3)))
+					//alt:f64  o3_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 				}
 
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					//alt:bf16  r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
 					outBase1 := outputBase + uintptr((row+1)*rhsCrossSize+col)*oSize
@@ -257,14 +257,14 @@ func avx2SmallFloat16( //alt:f16
 					//alt:f64  var o0_0, o1_0, o2_0, o3_0 archsimd.Float64x4
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
-						//alt:f64  o0_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64  o1_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64  o2_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64  o3_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3)))
+						o0_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
+						//alt:f64  o0_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64  o1_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64  o2_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64  o3_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3)))
 					} else {
 						zero := archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64  zero := archsimd.BroadcastFloat64x4(0.0)
@@ -276,14 +276,14 @@ func avx2SmallFloat16( //alt:f16
 					o2_0 = l2.MulAdd(r0, o2_0)
 					o3_0 = l3.MulAdd(r0, o3_0)
 
-					o0_0.Store((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
-					o1_0.Store((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
-					o2_0.Store((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
-					o3_0.Store((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
-					//alt:f64  o0_0.Store((*[4]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64  o1_0.Store((*[4]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64  o2_0.Store((*[4]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64  o3_0.Store((*[4]float64)(unsafe.Pointer(outBase3)))
+					o0_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase0))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase1))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase2))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase3))) //alt:f32|bf16|f16
+					//alt:f64  o0_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64  o1_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64  o2_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64  o3_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase3)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -351,26 +351,26 @@ func avx2SmallFloat16( //alt:f16
 
 				col := 0
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					//alt:bf16  r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 
 					outBase := outputBase + uintptr(row*rhsCrossSize+col)*oSize
 					var o0 archsimd.Float32x8 //alt:f32|bf16|f16
 					//alt:f64  var o0 archsimd.Float64x4
 
 					if k > 0 {
-						o0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-						//alt:f64  o0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase)))
+						o0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+						//alt:f64  o0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase)))
 					} else {
 						o0 = archsimd.BroadcastFloat32x8(0.0) //alt:f32|bf16|f16
 						//alt:f64  o0 = archsimd.BroadcastFloat64x4(0.0)
 					}
 
 					o0 = l0.MulAdd(r0, o0)
-					o0.Store((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-					//alt:f64  o0.Store((*[4]float64)(unsafe.Pointer(outBase)))
+					o0.StoreArray((*[8]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+					//alt:f64  o0.StoreArray((*[4]float64)(unsafe.Pointer(outBase)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -460,56 +460,56 @@ func avx2SmallFloat16Transposed( //alt:f16
 				//alt:f64  const vecWidth = 4
 
 				for ; k+4*vecWidth <= contractingSize; k += 4 * vecWidth {
-					//alt:f32 l0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 l0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  l0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
 					l0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  l0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  l0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
 					r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					acc = l0.MulAdd(r0, acc)
 
-					//alt:f32 l1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 l1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  l1, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
 					l1, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  l1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
-					//alt:f32 r1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64  l1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 r1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  r1, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
 					r1, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  r1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64  r1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					acc = l1.MulAdd(r1, acc)
 
-					//alt:f32 l2 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 l2 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  l2, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
 					l2, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  l2 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
-					//alt:f32 r2 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64  l2 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 r2 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  r2, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
 					r2, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  r2 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64  r2 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					acc = l2.MulAdd(r2, acc)
 
-					//alt:f32 l3 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 l3 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  l3, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
 					l3, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  l3 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
-					//alt:f32 r3 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64  l3 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 r3 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  r3, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
 					r3, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  r3 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64  r3 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					acc = l3.MulAdd(r3, acc)
 				}
 
 				for ; k+vecWidth <= contractingSize; k += vecWidth {
-					//alt:f32 lVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 lVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  lVal, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
 					lVal, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  lVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					//alt:f32 rVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  lVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 rVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  rVal, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
 					rVal, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32() //alt:f16
-					//alt:f64  rVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  rVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					acc = lVal.MulAdd(rVal, acc)
 				}
 

--- a/internal/gobackend/dot/matmul/gen_avx2_small_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_small_f64.go
@@ -174,12 +174,12 @@ func avx2SmallFloat64( //alt:f64
 
 				col := 0
 				for ; col+2*outputVecWidth <= rhsCrossSize; col += 2 * outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-					//alt:f32 r1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 					//alt:bf16  r0, r1 := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					//alt:f16  r0, r1 := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))                //alt:f64
-					r1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize))) //alt:f64
+					r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))                //alt:f64
+					r1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize))) //alt:f64
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
 					outBase1 := outputBase + uintptr((row+1)*rhsCrossSize+col)*oSize
@@ -190,22 +190,22 @@ func avx2SmallFloat64( //alt:f64
 					var o0_0, o0_1, o1_0, o1_1, o2_0, o2_1, o3_0, o3_1 archsimd.Float64x4 //alt:f64
 
 					if k > 0 {
-						//alt:f32|bf16|f16 o0_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0)))
-						//alt:f32|bf16|f16 o0_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-						//alt:f32|bf16|f16 o1_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1)))
-						//alt:f32|bf16|f16 o1_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-						//alt:f32|bf16|f16 o2_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2)))
-						//alt:f32|bf16|f16 o2_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-						//alt:f32|bf16|f16 o3_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3)))
-						//alt:f32|bf16|f16 o3_1 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
-						o0_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0)))                                 //alt:f64
-						o0_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f64
-						o1_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1)))                                 //alt:f64
-						o1_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f64
-						o2_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2)))                                 //alt:f64
-						o2_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f64
-						o3_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3)))                                 //alt:f64
-						o3_1 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f64
+						//alt:f32|bf16|f16 o0_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0)))
+						//alt:f32|bf16|f16 o0_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+						//alt:f32|bf16|f16 o1_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1)))
+						//alt:f32|bf16|f16 o1_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+						//alt:f32|bf16|f16 o2_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2)))
+						//alt:f32|bf16|f16 o2_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+						//alt:f32|bf16|f16 o3_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3)))
+						//alt:f32|bf16|f16 o3_1 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+						o0_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0)))                                 //alt:f64
+						o0_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f64
+						o1_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1)))                                 //alt:f64
+						o1_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f64
+						o2_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2)))                                 //alt:f64
+						o2_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f64
+						o3_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3)))                                 //alt:f64
+						o3_1 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f64
 					} else {
 						//alt:f32|bf16|f16 zero := archsimd.BroadcastFloat32x8(0.0)
 						zero := archsimd.BroadcastFloat64x4(0.0) //alt:f64
@@ -224,29 +224,29 @@ func avx2SmallFloat64( //alt:f64
 					o3_0 = l3.MulAdd(r0, o3_0)
 					o3_1 = l3.MulAdd(r1, o3_1)
 
-					//alt:f32|bf16|f16 o0_0.Store((*[8]float32)(unsafe.Pointer(outBase0)))
-					//alt:f32|bf16|f16 o0_1.Store((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-					//alt:f32|bf16|f16 o1_0.Store((*[8]float32)(unsafe.Pointer(outBase1)))
-					//alt:f32|bf16|f16 o1_1.Store((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-					//alt:f32|bf16|f16 o2_0.Store((*[8]float32)(unsafe.Pointer(outBase2)))
-					//alt:f32|bf16|f16 o2_1.Store((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-					//alt:f32|bf16|f16 o3_0.Store((*[8]float32)(unsafe.Pointer(outBase3)))
-					//alt:f32|bf16|f16 o3_1.Store((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
-					o0_0.Store((*[4]float64)(unsafe.Pointer(outBase0)))                                 //alt:f64
-					o0_1.Store((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f64
-					o1_0.Store((*[4]float64)(unsafe.Pointer(outBase1)))                                 //alt:f64
-					o1_1.Store((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f64
-					o2_0.Store((*[4]float64)(unsafe.Pointer(outBase2)))                                 //alt:f64
-					o2_1.Store((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f64
-					o3_0.Store((*[4]float64)(unsafe.Pointer(outBase3)))                                 //alt:f64
-					o3_1.Store((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f64
+					//alt:f32|bf16|f16 o0_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase0)))
+					//alt:f32|bf16|f16 o0_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+					//alt:f32|bf16|f16 o1_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase1)))
+					//alt:f32|bf16|f16 o1_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+					//alt:f32|bf16|f16 o2_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase2)))
+					//alt:f32|bf16|f16 o2_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+					//alt:f32|bf16|f16 o3_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase3)))
+					//alt:f32|bf16|f16 o3_1.StoreArray((*[8]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+					o0_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase0)))                                 //alt:f64
+					o0_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f64
+					o1_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase1)))                                 //alt:f64
+					o1_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f64
+					o2_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase2)))                                 //alt:f64
+					o2_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f64
+					o3_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase3)))                                 //alt:f64
+					o3_1.StoreArray((*[4]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f64
 				}
 
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					//alt:bf16  r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					//alt:f16  r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f64
+					r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f64
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
 					outBase1 := outputBase + uintptr((row+1)*rhsCrossSize+col)*oSize
@@ -257,14 +257,14 @@ func avx2SmallFloat64( //alt:f64
 					var o0_0, o1_0, o2_0, o3_0 archsimd.Float64x4 //alt:f64
 
 					if k > 0 {
-						//alt:f32|bf16|f16 o0_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase0)))
-						//alt:f32|bf16|f16 o1_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase1)))
-						//alt:f32|bf16|f16 o2_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase2)))
-						//alt:f32|bf16|f16 o3_0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase3)))
-						o0_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase0))) //alt:f64
-						o1_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase1))) //alt:f64
-						o2_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase2))) //alt:f64
-						o3_0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase3))) //alt:f64
+						//alt:f32|bf16|f16 o0_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase0)))
+						//alt:f32|bf16|f16 o1_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase1)))
+						//alt:f32|bf16|f16 o2_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase2)))
+						//alt:f32|bf16|f16 o3_0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase3)))
+						o0_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase0))) //alt:f64
+						o1_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase1))) //alt:f64
+						o2_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase2))) //alt:f64
+						o3_0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase3))) //alt:f64
 					} else {
 						//alt:f32|bf16|f16 zero := archsimd.BroadcastFloat32x8(0.0)
 						zero := archsimd.BroadcastFloat64x4(0.0) //alt:f64
@@ -276,14 +276,14 @@ func avx2SmallFloat64( //alt:f64
 					o2_0 = l2.MulAdd(r0, o2_0)
 					o3_0 = l3.MulAdd(r0, o3_0)
 
-					//alt:f32|bf16|f16 o0_0.Store((*[8]float32)(unsafe.Pointer(outBase0)))
-					//alt:f32|bf16|f16 o1_0.Store((*[8]float32)(unsafe.Pointer(outBase1)))
-					//alt:f32|bf16|f16 o2_0.Store((*[8]float32)(unsafe.Pointer(outBase2)))
-					//alt:f32|bf16|f16 o3_0.Store((*[8]float32)(unsafe.Pointer(outBase3)))
-					o0_0.Store((*[4]float64)(unsafe.Pointer(outBase0))) //alt:f64
-					o1_0.Store((*[4]float64)(unsafe.Pointer(outBase1))) //alt:f64
-					o2_0.Store((*[4]float64)(unsafe.Pointer(outBase2))) //alt:f64
-					o3_0.Store((*[4]float64)(unsafe.Pointer(outBase3))) //alt:f64
+					//alt:f32|bf16|f16 o0_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase0)))
+					//alt:f32|bf16|f16 o1_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase1)))
+					//alt:f32|bf16|f16 o2_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase2)))
+					//alt:f32|bf16|f16 o3_0.StoreArray((*[8]float32)(unsafe.Pointer(outBase3)))
+					o0_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase0))) //alt:f64
+					o1_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase1))) //alt:f64
+					o2_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase2))) //alt:f64
+					o3_0.StoreArray((*[4]float64)(unsafe.Pointer(outBase3))) //alt:f64
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -351,26 +351,26 @@ func avx2SmallFloat64( //alt:f64
 
 				col := 0
 				for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					//alt:bf16  r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
 					//alt:f16  r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))).ToFloat32()
-					r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f64
+					r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f64
 
 					outBase := outputBase + uintptr(row*rhsCrossSize+col)*oSize
 					//alt:f32|bf16|f16 var o0 archsimd.Float32x8
 					var o0 archsimd.Float64x4 //alt:f64
 
 					if k > 0 {
-						//alt:f32|bf16|f16 o0 = archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(outBase)))
-						o0 = archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(outBase))) //alt:f64
+						//alt:f32|bf16|f16 o0 = archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(outBase)))
+						o0 = archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(outBase))) //alt:f64
 					} else {
 						//alt:f32|bf16|f16 o0 = archsimd.BroadcastFloat32x8(0.0)
 						o0 = archsimd.BroadcastFloat64x4(0.0) //alt:f64
 					}
 
 					o0 = l0.MulAdd(r0, o0)
-					//alt:f32|bf16|f16 o0.Store((*[8]float32)(unsafe.Pointer(outBase)))
-					o0.Store((*[4]float64)(unsafe.Pointer(outBase))) //alt:f64
+					//alt:f32|bf16|f16 o0.StoreArray((*[8]float32)(unsafe.Pointer(outBase)))
+					o0.StoreArray((*[4]float64)(unsafe.Pointer(outBase))) //alt:f64
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -460,56 +460,56 @@ func avx2SmallFloat64Transposed( //alt:f64
 				const vecWidth = 4 //alt:f64
 
 				for ; k+4*vecWidth <= contractingSize; k += 4 * vecWidth {
-					//alt:f32 l0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 l0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  l0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
 					//alt:f16  l0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
-					l0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f64
-					//alt:f32 r0 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					l0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f64
+					//alt:f32 r0 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  r0, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
 					//alt:f16  r0, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
-					r0 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f64
+					r0 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f64
 					acc = l0.MulAdd(r0, acc)
 
-					//alt:f32 l1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 l1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  l1, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
 					//alt:f16  l1, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
-					l1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f64
-					//alt:f32 r1 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					l1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f64
+					//alt:f32 r1 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  r1, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
 					//alt:f16  r1, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))).ToFloat32()
-					r1 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f64
+					r1 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f64
 					acc = l1.MulAdd(r1, acc)
 
-					//alt:f32 l2 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 l2 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  l2, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
 					//alt:f16  l2, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
-					l2 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f64
-					//alt:f32 r2 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					l2 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f64
+					//alt:f32 r2 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  r2, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
 					//alt:f16  r2, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))).ToFloat32()
-					r2 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f64
+					r2 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f64
 					acc = l2.MulAdd(r2, acc)
 
-					//alt:f32 l3 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 l3 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  l3, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
 					//alt:f16  l3, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
-					l3 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f64
-					//alt:f32 r3 := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					l3 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f64
+					//alt:f32 r3 := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  r3, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
 					//alt:f16  r3, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))).ToFloat32()
-					r3 := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f64
+					r3 := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f64
 					acc = l3.MulAdd(r3, acc)
 				}
 
 				for ; k+vecWidth <= contractingSize; k += vecWidth {
-					//alt:f32 lVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 lVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  lVal, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
 					//alt:f16  lVal, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))).ToFloat32()
-					lVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f64
-					//alt:f32 rVal := archsimd.LoadFloat32x8((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					lVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f64
+					//alt:f32 rVal := archsimd.LoadFloat32x8Array((*[8]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  rVal, _ := bfloat16.LoadBFloat16x16((*[16]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
 					//alt:f16  rVal, _ := float16.LoadFloat16x16((*[16]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))).ToFloat32()
-					rVal := archsimd.LoadFloat64x4((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f64
+					rVal := archsimd.LoadFloat64x4Array((*[4]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f64
 					acc = lVal.MulAdd(rVal, acc)
 				}
 

--- a/internal/gobackend/dot/matmul/gen_avx512_large_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_bf16.go
@@ -347,10 +347,10 @@ func avx512LargeKernelBFloat16( //alt:bf16
 				// Load RHS (Broadcasting/Streaming)
 				rhsPtr0 := unsafe.Pointer(rhsRowPtr + rOffset)
 				//alt:f32|f64 rhsPtr1 := unsafe.Pointer(rhsRowPtr + rOffset + rhsRegisterStride)
-				//alt:f32 rhsVec0 := archsimd.LoadFloat32x16((*[16]float32)(rhsPtr0))
-				//alt:f64  rhsVec0 := archsimd.LoadFloat64x8((*[8]float64)(rhsPtr0))
-				//alt:f32 rhsVec1 := archsimd.LoadFloat32x16((*[16]float32)(rhsPtr1))
-				//alt:f64  rhsVec1 := archsimd.LoadFloat64x8((*[8]float64)(rhsPtr1))
+				//alt:f32 rhsVec0 := archsimd.LoadFloat32x16Array((*[16]float32)(rhsPtr0))
+				//alt:f64  rhsVec0 := archsimd.LoadFloat64x8Array((*[8]float64)(rhsPtr0))
+				//alt:f32 rhsVec1 := archsimd.LoadFloat32x16Array((*[16]float32)(rhsPtr1))
+				//alt:f64  rhsVec1 := archsimd.LoadFloat64x8Array((*[8]float64)(rhsPtr1))
 				rhsBF16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(rhsPtr0)) //alt:bf16
 				rhsVec0, rhsVec1 := rhsBF16.ToFloat32()                                //alt:bf16
 				//alt:f16  rhsF16 := float16.LoadFloat16x32((*[32]float16.Float16)(rhsPtr0))
@@ -409,22 +409,22 @@ func avx512LargeKernelBFloat16( //alt:bf16
 			outputIdx3 := outputIdx0 + uintptr(3*rhsPanelCols*bytesPerOutputElement)
 			registerStride := uintptr(outputNumLanes * bytesPerOutputElement) // It should be 64 bytes (512 bits) for AVX512.
 
-			accum_lhs0_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs0_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
-			accum_lhs0_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs0_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
-			accum_lhs1_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs1_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
-			accum_lhs1_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs1_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
-			accum_lhs2_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs2_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
-			accum_lhs2_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs2_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
-			accum_lhs3_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs3_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
-			accum_lhs3_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs3_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
+			accum_lhs0_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs0_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
+			accum_lhs0_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs0_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
+			accum_lhs1_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs1_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
+			accum_lhs1_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs1_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
+			accum_lhs2_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs2_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
+			accum_lhs2_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs2_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
+			accum_lhs3_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs3_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
+			accum_lhs3_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs3_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
 		}
 	}
 }

--- a/internal/gobackend/dot/matmul/gen_avx512_large_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_f16.go
@@ -347,10 +347,10 @@ func avx512LargeKernelFloat16( //alt:f16
 				// Load RHS (Broadcasting/Streaming)
 				rhsPtr0 := unsafe.Pointer(rhsRowPtr + rOffset)
 				//alt:f32|f64 rhsPtr1 := unsafe.Pointer(rhsRowPtr + rOffset + rhsRegisterStride)
-				//alt:f32 rhsVec0 := archsimd.LoadFloat32x16((*[16]float32)(rhsPtr0))
-				//alt:f64  rhsVec0 := archsimd.LoadFloat64x8((*[8]float64)(rhsPtr0))
-				//alt:f32 rhsVec1 := archsimd.LoadFloat32x16((*[16]float32)(rhsPtr1))
-				//alt:f64  rhsVec1 := archsimd.LoadFloat64x8((*[8]float64)(rhsPtr1))
+				//alt:f32 rhsVec0 := archsimd.LoadFloat32x16Array((*[16]float32)(rhsPtr0))
+				//alt:f64  rhsVec0 := archsimd.LoadFloat64x8Array((*[8]float64)(rhsPtr0))
+				//alt:f32 rhsVec1 := archsimd.LoadFloat32x16Array((*[16]float32)(rhsPtr1))
+				//alt:f64  rhsVec1 := archsimd.LoadFloat64x8Array((*[8]float64)(rhsPtr1))
 				//alt:bf16  rhsBF16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(rhsPtr0))
 				//alt:bf16  rhsVec0, rhsVec1 := rhsBF16.ToFloat32()
 				rhsF16 := float16.LoadFloat16x32((*[32]float16.Float16)(rhsPtr0)) //alt:f16
@@ -409,22 +409,22 @@ func avx512LargeKernelFloat16( //alt:f16
 			outputIdx3 := outputIdx0 + uintptr(3*rhsPanelCols*bytesPerOutputElement)
 			registerStride := uintptr(outputNumLanes * bytesPerOutputElement) // It should be 64 bytes (512 bits) for AVX512.
 
-			accum_lhs0_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs0_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
-			accum_lhs0_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs0_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
-			accum_lhs1_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs1_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
-			accum_lhs1_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs1_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
-			accum_lhs2_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs2_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
-			accum_lhs2_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs2_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
-			accum_lhs3_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs3_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
-			accum_lhs3_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
-			//alt:f64  accum_lhs3_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
+			accum_lhs0_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs0_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0)))
+			accum_lhs0_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs0_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
+			accum_lhs1_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs1_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1)))
+			accum_lhs1_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs1_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
+			accum_lhs2_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs2_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2)))
+			accum_lhs2_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs2_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
+			accum_lhs3_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs3_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3)))
+			accum_lhs3_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f32|bf16|f16
+			//alt:f64  accum_lhs3_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
 		}
 	}
 }

--- a/internal/gobackend/dot/matmul/gen_avx512_large_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_f64.go
@@ -347,10 +347,10 @@ func avx512LargeKernelFloat64( //alt:f64
 				// Load RHS (Broadcasting/Streaming)
 				rhsPtr0 := unsafe.Pointer(rhsRowPtr + rOffset)
 				rhsPtr1 := unsafe.Pointer(rhsRowPtr + rOffset + rhsRegisterStride) //alt:f32|f64
-				//alt:f32 rhsVec0 := archsimd.LoadFloat32x16((*[16]float32)(rhsPtr0))
-				rhsVec0 := archsimd.LoadFloat64x8((*[8]float64)(rhsPtr0)) //alt:f64
-				//alt:f32 rhsVec1 := archsimd.LoadFloat32x16((*[16]float32)(rhsPtr1))
-				rhsVec1 := archsimd.LoadFloat64x8((*[8]float64)(rhsPtr1)) //alt:f64
+				//alt:f32 rhsVec0 := archsimd.LoadFloat32x16Array((*[16]float32)(rhsPtr0))
+				rhsVec0 := archsimd.LoadFloat64x8Array((*[8]float64)(rhsPtr0)) //alt:f64
+				//alt:f32 rhsVec1 := archsimd.LoadFloat32x16Array((*[16]float32)(rhsPtr1))
+				rhsVec1 := archsimd.LoadFloat64x8Array((*[8]float64)(rhsPtr1)) //alt:f64
 				//alt:bf16  rhsBF16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(rhsPtr0))
 				//alt:bf16  rhsVec0, rhsVec1 := rhsBF16.ToFloat32()
 				//alt:f16  rhsF16 := float16.LoadFloat16x32((*[32]float16.Float16)(rhsPtr0))
@@ -409,22 +409,22 @@ func avx512LargeKernelFloat64( //alt:f64
 			outputIdx3 := outputIdx0 + uintptr(3*rhsPanelCols*bytesPerOutputElement)
 			registerStride := uintptr(outputNumLanes * bytesPerOutputElement) // It should be 64 bytes (512 bits) for AVX512.
 
-			//alt:f32|bf16|f16 accum_lhs0_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0)))
-			accum_lhs0_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs0_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
-			accum_lhs0_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs1_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1)))
-			accum_lhs1_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs1_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
-			accum_lhs1_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs2_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2)))
-			accum_lhs2_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs2_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
-			accum_lhs2_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs3_rhs0.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3)))
-			accum_lhs3_rhs0.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f64
-			//alt:f32|bf16|f16 accum_lhs3_rhs1.Store((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
-			accum_lhs3_rhs1.Store((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs0_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0)))
+			accum_lhs0_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs0_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride)))
+			accum_lhs0_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx0 + registerStride))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs1_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1)))
+			accum_lhs1_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs1_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride)))
+			accum_lhs1_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx1 + registerStride))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs2_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2)))
+			accum_lhs2_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs2_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride)))
+			accum_lhs2_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx2 + registerStride))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs3_rhs0.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3)))
+			accum_lhs3_rhs0.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3))) //alt:f64
+			//alt:f32|bf16|f16 accum_lhs3_rhs1.StoreArray((*[16]float32)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride)))
+			accum_lhs3_rhs1.StoreArray((*[8]float64)(unsafe.Pointer(outputBasePtr + outputIdx3 + registerStride))) //alt:f64
 		}
 	}
 }

--- a/internal/gobackend/dot/matmul/gen_avx512_small_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_small_bf16.go
@@ -186,14 +186,14 @@ func avx512SmallBFloat16( //alt:bf16
 					var r0, r1 archsimd.Float32x16 //alt:f32|bf16|f16
 					//alt:f64  var r0, r1 archsimd.Float64x8
 					{ //alt:f32|bf16|f16|f64
-						//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-						//alt:f32 r1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+						//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f32 r1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 						r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:bf16
 						r0, r1 = r0_bf16.ToFloat32()                                                                                 //alt:bf16
 						//alt:f16  r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:f16  r0, r1 = r0_f16.ToFloat32()
-						//alt:f64  r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-						//alt:f64  r1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+						//alt:f64  r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f64  r1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 					} //alt:f32|bf16|f16|f64
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
@@ -205,22 +205,22 @@ func avx512SmallBFloat16( //alt:bf16
 					//alt:f64  var o0_0, o0_1, o1_0, o1_1, o2_0, o2_1, o3_0, o3_1 archsimd.Float64x8
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-						o0_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-						o1_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-						o2_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-						o3_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						//alt:f64  o0_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64  o0_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o1_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64  o1_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o2_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64  o2_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o3_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3)))
-						//alt:f64  o3_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+						o0_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+						o0_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+						o1_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+						o2_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+						o3_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						//alt:f64  o0_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64  o0_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o1_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64  o1_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o2_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64  o2_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o3_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3)))
+						//alt:f64  o3_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 					} else {
 						zero := archsimd.BroadcastFloat32x16(0.0) //alt:f32|bf16|f16
 						//alt:f64  zero := archsimd.BroadcastFloat64x8(0.0)
@@ -239,22 +239,22 @@ func avx512SmallBFloat16( //alt:bf16
 					o3_0 = l3.MulAdd(r0, o3_0) //alt:f32|bf16|f16|f64
 					o3_1 = l3.MulAdd(r1, o3_1) //alt:f32|bf16|f16|f64
 
-					o0_0.Store((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-					o0_1.Store((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o1_0.Store((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-					o1_1.Store((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o2_0.Store((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-					o2_1.Store((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o3_0.Store((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-					o3_1.Store((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					//alt:f64  o0_0.Store((*[8]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64  o0_1.Store((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o1_0.Store((*[8]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64  o1_1.Store((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o2_0.Store((*[8]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64  o2_1.Store((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o3_0.Store((*[8]float64)(unsafe.Pointer(outBase3)))
-					//alt:f64  o3_1.Store((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+					o0_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+					o0_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+					o1_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+					o2_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+					o3_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					//alt:f64  o0_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64  o0_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o1_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64  o1_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o2_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64  o2_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o3_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase3)))
+					//alt:f64  o3_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 				}
 
 				//alt:f32 for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
@@ -262,8 +262,8 @@ func avx512SmallBFloat16( //alt:bf16
 				//alt:f32 var r0 archsimd.Float32x16
 				//alt:f64  var r0 archsimd.Float64x8
 				//alt:f32|f64 {
-				//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-				//alt:f64  r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+				//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+				//alt:f64  r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 				//alt:f32|f64 }
 
 				//alt:f32|f64 outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
@@ -275,14 +275,14 @@ func avx512SmallBFloat16( //alt:bf16
 				//alt:f64  var o0_0, o1_0, o2_0, o3_0 archsimd.Float64x8
 
 				//alt:f32|f64 if k > 0 {
-				//alt:f32 o0_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0)))
-				//alt:f32 o1_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1)))
-				//alt:f32 o2_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2)))
-				//alt:f32 o3_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3)))
-				//alt:f64  o0_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0)))
-				//alt:f64  o1_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1)))
-				//alt:f64  o2_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2)))
-				//alt:f64  o3_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3)))
+				//alt:f32 o0_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0)))
+				//alt:f32 o1_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1)))
+				//alt:f32 o2_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2)))
+				//alt:f32 o3_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3)))
+				//alt:f64  o0_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0)))
+				//alt:f64  o1_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1)))
+				//alt:f64  o2_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2)))
+				//alt:f64  o3_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3)))
 				//alt:f32|f64 } else {
 				//alt:f32 zero := archsimd.BroadcastFloat32x16(0.0)
 				//alt:f64  zero := archsimd.BroadcastFloat64x8(0.0)
@@ -297,14 +297,14 @@ func avx512SmallBFloat16( //alt:bf16
 				//alt:f32|f64 o2_0 = l2.MulAdd(r0, o2_0)
 				//alt:f32|f64 o3_0 = l3.MulAdd(r0, o3_0)
 
-				//alt:f32 o0_0.Store((*[16]float32)(unsafe.Pointer(outBase0)))
-				//alt:f32 o1_0.Store((*[16]float32)(unsafe.Pointer(outBase1)))
-				//alt:f32 o2_0.Store((*[16]float32)(unsafe.Pointer(outBase2)))
-				//alt:f32 o3_0.Store((*[16]float32)(unsafe.Pointer(outBase3)))
-				//alt:f64  o0_0.Store((*[8]float64)(unsafe.Pointer(outBase0)))
-				//alt:f64  o1_0.Store((*[8]float64)(unsafe.Pointer(outBase1)))
-				//alt:f64  o2_0.Store((*[8]float64)(unsafe.Pointer(outBase2)))
-				//alt:f64  o3_0.Store((*[8]float64)(unsafe.Pointer(outBase3)))
+				//alt:f32 o0_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase0)))
+				//alt:f32 o1_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase1)))
+				//alt:f32 o2_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase2)))
+				//alt:f32 o3_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase3)))
+				//alt:f64  o0_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase0)))
+				//alt:f64  o1_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase1)))
+				//alt:f64  o2_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase2)))
+				//alt:f64  o3_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase3)))
 				//alt:f32|f64 }
 
 				for ; col < rhsCrossSize; col++ {
@@ -384,12 +384,12 @@ func avx512SmallBFloat16( //alt:bf16
 					var r1 archsimd.Float32x16 //alt:bf16
 					//alt:f16  var r1 archsimd.Float32x16
 					{ //alt:f32|bf16|f16|f64
-						//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:bf16
 						r0, r1 = r0_bf16.ToFloat32()                                                                                 //alt:bf16
 						//alt:f16  r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:f16  r0, r1 = r0_f16.ToFloat32()
-						//alt:f64  r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f64  r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					} //alt:f32|bf16|f16|f64
 
 					outBase := outputBase + uintptr(row*rhsCrossSize+col)*oSize
@@ -399,10 +399,10 @@ func avx512SmallBFloat16( //alt:bf16
 					//alt:f16  var o1 archsimd.Float32x16
 
 					if k > 0 {
-						o0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-						//alt:f64  o0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase)))
-						o1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize))) //alt:bf16
-						//alt:f16  o1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+						o0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+						//alt:f64  o0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase)))
+						o1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize))) //alt:bf16
+						//alt:f16  o1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
 					} else {
 						o0 = archsimd.BroadcastFloat32x16(0.0) //alt:f32|bf16|f16
 						//alt:f64  o0 = archsimd.BroadcastFloat64x8(0.0)
@@ -414,10 +414,10 @@ func avx512SmallBFloat16( //alt:bf16
 					o1 = l0.MulAdd(r1, o1) //alt:bf16
 					//alt:f16  o1 = l0.MulAdd(r1, o1)
 
-					o0.Store((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-					//alt:f64  o0.Store((*[8]float64)(unsafe.Pointer(outBase)))
-					o1.Store((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize))) //alt:bf16
-					//alt:f16  o1.Store((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+					o0.StoreArray((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+					//alt:f64  o0.StoreArray((*[8]float64)(unsafe.Pointer(outBase)))
+					o1.StoreArray((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize))) //alt:bf16
+					//alt:f16  o1.StoreArray((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -513,20 +513,20 @@ func avx512SmallBFloat16Transposed( //alt:bf16
 				// Unroll by 4 registers on the contracting size
 				for ; k+4*vecWidth <= contractingSize; k += 4 * vecWidth {
 					// Load LHS (contiguous)
-					//alt:f32 l0 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 l0 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					l0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:bf16
 					l0a, l0b := l0_bf16.ToFloat32()                                                                            //alt:bf16
 					//alt:f16  l0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:f16  l0a, l0b := l0_f16.ToFloat32()
-					//alt:f64  l0 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f64  l0 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 
 					// Load RHS (contiguous for Transposed)
-					//alt:f32 r0 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:bf16
 					r0a, r0b := r0_bf16.ToFloat32()                                                                            //alt:bf16
 					//alt:f16  r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:f16  r0a, r0b := r0_f16.ToFloat32()
-					//alt:f64  r0 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 
 					//alt:f32|f64 acc = l0.MulAdd(r0, acc)
 					acc = l0a.MulAdd(r0a, acc) //alt:bf16
@@ -534,54 +534,54 @@ func avx512SmallBFloat16Transposed( //alt:bf16
 					//alt:f16  acc = l0a.MulAdd(r0a, acc)
 					//alt:f16  acc = l0b.MulAdd(r0b, acc)
 
-					//alt:f32 l1 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 l1 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					l1_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:bf16
 					l1a, l1b := l1_bf16.ToFloat32()                                                                                     //alt:bf16
 					//alt:f16  l1_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:f16  l1a, l1b := l1_f16.ToFloat32()
-					//alt:f64  l1 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
-					//alt:f32 r1 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64  l1 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 r1 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					r1_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:bf16
 					r1a, r1b := r1_bf16.ToFloat32()                                                                                     //alt:bf16
 					//alt:f16  r1_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:f16  r1a, r1b := r1_f16.ToFloat32()
-					//alt:f64  r1 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64  r1 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:f32|f64 acc = l1.MulAdd(r1, acc)
 					acc = l1a.MulAdd(r1a, acc) //alt:bf16
 					acc = l1b.MulAdd(r1b, acc) //alt:bf16
 					//alt:f16  acc = l1a.MulAdd(r1a, acc)
 					//alt:f16  acc = l1b.MulAdd(r1b, acc)
 
-					//alt:f32 l2 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 l2 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					l2_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:bf16
 					l2a, l2b := l2_bf16.ToFloat32()                                                                                       //alt:bf16
 					//alt:f16  l2_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:f16  l2a, l2b := l2_f16.ToFloat32()
-					//alt:f64  l2 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
-					//alt:f32 r2 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64  l2 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 r2 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					r2_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:bf16
 					r2a, r2b := r2_bf16.ToFloat32()                                                                                       //alt:bf16
 					//alt:f16  r2_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:f16  r2a, r2b := r2_f16.ToFloat32()
-					//alt:f64  r2 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64  r2 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:f32|f64 acc = l2.MulAdd(r2, acc)
 					acc = l2a.MulAdd(r2a, acc) //alt:bf16
 					acc = l2b.MulAdd(r2b, acc) //alt:bf16
 					//alt:f16  acc = l2a.MulAdd(r2a, acc)
 					//alt:f16  acc = l2b.MulAdd(r2b, acc)
 
-					//alt:f32 l3 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 l3 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					l3_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:bf16
 					l3a, l3b := l3_bf16.ToFloat32()                                                                                       //alt:bf16
 					//alt:f16  l3_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:f16  l3a, l3b := l3_f16.ToFloat32()
-					//alt:f64  l3 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
-					//alt:f32 r3 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64  l3 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 r3 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					r3_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:bf16
 					r3a, r3b := r3_bf16.ToFloat32()                                                                                       //alt:bf16
 					//alt:f16  r3_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:f16  r3a, r3b := r3_f16.ToFloat32()
-					//alt:f64  r3 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64  r3 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:f32|f64 acc = l3.MulAdd(r3, acc)
 					acc = l3a.MulAdd(r3a, acc) //alt:bf16
 					acc = l3b.MulAdd(r3b, acc) //alt:bf16
@@ -591,18 +591,18 @@ func avx512SmallBFloat16Transposed( //alt:bf16
 
 				// Remaining full vectors
 				for ; k+vecWidth <= contractingSize; k += vecWidth {
-					//alt:f32 lVal := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 lVal := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					l_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:bf16
 					la, lb := l_bf16.ToFloat32()                                                                              //alt:bf16
 					//alt:f16  l_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:f16  la, lb := l_f16.ToFloat32()
-					//alt:f64  lVal := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					//alt:f32 rVal := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  lVal := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 rVal := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					r_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:bf16
 					ra, rb := r_bf16.ToFloat32()                                                                              //alt:bf16
 					//alt:f16  r_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:f16  ra, rb := r_f16.ToFloat32()
-					//alt:f64  rVal := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  rVal := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:f32|f64 acc = lVal.MulAdd(rVal, acc)
 					acc = la.MulAdd(ra, acc) //alt:bf16
 					acc = lb.MulAdd(rb, acc) //alt:bf16

--- a/internal/gobackend/dot/matmul/gen_avx512_small_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_small_f16.go
@@ -186,14 +186,14 @@ func avx512SmallFloat16( //alt:f16
 					var r0, r1 archsimd.Float32x16 //alt:f32|bf16|f16
 					//alt:f64  var r0, r1 archsimd.Float64x8
 					{ //alt:f32|bf16|f16|f64
-						//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-						//alt:f32 r1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+						//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f32 r1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 						//alt:bf16  r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:bf16  r0, r1 = r0_bf16.ToFloat32()
 						r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f16
 						r0, r1 = r0_f16.ToFloat32()                                                                             //alt:f16
-						//alt:f64  r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-						//alt:f64  r1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+						//alt:f64  r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f64  r1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 					} //alt:f32|bf16|f16|f64
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
@@ -205,22 +205,22 @@ func avx512SmallFloat16( //alt:f16
 					//alt:f64  var o0_0, o0_1, o1_0, o1_1, o2_0, o2_1, o3_0, o3_1 archsimd.Float64x8
 
 					if k > 0 {
-						o0_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-						o0_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o1_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-						o1_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o2_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-						o2_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						o3_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-						o3_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-						//alt:f64  o0_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0)))
-						//alt:f64  o0_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o1_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1)))
-						//alt:f64  o1_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o2_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2)))
-						//alt:f64  o2_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-						//alt:f64  o3_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3)))
-						//alt:f64  o3_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+						o0_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+						o0_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o1_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+						o1_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o2_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+						o2_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						o3_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+						o3_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+						//alt:f64  o0_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0)))
+						//alt:f64  o0_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o1_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1)))
+						//alt:f64  o1_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o2_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2)))
+						//alt:f64  o2_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+						//alt:f64  o3_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3)))
+						//alt:f64  o3_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 					} else {
 						zero := archsimd.BroadcastFloat32x16(0.0) //alt:f32|bf16|f16
 						//alt:f64  zero := archsimd.BroadcastFloat64x8(0.0)
@@ -239,22 +239,22 @@ func avx512SmallFloat16( //alt:f16
 					o3_0 = l3.MulAdd(r0, o3_0) //alt:f32|bf16|f16|f64
 					o3_1 = l3.MulAdd(r1, o3_1) //alt:f32|bf16|f16|f64
 
-					o0_0.Store((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
-					o0_1.Store((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o1_0.Store((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
-					o1_1.Store((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o2_0.Store((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
-					o2_1.Store((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					o3_0.Store((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
-					o3_1.Store((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
-					//alt:f64  o0_0.Store((*[8]float64)(unsafe.Pointer(outBase0)))
-					//alt:f64  o0_1.Store((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o1_0.Store((*[8]float64)(unsafe.Pointer(outBase1)))
-					//alt:f64  o1_1.Store((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o2_0.Store((*[8]float64)(unsafe.Pointer(outBase2)))
-					//alt:f64  o2_1.Store((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-					//alt:f64  o3_0.Store((*[8]float64)(unsafe.Pointer(outBase3)))
-					//alt:f64  o3_1.Store((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+					o0_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase0)))                                 //alt:f32|bf16|f16
+					o0_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o1_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase1)))                                 //alt:f32|bf16|f16
+					o1_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o2_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase2)))                                 //alt:f32|bf16|f16
+					o2_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					o3_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase3)))                                 //alt:f32|bf16|f16
+					o3_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f32|bf16|f16
+					//alt:f64  o0_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase0)))
+					//alt:f64  o0_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o1_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase1)))
+					//alt:f64  o1_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o2_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase2)))
+					//alt:f64  o2_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+					//alt:f64  o3_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase3)))
+					//alt:f64  o3_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
 				}
 
 				//alt:f32 for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
@@ -262,8 +262,8 @@ func avx512SmallFloat16( //alt:f16
 				//alt:f32 var r0 archsimd.Float32x16
 				//alt:f64  var r0 archsimd.Float64x8
 				//alt:f32|f64 {
-				//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-				//alt:f64  r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+				//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+				//alt:f64  r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 				//alt:f32|f64 }
 
 				//alt:f32|f64 outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
@@ -275,14 +275,14 @@ func avx512SmallFloat16( //alt:f16
 				//alt:f64  var o0_0, o1_0, o2_0, o3_0 archsimd.Float64x8
 
 				//alt:f32|f64 if k > 0 {
-				//alt:f32 o0_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0)))
-				//alt:f32 o1_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1)))
-				//alt:f32 o2_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2)))
-				//alt:f32 o3_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3)))
-				//alt:f64  o0_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0)))
-				//alt:f64  o1_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1)))
-				//alt:f64  o2_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2)))
-				//alt:f64  o3_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3)))
+				//alt:f32 o0_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0)))
+				//alt:f32 o1_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1)))
+				//alt:f32 o2_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2)))
+				//alt:f32 o3_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3)))
+				//alt:f64  o0_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0)))
+				//alt:f64  o1_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1)))
+				//alt:f64  o2_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2)))
+				//alt:f64  o3_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3)))
 				//alt:f32|f64 } else {
 				//alt:f32 zero := archsimd.BroadcastFloat32x16(0.0)
 				//alt:f64  zero := archsimd.BroadcastFloat64x8(0.0)
@@ -297,14 +297,14 @@ func avx512SmallFloat16( //alt:f16
 				//alt:f32|f64 o2_0 = l2.MulAdd(r0, o2_0)
 				//alt:f32|f64 o3_0 = l3.MulAdd(r0, o3_0)
 
-				//alt:f32 o0_0.Store((*[16]float32)(unsafe.Pointer(outBase0)))
-				//alt:f32 o1_0.Store((*[16]float32)(unsafe.Pointer(outBase1)))
-				//alt:f32 o2_0.Store((*[16]float32)(unsafe.Pointer(outBase2)))
-				//alt:f32 o3_0.Store((*[16]float32)(unsafe.Pointer(outBase3)))
-				//alt:f64  o0_0.Store((*[8]float64)(unsafe.Pointer(outBase0)))
-				//alt:f64  o1_0.Store((*[8]float64)(unsafe.Pointer(outBase1)))
-				//alt:f64  o2_0.Store((*[8]float64)(unsafe.Pointer(outBase2)))
-				//alt:f64  o3_0.Store((*[8]float64)(unsafe.Pointer(outBase3)))
+				//alt:f32 o0_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase0)))
+				//alt:f32 o1_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase1)))
+				//alt:f32 o2_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase2)))
+				//alt:f32 o3_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase3)))
+				//alt:f64  o0_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase0)))
+				//alt:f64  o1_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase1)))
+				//alt:f64  o2_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase2)))
+				//alt:f64  o3_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase3)))
 				//alt:f32|f64 }
 
 				for ; col < rhsCrossSize; col++ {
@@ -384,12 +384,12 @@ func avx512SmallFloat16( //alt:f16
 					//alt:bf16  var r1 archsimd.Float32x16
 					var r1 archsimd.Float32x16 //alt:f16
 					{                          //alt:f32|bf16|f16|f64
-						//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:bf16  r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:bf16  r0, r1 = r0_bf16.ToFloat32()
 						r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f16
 						r0, r1 = r0_f16.ToFloat32()                                                                             //alt:f16
-						//alt:f64  r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f64  r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 					} //alt:f32|bf16|f16|f64
 
 					outBase := outputBase + uintptr(row*rhsCrossSize+col)*oSize
@@ -399,10 +399,10 @@ func avx512SmallFloat16( //alt:f16
 					var o1 archsimd.Float32x16 //alt:f16
 
 					if k > 0 {
-						o0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-						//alt:f64  o0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase)))
-						//alt:bf16  o1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
-						o1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize))) //alt:f16
+						o0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+						//alt:f64  o0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase)))
+						//alt:bf16  o1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+						o1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize))) //alt:f16
 					} else {
 						o0 = archsimd.BroadcastFloat32x16(0.0) //alt:f32|bf16|f16
 						//alt:f64  o0 = archsimd.BroadcastFloat64x8(0.0)
@@ -414,10 +414,10 @@ func avx512SmallFloat16( //alt:f16
 					//alt:bf16  o1 = l0.MulAdd(r1, o1)
 					o1 = l0.MulAdd(r1, o1) //alt:f16
 
-					o0.Store((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
-					//alt:f64  o0.Store((*[8]float64)(unsafe.Pointer(outBase)))
-					//alt:bf16  o1.Store((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
-					o1.Store((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize))) //alt:f16
+					o0.StoreArray((*[16]float32)(unsafe.Pointer(outBase))) //alt:f32|bf16|f16
+					//alt:f64  o0.StoreArray((*[8]float64)(unsafe.Pointer(outBase)))
+					//alt:bf16  o1.StoreArray((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+					o1.StoreArray((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize))) //alt:f16
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -513,20 +513,20 @@ func avx512SmallFloat16Transposed( //alt:f16
 				// Unroll by 4 registers on the contracting size
 				for ; k+4*vecWidth <= contractingSize; k += 4 * vecWidth {
 					// Load LHS (contiguous)
-					//alt:f32 l0 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 l0 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  l0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  l0a, l0b := l0_bf16.ToFloat32()
 					l0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f16
 					l0a, l0b := l0_f16.ToFloat32()                                                                        //alt:f16
-					//alt:f64  l0 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f64  l0 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 
 					// Load RHS (contiguous for Transposed)
-					//alt:f32 r0 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  r0a, r0b := r0_bf16.ToFloat32()
 					r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f16
 					r0a, r0b := r0_f16.ToFloat32()                                                                        //alt:f16
-					//alt:f64  r0 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  r0 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 
 					//alt:f32|f64 acc = l0.MulAdd(r0, acc)
 					//alt:bf16  acc = l0a.MulAdd(r0a, acc)
@@ -534,54 +534,54 @@ func avx512SmallFloat16Transposed( //alt:f16
 					acc = l0a.MulAdd(r0a, acc) //alt:f16
 					acc = l0b.MulAdd(r0b, acc) //alt:f16
 
-					//alt:f32 l1 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 l1 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  l1_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  l1a, l1b := l1_bf16.ToFloat32()
 					l1_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f16
 					l1a, l1b := l1_f16.ToFloat32()                                                                                 //alt:f16
-					//alt:f64  l1 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
-					//alt:f32 r1 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64  l1 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 r1 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  r1_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  r1a, r1b := r1_bf16.ToFloat32()
 					r1_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f16
 					r1a, r1b := r1_f16.ToFloat32()                                                                                 //alt:f16
-					//alt:f64  r1 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f64  r1 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:f32|f64 acc = l1.MulAdd(r1, acc)
 					//alt:bf16  acc = l1a.MulAdd(r1a, acc)
 					//alt:bf16  acc = l1b.MulAdd(r1b, acc)
 					acc = l1a.MulAdd(r1a, acc) //alt:f16
 					acc = l1b.MulAdd(r1b, acc) //alt:f16
 
-					//alt:f32 l2 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 l2 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  l2_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  l2a, l2b := l2_bf16.ToFloat32()
 					l2_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f16
 					l2a, l2b := l2_f16.ToFloat32()                                                                                   //alt:f16
-					//alt:f64  l2 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
-					//alt:f32 r2 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64  l2 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 r2 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  r2_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  r2a, r2b := r2_bf16.ToFloat32()
 					r2_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f16
 					r2a, r2b := r2_f16.ToFloat32()                                                                                   //alt:f16
-					//alt:f64  r2 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f64  r2 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:f32|f64 acc = l2.MulAdd(r2, acc)
 					//alt:bf16  acc = l2a.MulAdd(r2a, acc)
 					//alt:bf16  acc = l2b.MulAdd(r2b, acc)
 					acc = l2a.MulAdd(r2a, acc) //alt:f16
 					acc = l2b.MulAdd(r2b, acc) //alt:f16
 
-					//alt:f32 l3 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 l3 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  l3_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  l3a, l3b := l3_bf16.ToFloat32()
 					l3_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f16
 					l3a, l3b := l3_f16.ToFloat32()                                                                                   //alt:f16
-					//alt:f64  l3 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
-					//alt:f32 r3 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64  l3 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 r3 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  r3_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  r3a, r3b := r3_bf16.ToFloat32()
 					r3_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f16
 					r3a, r3b := r3_f16.ToFloat32()                                                                                   //alt:f16
-					//alt:f64  r3 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f64  r3 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:f32|f64 acc = l3.MulAdd(r3, acc)
 					//alt:bf16  acc = l3a.MulAdd(r3a, acc)
 					//alt:bf16  acc = l3b.MulAdd(r3b, acc)
@@ -591,18 +591,18 @@ func avx512SmallFloat16Transposed( //alt:f16
 
 				// Remaining full vectors
 				for ; k+vecWidth <= contractingSize; k += vecWidth {
-					//alt:f32 lVal := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 lVal := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  l_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  la, lb := l_bf16.ToFloat32()
 					l_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f16
 					la, lb := l_f16.ToFloat32()                                                                          //alt:f16
-					//alt:f64  lVal := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
-					//alt:f32 rVal := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  lVal := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 rVal := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  r_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  ra, rb := r_bf16.ToFloat32()
 					r_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f16
 					ra, rb := r_f16.ToFloat32()                                                                          //alt:f16
-					//alt:f64  rVal := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f64  rVal := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:f32|f64 acc = lVal.MulAdd(rVal, acc)
 					//alt:bf16  acc = la.MulAdd(ra, acc)
 					//alt:bf16  acc = lb.MulAdd(rb, acc)

--- a/internal/gobackend/dot/matmul/gen_avx512_small_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_small_f64.go
@@ -186,14 +186,14 @@ func avx512SmallFloat64( //alt:f64
 					//alt:f32|bf16|f16 var r0, r1 archsimd.Float32x16
 					var r0, r1 archsimd.Float64x8 //alt:f64
 					{                             //alt:f32|bf16|f16|f64
-						//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-						//alt:f32 r1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
+						//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f32 r1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize)))
 						//alt:bf16  r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:bf16  r0, r1 = r0_bf16.ToFloat32()
 						//alt:f16  r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:f16  r0, r1 = r0_f16.ToFloat32()
-						r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))                //alt:f64
-						r1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize))) //alt:f64
+						r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))                //alt:f64
+						r1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col+outputVecWidth)*iSize))) //alt:f64
 					} //alt:f32|bf16|f16|f64
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize
@@ -205,22 +205,22 @@ func avx512SmallFloat64( //alt:f64
 					var o0_0, o0_1, o1_0, o1_1, o2_0, o2_1, o3_0, o3_1 archsimd.Float64x8 //alt:f64
 
 					if k > 0 {
-						//alt:f32|bf16|f16 o0_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0)))
-						//alt:f32|bf16|f16 o0_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-						//alt:f32|bf16|f16 o1_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1)))
-						//alt:f32|bf16|f16 o1_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-						//alt:f32|bf16|f16 o2_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2)))
-						//alt:f32|bf16|f16 o2_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-						//alt:f32|bf16|f16 o3_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3)))
-						//alt:f32|bf16|f16 o3_1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
-						o0_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0)))                                 //alt:f64
-						o0_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f64
-						o1_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1)))                                 //alt:f64
-						o1_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f64
-						o2_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2)))                                 //alt:f64
-						o2_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f64
-						o3_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3)))                                 //alt:f64
-						o3_1 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f64
+						//alt:f32|bf16|f16 o0_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0)))
+						//alt:f32|bf16|f16 o0_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+						//alt:f32|bf16|f16 o1_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1)))
+						//alt:f32|bf16|f16 o1_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+						//alt:f32|bf16|f16 o2_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2)))
+						//alt:f32|bf16|f16 o2_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+						//alt:f32|bf16|f16 o3_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3)))
+						//alt:f32|bf16|f16 o3_1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+						o0_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0)))                                 //alt:f64
+						o0_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f64
+						o1_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1)))                                 //alt:f64
+						o1_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f64
+						o2_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2)))                                 //alt:f64
+						o2_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f64
+						o3_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3)))                                 //alt:f64
+						o3_1 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f64
 					} else {
 						//alt:f32|bf16|f16 zero := archsimd.BroadcastFloat32x16(0.0)
 						zero := archsimd.BroadcastFloat64x8(0.0) //alt:f64
@@ -239,22 +239,22 @@ func avx512SmallFloat64( //alt:f64
 					o3_0 = l3.MulAdd(r0, o3_0) //alt:f32|bf16|f16|f64
 					o3_1 = l3.MulAdd(r1, o3_1) //alt:f32|bf16|f16|f64
 
-					//alt:f32|bf16|f16 o0_0.Store((*[16]float32)(unsafe.Pointer(outBase0)))
-					//alt:f32|bf16|f16 o0_1.Store((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
-					//alt:f32|bf16|f16 o1_0.Store((*[16]float32)(unsafe.Pointer(outBase1)))
-					//alt:f32|bf16|f16 o1_1.Store((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
-					//alt:f32|bf16|f16 o2_0.Store((*[16]float32)(unsafe.Pointer(outBase2)))
-					//alt:f32|bf16|f16 o2_1.Store((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
-					//alt:f32|bf16|f16 o3_0.Store((*[16]float32)(unsafe.Pointer(outBase3)))
-					//alt:f32|bf16|f16 o3_1.Store((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
-					o0_0.Store((*[8]float64)(unsafe.Pointer(outBase0)))                                 //alt:f64
-					o0_1.Store((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f64
-					o1_0.Store((*[8]float64)(unsafe.Pointer(outBase1)))                                 //alt:f64
-					o1_1.Store((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f64
-					o2_0.Store((*[8]float64)(unsafe.Pointer(outBase2)))                                 //alt:f64
-					o2_1.Store((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f64
-					o3_0.Store((*[8]float64)(unsafe.Pointer(outBase3)))                                 //alt:f64
-					o3_1.Store((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f64
+					//alt:f32|bf16|f16 o0_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase0)))
+					//alt:f32|bf16|f16 o0_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize)))
+					//alt:f32|bf16|f16 o1_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase1)))
+					//alt:f32|bf16|f16 o1_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize)))
+					//alt:f32|bf16|f16 o2_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase2)))
+					//alt:f32|bf16|f16 o2_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize)))
+					//alt:f32|bf16|f16 o3_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase3)))
+					//alt:f32|bf16|f16 o3_1.StoreArray((*[16]float32)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize)))
+					o0_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase0)))                                 //alt:f64
+					o0_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase0 + uintptr(outputVecWidth)*oSize))) //alt:f64
+					o1_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase1)))                                 //alt:f64
+					o1_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase1 + uintptr(outputVecWidth)*oSize))) //alt:f64
+					o2_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase2)))                                 //alt:f64
+					o2_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase2 + uintptr(outputVecWidth)*oSize))) //alt:f64
+					o3_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase3)))                                 //alt:f64
+					o3_1.StoreArray((*[8]float64)(unsafe.Pointer(outBase3 + uintptr(outputVecWidth)*oSize))) //alt:f64
 				}
 
 				//alt:f32 for ; col+outputVecWidth <= rhsCrossSize; col += outputVecWidth {
@@ -262,8 +262,8 @@ func avx512SmallFloat64( //alt:f64
 					//alt:f32 var r0 archsimd.Float32x16
 					var r0 archsimd.Float64x8 //alt:f64
 					{                         //alt:f32|f64
-						//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
-						r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f64
+						//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f64
 					} //alt:f32|f64
 
 					outBase0 := outputBase + uintptr((row+0)*rhsCrossSize+col)*oSize //alt:f32|f64
@@ -275,14 +275,14 @@ func avx512SmallFloat64( //alt:f64
 					var o0_0, o1_0, o2_0, o3_0 archsimd.Float64x8 //alt:f64
 
 					if k > 0 { //alt:f32|f64
-						//alt:f32 o0_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase0)))
-						//alt:f32 o1_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase1)))
-						//alt:f32 o2_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase2)))
-						//alt:f32 o3_0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase3)))
-						o0_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase0))) //alt:f64
-						o1_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase1))) //alt:f64
-						o2_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase2))) //alt:f64
-						o3_0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase3))) //alt:f64
+						//alt:f32 o0_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase0)))
+						//alt:f32 o1_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase1)))
+						//alt:f32 o2_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase2)))
+						//alt:f32 o3_0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase3)))
+						o0_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase0))) //alt:f64
+						o1_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase1))) //alt:f64
+						o2_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase2))) //alt:f64
+						o3_0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase3))) //alt:f64
 					} else { //alt:f32|f64
 						//alt:f32 zero := archsimd.BroadcastFloat32x16(0.0)
 						zero := archsimd.BroadcastFloat64x8(0.0) //alt:f64
@@ -297,14 +297,14 @@ func avx512SmallFloat64( //alt:f64
 					o2_0 = l2.MulAdd(r0, o2_0) //alt:f32|f64
 					o3_0 = l3.MulAdd(r0, o3_0) //alt:f32|f64
 
-					//alt:f32 o0_0.Store((*[16]float32)(unsafe.Pointer(outBase0)))
-					//alt:f32 o1_0.Store((*[16]float32)(unsafe.Pointer(outBase1)))
-					//alt:f32 o2_0.Store((*[16]float32)(unsafe.Pointer(outBase2)))
-					//alt:f32 o3_0.Store((*[16]float32)(unsafe.Pointer(outBase3)))
-					o0_0.Store((*[8]float64)(unsafe.Pointer(outBase0))) //alt:f64
-					o1_0.Store((*[8]float64)(unsafe.Pointer(outBase1))) //alt:f64
-					o2_0.Store((*[8]float64)(unsafe.Pointer(outBase2))) //alt:f64
-					o3_0.Store((*[8]float64)(unsafe.Pointer(outBase3))) //alt:f64
+					//alt:f32 o0_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase0)))
+					//alt:f32 o1_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase1)))
+					//alt:f32 o2_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase2)))
+					//alt:f32 o3_0.StoreArray((*[16]float32)(unsafe.Pointer(outBase3)))
+					o0_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase0))) //alt:f64
+					o1_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase1))) //alt:f64
+					o2_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase2))) //alt:f64
+					o3_0.StoreArray((*[8]float64)(unsafe.Pointer(outBase3))) //alt:f64
 				} //alt:f32|f64
 
 				for ; col < rhsCrossSize; col++ {
@@ -384,12 +384,12 @@ func avx512SmallFloat64( //alt:f64
 					//alt:bf16  var r1 archsimd.Float32x16
 					//alt:f16  var r1 archsimd.Float32x16
 					{ //alt:f32|bf16|f16|f64
-						//alt:f32 r0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
+						//alt:f32 r0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:bf16  r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:bf16  r0, r1 = r0_bf16.ToFloat32()
 						//alt:f16  r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(col)*iSize)))
 						//alt:f16  r0, r1 = r0_f16.ToFloat32()
-						r0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f64
+						r0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(col)*iSize))) //alt:f64
 					} //alt:f32|bf16|f16|f64
 
 					outBase := outputBase + uintptr(row*rhsCrossSize+col)*oSize
@@ -399,10 +399,10 @@ func avx512SmallFloat64( //alt:f64
 					//alt:f16  var o1 archsimd.Float32x16
 
 					if k > 0 {
-						//alt:f32|bf16|f16 o0 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase)))
-						o0 = archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(outBase))) //alt:f64
-						//alt:bf16  o1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
-						//alt:f16  o1 = archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+						//alt:f32|bf16|f16 o0 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase)))
+						o0 = archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(outBase))) //alt:f64
+						//alt:bf16  o1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+						//alt:f16  o1 = archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
 					} else {
 						//alt:f32|bf16|f16 o0 = archsimd.BroadcastFloat32x16(0.0)
 						o0 = archsimd.BroadcastFloat64x8(0.0) //alt:f64
@@ -414,10 +414,10 @@ func avx512SmallFloat64( //alt:f64
 					//alt:bf16  o1 = l0.MulAdd(r1, o1)
 					//alt:f16  o1 = l0.MulAdd(r1, o1)
 
-					//alt:f32|bf16|f16 o0.Store((*[16]float32)(unsafe.Pointer(outBase)))
-					o0.Store((*[8]float64)(unsafe.Pointer(outBase))) //alt:f64
-					//alt:bf16  o1.Store((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
-					//alt:f16  o1.Store((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+					//alt:f32|bf16|f16 o0.StoreArray((*[16]float32)(unsafe.Pointer(outBase)))
+					o0.StoreArray((*[8]float64)(unsafe.Pointer(outBase))) //alt:f64
+					//alt:bf16  o1.StoreArray((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
+					//alt:f16  o1.StoreArray((*[16]float32)(unsafe.Pointer(outBase + uintptr(outputVecWidth)*oSize)))
 				}
 
 				for ; col < rhsCrossSize; col++ {
@@ -513,20 +513,20 @@ func avx512SmallFloat64Transposed( //alt:f64
 				// Unroll by 4 registers on the contracting size
 				for ; k+4*vecWidth <= contractingSize; k += 4 * vecWidth {
 					// Load LHS (contiguous)
-					//alt:f32 l0 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 l0 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  l0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  l0a, l0b := l0_bf16.ToFloat32()
 					//alt:f16  l0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:f16  l0a, l0b := l0_f16.ToFloat32()
-					l0 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f64
+					l0 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f64
 
 					// Load RHS (contiguous for Transposed)
-					//alt:f32 r0 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					//alt:f32 r0 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  r0_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  r0a, r0b := r0_bf16.ToFloat32()
 					//alt:f16  r0_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:f16  r0a, r0b := r0_f16.ToFloat32()
-					r0 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f64
+					r0 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f64
 
 					acc = l0.MulAdd(r0, acc) //alt:f32|f64
 					//alt:bf16  acc = l0a.MulAdd(r0a, acc)
@@ -534,55 +534,55 @@ func avx512SmallFloat64Transposed( //alt:f64
 					//alt:f16  acc = l0a.MulAdd(r0a, acc)
 					//alt:f16  acc = l0b.MulAdd(r0b, acc)
 
-					//alt:f32 l1 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
+					//alt:f32 l1 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  l1_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  l1a, l1b := l1_bf16.ToFloat32()
 					//alt:f16  l1_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize)))
 					//alt:f16  l1a, l1b := l1_f16.ToFloat32()
-					l1 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f64
-					//alt:f32 r1 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
+					l1 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+vecWidth)*iSize))) //alt:f64
+					//alt:f32 r1 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  r1_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:bf16  r1a, r1b := r1_bf16.ToFloat32()
 					//alt:f16  r1_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize)))
 					//alt:f16  r1a, r1b := r1_f16.ToFloat32()
-					r1 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f64
-					acc = l1.MulAdd(r1, acc)                                                                          //alt:f32|f64
+					r1 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+vecWidth)*iSize))) //alt:f64
+					acc = l1.MulAdd(r1, acc)                                                                               //alt:f32|f64
 					//alt:bf16  acc = l1a.MulAdd(r1a, acc)
 					//alt:bf16  acc = l1b.MulAdd(r1b, acc)
 					//alt:f16  acc = l1a.MulAdd(r1a, acc)
 					//alt:f16  acc = l1b.MulAdd(r1b, acc)
 
-					//alt:f32 l2 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
+					//alt:f32 l2 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  l2_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  l2a, l2b := l2_bf16.ToFloat32()
 					//alt:f16  l2_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:f16  l2a, l2b := l2_f16.ToFloat32()
-					l2 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f64
-					//alt:f32 r2 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
+					l2 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+2*vecWidth)*iSize))) //alt:f64
+					//alt:f32 r2 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  r2_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:bf16  r2a, r2b := r2_bf16.ToFloat32()
 					//alt:f16  r2_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize)))
 					//alt:f16  r2a, r2b := r2_f16.ToFloat32()
-					r2 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f64
-					acc = l2.MulAdd(r2, acc)                                                                            //alt:f32|f64
+					r2 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+2*vecWidth)*iSize))) //alt:f64
+					acc = l2.MulAdd(r2, acc)                                                                                 //alt:f32|f64
 					//alt:bf16  acc = l2a.MulAdd(r2a, acc)
 					//alt:bf16  acc = l2b.MulAdd(r2b, acc)
 					//alt:f16  acc = l2a.MulAdd(r2a, acc)
 					//alt:f16  acc = l2b.MulAdd(r2b, acc)
 
-					//alt:f32 l3 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
+					//alt:f32 l3 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  l3_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  l3a, l3b := l3_bf16.ToFloat32()
 					//alt:f16  l3_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:f16  l3a, l3b := l3_f16.ToFloat32()
-					l3 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f64
-					//alt:f32 r3 := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
+					l3 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k+3*vecWidth)*iSize))) //alt:f64
+					//alt:f32 r3 := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  r3_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:bf16  r3a, r3b := r3_bf16.ToFloat32()
 					//alt:f16  r3_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize)))
 					//alt:f16  r3a, r3b := r3_f16.ToFloat32()
-					r3 := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f64
-					acc = l3.MulAdd(r3, acc)                                                                            //alt:f32|f64
+					r3 := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k+3*vecWidth)*iSize))) //alt:f64
+					acc = l3.MulAdd(r3, acc)                                                                                 //alt:f32|f64
 					//alt:bf16  acc = l3a.MulAdd(r3a, acc)
 					//alt:bf16  acc = l3b.MulAdd(r3b, acc)
 					//alt:f16  acc = l3a.MulAdd(r3a, acc)
@@ -591,19 +591,19 @@ func avx512SmallFloat64Transposed( //alt:f64
 
 				// Remaining full vectors
 				for ; k+vecWidth <= contractingSize; k += vecWidth {
-					//alt:f32 lVal := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
+					//alt:f32 lVal := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  l_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:bf16  la, lb := l_bf16.ToFloat32()
 					//alt:f16  l_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(lRowBase + uintptr(k)*iSize)))
 					//alt:f16  la, lb := l_f16.ToFloat32()
-					lVal := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f64
-					//alt:f32 rVal := archsimd.LoadFloat32x16((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
+					lVal := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(lRowBase + uintptr(k)*iSize))) //alt:f64
+					//alt:f32 rVal := archsimd.LoadFloat32x16Array((*[16]float32)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  r_bf16 := bfloat16.LoadBFloat16x32((*[32]bfloat16.BFloat16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:bf16  ra, rb := r_bf16.ToFloat32()
 					//alt:f16  r_f16 := float16.LoadFloat16x32((*[32]float16.Float16)(unsafe.Pointer(rColBase + uintptr(k)*iSize)))
 					//alt:f16  ra, rb := r_f16.ToFloat32()
-					rVal := archsimd.LoadFloat64x8((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f64
-					acc = lVal.MulAdd(rVal, acc)                                                               //alt:f32|f64
+					rVal := archsimd.LoadFloat64x8Array((*[8]float64)(unsafe.Pointer(rColBase + uintptr(k)*iSize))) //alt:f64
+					acc = lVal.MulAdd(rVal, acc)                                                                    //alt:f32|f64
 					//alt:bf16  acc = la.MulAdd(ra, acc)
 					//alt:bf16  acc = lb.MulAdd(rb, acc)
 					//alt:f16  acc = la.MulAdd(ra, acc)


### PR DESCRIPTION
## Summary

This PR updates the experimental SIMD implementation in the `go` backend from Go 1.26 to the updated Go 1.27 `simd/archsimd` API.

### Key Changes:
- **Load/Store API Conventions**:
  - Adopted `archsimd.Load<Type>Array((*[N]T)(ptr))` and `vec.StoreArray((*[N]T)(ptr))` for fixed array pointer loads/stores in GEMM microkernels (zero slice overhead).
  - Adopted `archsimd.Load<Type>(slice)` and `vec.Store(slice)` where slice operations are used.
- **Pairwise & Permutation Operations**:
  - Migrated pairwise reduction methods to `ConcatAddPairs`, `ConcatSubPairs`, and `ConcatAddPairsGrouped` (renamed in Go 1.27).
  - Updated lane interleave and permutation functions (`InterleaveLoGrouped`, `ConcatPermute`) across AVX2 and AVX-512 transpose kernels.
- **Half-Precision Conversions**:
  - Updated AVX2 and AVX-512 vector conversions in `dtypes/bfloat16` and `dtypes/float16` to Go 1.27 conventions.
- **Code Generation**:
  - Regenerated all specialized AVX2 and AVX-512 kernel alternates (`gen_avx2_large_*.go`, `gen_avx2_small_*.go`, `gen_avx512_large_*.go`, `gen_avx512_small_*.go`).
- **Toolchain & Documentation**:
  - Updated `go.mod` to Go 1.27.
  - Updated documentation in `.agents/AGENTS.md` covering Go 1.27 SIMD API conventions.

### Testing & Verification:
- All unit tests in `internal/gobackend/dot/matmul` pass.
- Full `gobackend` compliance test suite passes cleanly with `GOEXPERIMENT=simd`.