### PR TITLE
Add AVX-512 assembly microkernels for large GEMM, benchmarks, and GitHub CI workflows

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -49,10 +49,10 @@ auto-differentiation, use GoMLX instead.
 - `support`: generic support libraries.
   - `support/testutil`: test utilities that can be used by any `compute.Backend`
     implementation to test. 
-  - `support/backendtest`: Backend compliance tests, that can be run against
-    any backend. Simply call `RunAll(t *testing.T, b compute.Backend)` from your
-    backend tests. These tests always check the capabilities of the backend, and
-    tests not implemented by the backend are skipped.
+  - `support/backendtest`: Backend compliance tests and standard benchmarks, that can be run
+    against any backend. Call `RunAll(t *testing.T, b compute.Backend)` from your backend tests,
+    and `RunAllBenchmarks(b *testing.B, backend compute.Backend)` from your backend benchmarks.
+    Tests/benchmarks check backend capabilities and gracefully skip features returning `ErrNotImplemented`.
 
 ## Coding Style In GoMLX projects, including this one.
 
@@ -91,12 +91,31 @@ Whenever printing an error, use `"%+v"` format so the full stack is printed.
 - Use `any` instead of `interface{}`.
 - Organize tests in hierarchies using `t.Run()` to group related tests.
 
-### Tests
+### Compliance Tests & Benchmarks
 
-- For backend tests that could be used for any backend, write them in `support/backendtest` so other
+- For backend tests and benchmarks that could be used for any backend, write them in `support/backendtest` so other
   backends can benefit.
 - We DONT depend on testify or other test libraries: we are trying to minimize external dependencies.
 - Use the locally defined `support/testutil` for test utilities for equality (or InDelta or InRelativeDelta comparisons of buffers, etc.).
+- **Standard Benchmarks**:
+  - `support/backendtest` also provides a standard benchmark suite (call `backendtest.RunAllBenchmarks(b *testing.B, backend compute.Backend)` in `support/backendtest/benchmarks.go`).
+  - Includes benchmarks for standard operations (`BenchmarkDotGeneral`, `BenchmarkDense`, `BenchmarkQuantizedDense`, `BenchmarkSoftmax`, `BenchmarkGelu`, `BenchmarkLayerNorm`).
+  - **How to run**: `support/backendtest` is backend-agnostic and does not instantiate a backend directly. Run benchmarks via a concrete backend package (e.g. `gobackend`), for example:
+    ```bash
+    # Run all benchmarks on the Go backend:
+    go test -bench=. -benchmem ./gobackend
+
+    # Run only DotGeneral benchmarks without running unit tests:
+    go test -run none -bench BenchmarkGoBackend/DotGeneral ./gobackend
+
+    # Run a specific sub-benchmark model (e.g. the "Large" matrix multiplications):
+    go test -run none -bench BenchmarkGoBackend/DotGeneral/Large ./gobackend
+    ```
+  - **Graceful Skips**: If an op, layout, or data type combination returns `compute.ErrNotImplemented`, compliance benchmarks skip cleanly via `b.Skipf(...)`.
+  - **Warm-up & Timer**: Benchmarks use Go's `for b.Loop()`. Warm-up iterations (3 runs) are executed *before* `for b.Loop()`, which allows `b.Loop()` to cleanly reset the benchmark timer on its first call and enables compiler loop-variable keep-alive optimizations.
+  - **Reported Metrics**: Benchmarks report standard `ns/op` as well as custom metrics via `b.ReportMetric`:
+    - `ms/op`: execution time per iteration in milliseconds across all benchmarked ops.
+    - `GFlops/s`: throughput for `DotGeneral` operations (calculated as $2 \times \text{outputSize} \times \prod \text{contractingDims}$).
 
 ### Follow Existing Patterns
 

--- a/.github/workflows/darwin_tests.yaml
+++ b/.github/workflows/darwin_tests.yaml
@@ -1,0 +1,48 @@
+name: "Darwin/arm64"
+permissions:
+  # read|write|none
+  actions: read
+  checks: read
+  contents: read
+  deployments: read
+  # id-token: read    --> doesn't work
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+# Triggers the workflow on push or pull request events but only for the "main" branch
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  macos-tests:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.27.1"
+
+      - name: Test
+        run: |
+          go test ./...
+
+      - name: Test with SIMD
+        env:
+          GOEXPERIMENT: simd
+        run: |
+          go test ./...

--- a/.github/workflows/linux_amd64_tests.yaml
+++ b/.github/workflows/linux_amd64_tests.yaml
@@ -1,0 +1,46 @@
+name: "Linux/amd64"
+permissions:
+  # read|write|none
+  actions: read
+  checks: read
+  contents: read
+  deployments: read
+  # id-token: read    --> doesn't work
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+# Triggers the workflow on push or pull request events but only for the "main" branch
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  linux-amd64-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.27.1"
+
+      - name: Test
+        run: |
+          go test ./...
+
+      - name: Test with SIMD
+        env:
+          GOEXPERIMENT: simd
+        run: |
+          go test ./...

--- a/.github/workflows/linux_arm64_tests.yaml
+++ b/.github/workflows/linux_arm64_tests.yaml
@@ -1,0 +1,46 @@
+name: "Linux/arm64"
+permissions:
+  # read|write|none
+  actions: read
+  checks: read
+  contents: read
+  deployments: read
+  # id-token: read    --> doesn't work
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+# Triggers the workflow on push or pull request events but only for the "main" branch
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  linux-arm64-tests:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.27.1"
+
+      - name: Test
+        run: |
+          go test ./...
+
+      - name: Test with SIMD
+        env:
+          GOEXPERIMENT: simd
+        run: |
+          go test ./...

--- a/.github/workflows/windows_amd64_tests.yaml
+++ b/.github/workflows/windows_amd64_tests.yaml
@@ -1,0 +1,50 @@
+name: "Windows/amd64"
+permissions:
+  # read|write|none
+  actions: read
+  checks: read
+  contents: read
+  deployments: read
+  # id-token: read    --> doesn't work
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+# Triggers the workflow on push or pull request events but only for the "main" branch
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  windows-amd64-tests:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.27.1"
+
+      - name: Test
+        run: |
+          go test ./...
+
+      - name: Test with SIMD
+        env:
+          GOEXPERIMENT: simd
+        run: |
+          go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 [![Documentation](https://img.shields.io/badge/docs-gomlx.github.io-blue.svg)](https://gomlx.github.io/)
 [![Sponsor GoMLX](https://img.shields.io/badge/Sponsor-GoMLX-white?logo=github&style=flat-square)](https://github.com/gomlx/gomlx/blob/main/README.md#-support-the-project)
+<br/>
+[![Linux/amd64 Tests](https://github.com/gomlx/compute/actions/workflows/linux_amd64_tests.yaml/badge.svg)](https://github.com/gomlx/compute/actions/workflows/linux_amd64_tests.yaml)
+[![Linux/arm64 Tests](https://github.com/gomlx/compute/actions/workflows/linux_arm64_tests.yaml/badge.svg)](https://github.com/gomlx/compute/actions/workflows/linux_arm64_tests.yaml)
+[![Darwin/arm64 Tests](https://github.com/gomlx/compute/actions/workflows/darwin_tests.yaml/badge.svg)](https://github.com/gomlx/compute/actions/workflows/darwin_tests.yaml)
+[![Windows/amd64 Tests](https://github.com/gomlx/compute/actions/workflows/windows_amd64_tests.yaml/badge.svg)](https://github.com/gomlx/compute/actions/workflows/windows_amd64_tests.yaml)
 
 
 # Compute Backends API

--- a/README.md
+++ b/README.md
@@ -7,35 +7,49 @@
 [![Windows/amd64 Tests](https://github.com/gomlx/compute/actions/workflows/windows_amd64_tests.yaml/badge.svg)](https://github.com/gomlx/compute/actions/workflows/windows_amd64_tests.yaml)
 
 
-# Compute Backends API
+# Compute Backend APIs
 
 Package `compute` provides a modular API for defining and executing multidimensional computation graphs with pluggable backends.
 
 It defines `shapes` (tensor shapes) and `dtypes` (data types) and the top-level `compute` package defines a `Backend` API (a series of interfaces), that
 can be used to define a computation graph, JIT-compile it, transfer buffers (raw values) to/from the backend, and execute compiled computations.
 
-It powers [GoMLX](https://github.com/gomlx/gomlx), the machine learning framework for Go, but can be used directly also. With the caveat that the `compute.Backend` doesn't aim to be ergonomic, but instead "correct" and "minimal". For a more convenient API for complex computation, and auto-differentiation, use GoMLX instead.
+It powers [GoMLX](https://github.com/gomlx/gomlx), the machine learning framework for Go, but can be used directly also. With the caveat that the `compute.Backend` doesn't aim to be ergonomic, but instead "correct" and "minimal" (including minimal dependencies). 
+For a more convenient API for complex computation, and auto-differentiation, use GoMLX instead.
 
-## Available Backends
+## Available Backend Implementations
 
-The `compute.Backend` API is currently implemented by:
 
-- Package `gobackend`: a native Go implementation, hence very portable
-  (including it runs in WASM). It covers 80% of the API (some ops are still
-  missing). We are working on SIMD versions: AVX512 and AVX2 using
-  `simd/archsimd` for now, only for _matmul_ (with huge performance gains).
+### The Native **"go"** Backend
+
+This repo also include the package `gobackend` that implements the `compute.Backend` API using pure Go. 
+It is very portable but relatively slow (when compared with well supported backends like XLA and ONNX).
+
+It has some support for SIMD for AVX2 and AVX512 (_amd64_) when using `GOEXPERIMENT=simd`, and there are 
+plenty of "low-hanging fruit" to improve performance, for anyone interested in contributing.
+
+See below "Environment Varaiables" for more fine-control.
+
+### Other backends:
+
+The `compute.Backend` APIs is currently implemented by:
+
 - Package
-  [`compute/xla`](https://github.com/gomlx/go-xla/tree/main/compute/xla): an
+  [`github.com/gomlx/go-xla/compute/xla`](https://github.com/gomlx/go-xla/tree/main/compute/xla): an
   [XLA (PJRT)](https://openxla.org/) based implementation, the same used by Jax
   and TensorFlow. It uses CGO (it's a C++ library), but it supports GPUs and
   TPUs, as well as a fast CPU, proper JIT compilation. Limited to static shapes
-  though.
+  though. It includes an optional "auto-installer".
+- Package [`github.com/gomlx/compute-onnx`](https://github.com/gomlx/compute-onnx): a ONNX Runtime (ORT) based
+  based implementation. It converts a `compute.Backend` computation graph into a ONNX proto and executes it
+  using ORT. It includes an optional "auto-installer". Broader support for hardware, dyanmic shape support in
+  some platforms, accelerated web-assembly (using "onnx:webgpu") with some caveats.
 - The project [go-darwinml](https://github.com/gomlx/go-darwinml/) is an
   **experimental** support to Apple's CoreML, with accelerate for GPU (Metal)
-  and CPU (arm64).
+  and CPU (arm64). It's currently broken, and looking for collaborator -- or donations so I can acquire hardware
+  to support it.
 
 ## Using the `compute.Backend` interface
-
 
 ## Roadmap
 
@@ -49,9 +63,9 @@ The `compute.Backend` API is currently implemented by:
 We are exploring support (Backend implementations) for:
 
 * Integrate more SIMD using go-highway for the Go backend.
-* ONNX Runtime: dynamically generate an ONNX proto and use ORT to execute it;
+* [LiteRTX](https://github.com/google-ai-edge/litert): Add LiteRT based Backend implementation. Broad support for
+  edge hardware (as well as web assembly), and supposedly very efficient.
 * [llama.cpp](https://github.com/ggml-org/llama.cpp): using [github.com/hybridgroup/yzma](https://github.com/hybridgroup/yzma) a "pure-go" binding;
-* [WebNN](https://learn.microsoft.com/en-us/windows/ai/directml/webnn-overview) or WebGL.
 
 ## Implementing your own backend
 
@@ -86,9 +100,11 @@ some of the example models to benchmark your backend against some of the others.
     One can install PJRTs build for NVIDIA GPUs (there is an installation script for that), there is also one for ROCm (not tested by the author),
     for TPU (Google Cloud) and reports of PJRTs being built to even new accelerators (e.g.: [TensTorrent XLA](https://github.com/tenstorrent/tt-xla))
 - For the native Go backend:
-  - `GOMLX_SIMD_AVX512`: set to `0` or `false` to disable AVX512 SIMD implementation in the native Go backend. The default is enabled if AVX512 is present.
-  - `GOMLX_SIMD_AVX2`: set to `0` or `false` to disable AVX2 SIMD implementation in the native Go backend. The default is enabled if AVX2 is present.
-  - `GOMLX_FUSION`: if set to `0`, `false` to disable fused operations in the native Go backend. The default is enabled.
+  - `GOMLX_GO_SIMD_AVX512`: set to `0` or `false` to disable AVX512 SIMD implementation in the native Go backend. The default is enabled if AVX512 is present.
+  - `GOMLX_GO_SIMD_AVX2`: set to `0` or `false` to disable AVX2 SIMD implementation in the native Go backend. The default is enabled if AVX2 is present.
+  - `GOMLX_GO_AVX512_ASM`: set to `0` or `false` to disable the assembly microkernel for Float32 and use the Go SIMD kernel instead.
+  - `GOMLX_GO_AVX512_KC`, `GOMLX_GO_AVX512_MC`, `GOMLX_GO_AVX512_NC`: cache blocking tuning parameters for AVX512 matrix multiplication.
+  - `GOMLX_GO_FUSION`: if set to `0`, `false` to disable fused operations in the native Go backend. The default is enabled.
 - For the [XLA backend](https://github.com/gomlx/go-xla/tree/main/compute/xla)
   - `PJRT_PLUGIN_LIBRARY_PATH`: the underlying XLA backend uses this variable as an extra directory to search for plugin locations.
     It searches for the systems library paths (`$LD_LIBRARY_PATH`, `/etc/ld.so.conf`), the default `/usr/local/lib/gomlx/pjrt` and `$PJRT_PLUGIN_LIBRARY_PATH` if set.

--- a/README.md
+++ b/README.md
@@ -14,42 +14,83 @@ Package `compute` provides a modular API for defining and executing multidimensi
 It defines `shapes` (tensor shapes) and `dtypes` (data types) and the top-level `compute` package defines a `Backend` API (a series of interfaces), that
 can be used to define a computation graph, JIT-compile it, transfer buffers (raw values) to/from the backend, and execute compiled computations.
 
-It powers [GoMLX](https://github.com/gomlx/gomlx), the machine learning framework for Go, but can be used directly also. With the caveat that the `compute.Backend` doesn't aim to be ergonomic, but instead "correct" and "minimal" (including minimal dependencies). 
-For a more convenient API for complex computation, and auto-differentiation, use GoMLX instead.
+It powers [GoMLX](https://github.com/gomlx/gomlx), the machine learning framework for Go, but can be used directly also. With the caveat that `compute.Backend` doesn't aim to be ergonomic, but instead "correct" and "minimal" (including minimal dependencies). 
+For a more convenient API for complex computation and auto-differentiation, use GoMLX instead.
+
+The default `compute.New()` function creates a backend object using any registered implementation, or inspects the `GOMLX_BACKEND` environment variable to select a specific backend and optional configuration. For example, to use the Go backend, set `GOMLX_BACKEND=go` (or `GOMLX_BACKEND="go:parallelism=4"` to configure it). If `GOMLX_BACKEND` is not set, `compute.New()` falls back to `compute.DefaultConfig` or the first registered backend.
 
 ## Available Backend Implementations
 
-
 ### The Native **"go"** Backend
 
-This repo also include the package `gobackend` that implements the `compute.Backend` API using pure Go. 
-It is very portable but relatively slow (when compared with well supported backends like XLA and ONNX).
+This repository includes the package `gobackend` that implements the `compute.Backend` API using pure Go. 
+It is very portable but relatively slow (when compared with well-supported backends like XLA and ONNX).
 
-It has some support for SIMD for AVX2 and AVX512 (_amd64_) when using `GOEXPERIMENT=simd`, and there are 
-plenty of "low-hanging fruit" to improve performance, for anyone interested in contributing.
+It has support for SIMD on AVX2 and AVX-512 (*amd64*) when built with `GOEXPERIMENT=simd`, and there are 
+plenty of "low-hanging fruit" to improve performance for anyone interested in contributing.
 
-See below "Environment Varaiables" for more fine-control.
+#### Backend Configuration Options (`GOMLX_BACKEND=go:...`)
 
-### Other backends:
+When instantiating the Go backend (via `compute.New()` or `GOMLX_BACKEND`), options can be provided as a comma-separated list of `<option>` or `<option>=<value>`:
 
-The `compute.Backend` APIs is currently implemented by:
+- `parallelism=<N>`: sets the maximum worker pool concurrency (number of worker goroutines) used to parallelize operations. Defaults to the number of available CPU cores.
+- `ops_sequential`: forces graph operations to be executed sequentially.
+- `ops_parallel`: forces independent graph operations to be executed in parallel where possible. (By default, ops execute in parallel when only one computation is running, and sequentially otherwise).
+- `dependency_order`: schedules graph nodes based on dependency order.
+- `creation_order`: schedules graph nodes based on creation order.
+
+Example:
+```bash
+export GOMLX_BACKEND="go:parallelism=8,ops_parallel"
+```
+
+See the [Environment Variables](#environment-variables) section below for fine-grained control over SIMD features and optimizations.
+
+### Other Backends
+
+The `compute.Backend` API is currently implemented by:
 
 - Package
   [`github.com/gomlx/go-xla/compute/xla`](https://github.com/gomlx/go-xla/tree/main/compute/xla): an
-  [XLA (PJRT)](https://openxla.org/) based implementation, the same used by Jax
+  [XLA (PJRT)](https://openxla.org/) based implementation, the same engine used by JAX
   and TensorFlow. It uses CGO (it's a C++ library), but it supports GPUs and
   TPUs, as well as a fast CPU, proper JIT compilation. Limited to static shapes
-  though. It includes an optional "auto-installer".
-- Package [`github.com/gomlx/compute-onnx`](https://github.com/gomlx/compute-onnx): a ONNX Runtime (ORT) based
-  based implementation. It converts a `compute.Backend` computation graph into a ONNX proto and executes it
-  using ORT. It includes an optional "auto-installer". Broader support for hardware, dyanmic shape support in
-  some platforms, accelerated web-assembly (using "onnx:webgpu") with some caveats.
-- The project [go-darwinml](https://github.com/gomlx/go-darwinml/) is an
-  **experimental** support to Apple's CoreML, with accelerate for GPU (Metal)
-  and CPU (arm64). It's currently broken, and looking for collaborator -- or donations so I can acquire hardware
+  though. It includes an optional auto-installer.
+- Package [`github.com/gomlx/compute-onnx`](https://github.com/gomlx/compute-onnx): an
+  ONNX Runtime (ORT) based implementation. It converts a `compute.Backend` computation graph into an ONNX proto and executes it
+  using ORT. It includes an optional auto-installer. Offers broader support for hardware, dynamic shape support on
+  some platforms, and accelerated WebAssembly (using `"onnx:webgpu"`) with some caveats.
+- The project [go-darwinml](https://github.com/gomlx/go-darwinml/):
+  **experimental** support for Apple's CoreML, with acceleration for GPU (Metal)
+  and CPU (arm64). It is currently broken and looking for collaborators -- or donations to acquire hardware
   to support it.
 
 ## Using the `compute.Backend` interface
+
+To use a backend, import the desired backend package (which registers itself) and call `compute.New()`:
+
+```go
+package main
+
+import (
+	"log"
+
+	"github.com/gomlx/compute"
+	_ "github.com/gomlx/compute/gobackend" // Registers the "go" backend
+)
+
+func main() {
+	// Creates backend: uses $GOMLX_BACKEND if set, or the default registered backend.
+	backend, err := compute.New()
+	if err != nil {
+		log.Fatalf("Failed to initialize backend: %+v", err)
+	}
+	defer backend.Finalize()
+
+	// Use backend to build and execute computation graphs...
+	_ = backend
+}
+```
 
 ## Roadmap
 
@@ -63,22 +104,22 @@ The `compute.Backend` APIs is currently implemented by:
 We are exploring support (Backend implementations) for:
 
 * Integrate more SIMD using go-highway for the Go backend.
-* [LiteRTX](https://github.com/google-ai-edge/litert): Add LiteRT based Backend implementation. Broad support for
-  edge hardware (as well as web assembly), and supposedly very efficient.
-* [llama.cpp](https://github.com/ggml-org/llama.cpp): using [github.com/hybridgroup/yzma](https://github.com/hybridgroup/yzma) a "pure-go" binding;
+* [LiteRT](https://github.com/google-ai-edge/litert): Add LiteRT-based Backend implementation. Broad support for
+  edge hardware (as well as WebAssembly), and supposedly very efficient.
+* [llama.cpp](https://github.com/ggml-org/llama.cpp): using [github.com/hybridgroup/yzma](https://github.com/hybridgroup/yzma), a "pure-go" binding.
 
 ## Implementing your own backend
 
 It's conceptually simple:
 
-- Inherit from `notimplemented`, and return an empty capabilities.
+- Inherit from `notimplemented`, and return empty capabilities.
 - Implement the transferring of buffers to/from your backend.
 - Implement the operations that you need.
 - Make sure you pass the "compliance" tests in `support/backendtest`, by calling
   the function `backendtest.RunAll(t *testing.T, b compute.Backend)`, or running
   the individual tests. Example:
 
-```
+```go
 func TestCompliance(t *testing.T) {
 	backendtest.RunAll(t, myBackend)
 }
@@ -91,19 +132,21 @@ some of the example models to benchmark your backend against some of the others.
 
 ## Environment Variables
 
-- `GOMLX_BACKEND`: defines the backend engine to use (if using `backends.New()`). The value is formatted as "<backend_name>[:<backend_config>]",
+- `GOMLX_BACKEND`: defines the backend engine to use (if using `compute.New()`). The value is formatted as "<backend_name>[:<backend_config>]",
   with the config part being optional. Examples:
   - `GOMLX_BACKEND=go`: Use the "Go backend", the pure Go implementation that is very portable but slow.
-  - `GOMLX_BACKEND="xla:cpu"`: Use XLA (the faster backend, only runs on Linux now) for CPU
-  - `GOMLX_BACKEND="xla:cuda"`: Use XLA for for Nvidia CUDA
+  - `GOMLX_BACKEND="go:parallelism=4"`: Use the Go backend configured with at most 4 worker goroutines.
+  - `GOMLX_BACKEND="xla:cpu"`: Use XLA (the faster backend, only runs on Linux now) for CPU.
+  - `GOMLX_BACKEND="xla:cuda"`: Use XLA for Nvidia CUDA.
   - `GOMLX_BACKEND="xla:/path/to/my/pjrt_plugin.so"`: Use XLA with an arbitrary PJRT. PJRT is a plugin system for XLA to support different hardware.
-    One can install PJRTs build for NVIDIA GPUs (there is an installation script for that), there is also one for ROCm (not tested by the author),
-    for TPU (Google Cloud) and reports of PJRTs being built to even new accelerators (e.g.: [TensTorrent XLA](https://github.com/tenstorrent/tt-xla))
+    One can install PJRTs built for NVIDIA GPUs (there is an installation script for that), there is also one for ROCm (not tested by the author),
+    for TPU (Google Cloud) and reports of PJRTs being built for even newer accelerators (e.g.: [TensTorrent XLA](https://github.com/tenstorrent/tt-xla)).
 - For the native Go backend:
   - `GOMLX_GO_SIMD_AVX512`: set to `0` or `false` to disable AVX512 SIMD implementation in the native Go backend. The default is enabled if AVX512 is present.
   - `GOMLX_GO_SIMD_AVX2`: set to `0` or `false` to disable AVX2 SIMD implementation in the native Go backend. The default is enabled if AVX2 is present.
   - `GOMLX_GO_AVX512_ASM`: set to `0` or `false` to disable the assembly microkernel for Float32 and use the Go SIMD kernel instead.
   - `GOMLX_GO_AVX512_KC`, `GOMLX_GO_AVX512_MC`, `GOMLX_GO_AVX512_NC`: cache blocking tuning parameters for AVX512 matrix multiplication.
+  - `GOMLX_GO_DOT_MATMUL`: set to `0` or `false` to disable the default matrix multiplication implementation in the native Go backend. The default is enabled.
   - `GOMLX_GO_FUSION`: if set to `0`, `false` to disable fused operations in the native Go backend. The default is enabled.
 - For the [XLA backend](https://github.com/gomlx/go-xla/tree/main/compute/xla)
   - `PJRT_PLUGIN_LIBRARY_PATH`: the underlying XLA backend uses this variable as an extra directory to search for plugin locations.
@@ -114,10 +157,10 @@ some of the example models to benchmark your backend against some of the others.
 
 ## WebAssembly (WASM) Support
 
-The "go" backend is well supported in WASM environment.
+The "go" backend is well-supported in WebAssembly (WASM) environments.
 
 It passes all compliance tests:
 
-```go
-GOOS=js GOARCH=wasm go test  -exec wasmbrowsertest ./... -count=1 -v
+```bash
+GOOS=js GOARCH=wasm go test -exec wasmbrowsertest ./... -count=1 -v
 ```

--- a/gobackend/gobackend_test.go
+++ b/gobackend/gobackend_test.go
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// BenchmarkStandard runs all standard compute.Backend benchmarks on the given backend.
+// BenchmarkGoBackend runs all compliance (backendtest) compute.Backend benchmarks on the given backend.
 // To run:
 //
 //	$ go test -bench=. -benchmem

--- a/internal/gobackend/dot/dot.go
+++ b/internal/gobackend/dot/dot.go
@@ -15,10 +15,10 @@
 //
 // Environment variables that can be used to disable certain features:
 //
-//   - GOMLX_DOT_MATMUL: set to false to disable the default matmul implementation.
+//   - GOMLX_GO_DOT_MATMUL: set to false to disable the default matmul implementation.
 //     if you haven't added other plugin implementations, it will effectively disable DotGeneral.
-//   - GOMLX_SIMD_AVX512: set to false to disable the AVX512 implementation, even if the runtime architecture allows it.
-//   - GOMLX_SIMD_AVX2: set to false to disable the AVX2 implementation, even if the runtime architecture allows it.
+//   - GOMLX_GO_SIMD_AVX512: set to false to disable the AVX512 implementation, even if the runtime architecture allows it.
+//   - GOMLX_GO_SIMD_AVX2: set to false to disable the AVX2 implementation, even if the runtime architecture allows it.
 package dot
 
 import (

--- a/internal/gobackend/dot/matmul/avx2.go
+++ b/internal/gobackend/dot/matmul/avx2.go
@@ -51,7 +51,7 @@ func init() {
 		return
 	}
 
-	allowed := envutil.MustReadBool(envutil.SIMD_AVX2_Env, true)
+	allowed := envutil.MustReadBool(envutil.GoBackendSIMD_AVX2, true)
 	if allowed && archsimd.X86.AVX2() {
 		registerAVX2(false)
 	}

--- a/internal/gobackend/dot/matmul/avx2_large.go
+++ b/internal/gobackend/dot/matmul/avx2_large.go
@@ -5,7 +5,6 @@
 package matmul
 
 import (
-	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -226,6 +225,11 @@ func avx2LargeMatrixSliceFloat32( //alt:f32
 
 // avx2LargeKernelFloat32 implements a kernel of the matrix multiplication for
 // a lhs and rhs packed panels into an intermediate output panel.
+//
+// Memory safety note: We use raw unsafe pointers to avoid bounds-checking (BCE) overhead
+// in the inner loops. Because the caller (parent function on the stack) owns and holds references
+// to packedLHS, packedRHS, and packedOutput throughout execution, they remain reachable and
+// do not need runtime.KeepAlive() calls at the end.
 func avx2LargeKernelFloat32( //alt:f32
 	//alt:bf16 func avx2LargeKernelBFloat16(
 	//alt:f16 func avx2LargeKernelFloat16(
@@ -240,17 +244,7 @@ func avx2LargeKernelFloat32( //alt:f32
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
-	defer func() {
-		runtime.KeepAlive(packedLHS)
-		runtime.KeepAlive(packedRHS)
-		runtime.KeepAlive(packedOutput)
-	}()
 	_ = lhsPanelRows // Not needed.
-
-	// BCE hints
-	_ = packedLHS[contractingLen*lhsActiveRows-1]
-	_ = packedRHS[contractingLen*rhsActiveCols-1]
-	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These must match params.LHSL1KernelRows and params.RHSL1KernelCols.

--- a/internal/gobackend/dot/matmul/avx2_large.go
+++ b/internal/gobackend/dot/matmul/avx2_large.go
@@ -5,6 +5,7 @@
 package matmul
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -244,7 +245,17 @@ func avx2LargeKernelFloat32( //alt:f32
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
+	defer func() {
+		runtime.KeepAlive(packedLHS)
+		runtime.KeepAlive(packedRHS)
+		runtime.KeepAlive(packedOutput)
+	}()
 	_ = lhsPanelRows // Not needed.
+
+	// BCE hints
+	_ = packedLHS[contractingLen*lhsActiveRows-1]
+	_ = packedRHS[contractingLen*rhsActiveCols-1]
+	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These must match params.LHSL1KernelRows and params.RHSL1KernelCols.

--- a/internal/gobackend/dot/matmul/avx512.go
+++ b/internal/gobackend/dot/matmul/avx512.go
@@ -27,10 +27,14 @@ import (
 //go:generate go run ../../../cmd/alternates_generator -base=avx512_large.go -tags=bf16,f16,f64
 
 var (
+	// AVX512UseAsm enables the assembly microkernel for Float32 large matrices (4 rows x 64 cols).
+	// Set GOMLX_AVX512_ASM=false to disable and use the Go SIMD kernel (4 rows x 32 cols).
+	AVX512UseAsm = envutil.MustReadBool("GOMLX_AVX512_ASM", true)
+
 	// AVX512ParamsFloat32 are the parameters to use for Float32, tuned for the 16 registers implementations.
 	AVX512ParamsFloat32 = CacheParams{
 		LHSL1KernelRows:      4,   // Mr: Uses 4 ZMM registers for accumulation rows, this number must be a multiple of 4
-		RHSL1KernelCols:      32,  // Nr: Uses 2 ZMM registers for accumulation cols, each holds 16 values
+		RHSL1KernelCols:      32,  // Nr: 32 for Go SIMD, updated to 64 if AVX512UseAsm is true
 		PanelContractingSize: 128, // Kc: A strip fits in L1 cache
 		LHSPanelCrossSize:    24,  // Mc: Fits in L2 cache (multiple of LHSL1KernelRows), multiple of LHSL1KernelRows, but usually just LHSL1KernelRows.
 		RHSPanelCrossSize:    512, // Nc: Fits in L3 cache (multiple of RHSL1KernelCols), multiple of RHSL1KernelRows.
@@ -59,6 +63,9 @@ var (
 )
 
 func init() {
+	if AVX512UseAsm {
+		AVX512ParamsFloat32.RHSL1KernelCols = 64
+	}
 	if !envutil.MustReadBool(EnabledEnv, true) {
 		return
 	}

--- a/internal/gobackend/dot/matmul/avx512.go
+++ b/internal/gobackend/dot/matmul/avx512.go
@@ -35,8 +35,8 @@ var (
 	AVX512ParamsFloat32 = CacheParams{
 		LHSL1KernelRows:      4,   // Mr: Uses 4 ZMM registers for accumulation rows, this number must be a multiple of 4
 		RHSL1KernelCols:      32,  // Nr: 32 for Go SIMD, updated to 64 if AVX512UseAsm is true
-		PanelContractingSize: 128, // Kc: A strip fits in L1 cache
-		LHSPanelCrossSize:    24,  // Mc: Fits in L2 cache (multiple of LHSL1KernelRows), multiple of LHSL1KernelRows, but usually just LHSL1KernelRows.
+		PanelContractingSize: 192, // Kc: A strip fits in L1 cache
+		LHSPanelCrossSize:    32,  // Mc: Fits in L2 cache (multiple of LHSL1KernelRows), multiple of LHSL1KernelRows, but usually just LHSL1KernelRows.
 		RHSPanelCrossSize:    512, // Nc: Fits in L3 cache (multiple of RHSL1KernelCols), multiple of RHSL1KernelRows.
 	}
 
@@ -65,6 +65,15 @@ var (
 func init() {
 	if AVX512UseAsm {
 		AVX512ParamsFloat32.RHSL1KernelCols = 64
+	}
+	if kc := envutil.MustReadInt("GOMLX_AVX512_KC", 0); kc > 0 {
+		AVX512ParamsFloat32.PanelContractingSize = kc
+	}
+	if mc := envutil.MustReadInt("GOMLX_AVX512_MC", 0); mc > 0 {
+		AVX512ParamsFloat32.LHSPanelCrossSize = mc
+	}
+	if nc := envutil.MustReadInt("GOMLX_AVX512_NC", 0); nc > 0 {
+		AVX512ParamsFloat32.RHSPanelCrossSize = nc
 	}
 	if !envutil.MustReadBool(EnabledEnv, true) {
 		return

--- a/internal/gobackend/dot/matmul/avx512.go
+++ b/internal/gobackend/dot/matmul/avx512.go
@@ -65,6 +65,9 @@ var (
 func init() {
 	if AVX512UseAsm {
 		AVX512ParamsFloat32.RHSL1KernelCols = 64
+		AVX512ParamsFloat16.RHSL1KernelCols = 64
+		AVX512ParamsBFloat16.RHSL1KernelCols = 64
+		AVX512ParamsFloat64.RHSL1KernelCols = 32
 	}
 	if kc := envutil.MustReadInt("GOMLX_AVX512_KC", 0); kc > 0 {
 		AVX512ParamsFloat32.PanelContractingSize = kc

--- a/internal/gobackend/dot/matmul/avx512.go
+++ b/internal/gobackend/dot/matmul/avx512.go
@@ -28,8 +28,8 @@ import (
 
 var (
 	// AVX512UseAsm enables the assembly microkernel for Float32 large matrices (4 rows x 64 cols).
-	// Set GOMLX_AVX512_ASM=false to disable and use the Go SIMD kernel (4 rows x 32 cols).
-	AVX512UseAsm = envutil.MustReadBool("GOMLX_AVX512_ASM", true)
+	// Set GOMLX_GO_AVX512_ASM=false to disable and use the Go SIMD kernel (4 rows x 32 cols).
+	AVX512UseAsm = envutil.MustReadBool(envutil.GoBackendAVX512_ASM, true)
 
 	// AVX512ParamsFloat32 are the parameters to use for Float32, tuned for the 16 registers implementations.
 	AVX512ParamsFloat32 = CacheParams{
@@ -69,20 +69,20 @@ func init() {
 		AVX512ParamsBFloat16.RHSL1KernelCols = 64
 		AVX512ParamsFloat64.RHSL1KernelCols = 32
 	}
-	if kc := envutil.MustReadInt("GOMLX_AVX512_KC", 0); kc > 0 {
+	if kc := envutil.MustReadInt(envutil.GoBackendAVX512_KC, 0); kc > 0 {
 		AVX512ParamsFloat32.PanelContractingSize = kc
 	}
-	if mc := envutil.MustReadInt("GOMLX_AVX512_MC", 0); mc > 0 {
+	if mc := envutil.MustReadInt(envutil.GoBackendAVX512_MC, 0); mc > 0 {
 		AVX512ParamsFloat32.LHSPanelCrossSize = mc
 	}
-	if nc := envutil.MustReadInt("GOMLX_AVX512_NC", 0); nc > 0 {
+	if nc := envutil.MustReadInt(envutil.GoBackendAVX512_NC, 0); nc > 0 {
 		AVX512ParamsFloat32.RHSPanelCrossSize = nc
 	}
 	if !envutil.MustReadBool(EnabledEnv, true) {
 		return
 	}
 
-	allowed := envutil.MustReadBool(envutil.SIMD_AVX512_Env, true)
+	allowed := envutil.MustReadBool(envutil.GoBackendSIMD_AVX512, true)
 	if allowed && archsimd.X86.AVX512() {
 		registerAVX512(false)
 	}

--- a/internal/gobackend/dot/matmul/avx512_internal_test.go
+++ b/internal/gobackend/dot/matmul/avx512_internal_test.go
@@ -41,6 +41,39 @@ func TestAVX512(t *testing.T) {
 		})
 	})
 
+	t.Run("Float16AsmDirect", func(t *testing.T) {
+		// contractingLen = 2, lhsActiveRows = 2, rhsActiveCols = 2
+		// LHS has 4 rows x 2 cols, packed in strips of 4 rows:
+		// for col 0: row0, row1, row2, row3
+		// for col 1: row0, row1, row2, row3
+		lhs := make([]float16.Float16, 4*2)
+		// col 0:
+		lhs[0] = float16.FromFloat32(1) // row 0
+		lhs[1] = float16.FromFloat32(3) // row 1
+		lhs[2] = float16.FromFloat32(0) // row 2
+		lhs[3] = float16.FromFloat32(0) // row 3
+		// col 1:
+		lhs[4] = float16.FromFloat32(2) // row 0
+		lhs[5] = float16.FromFloat32(4) // row 1
+		lhs[6] = float16.FromFloat32(0) // row 2
+		lhs[7] = float16.FromFloat32(0) // row 3
+
+		// RHS has 2 rows x 64 cols:
+		rhs := make([]float16.Float16, 2*64)
+		// row 0: col 0 = 10, col 1 = 11
+		rhs[0] = float16.FromFloat32(10)
+		rhs[1] = float16.FromFloat32(11)
+		// row 1: col 0 = 12, col 1 = 13
+		rhs[64] = float16.FromFloat32(12)
+		rhs[65] = float16.FromFloat32(13)
+
+		out := make([]float32, 4*64)
+		avx512LargeKernelFloat16Asm(lhs, rhs, out, 4, 64, 2, 2, 2)
+		if out[0] != 34 || out[1] != 37 || out[64] != 78 || out[65] != 85 {
+			t.Fatalf("Float16AsmDirect: unexpected output: row0=[%v, %v], row1=[%v, %v]", out[0], out[1], out[64], out[65])
+		}
+	})
+
 	t.Run("Transpose/4x8x64bits", func(t *testing.T) {
 		var input [4 * 8]uint64
 		for i := range input {

--- a/internal/gobackend/dot/matmul/avx512_large.go
+++ b/internal/gobackend/dot/matmul/avx512_large.go
@@ -179,12 +179,9 @@ func avx512LargeMatrixSliceFloat32( //alt:f32
 ) {
 	_ = lhsCrossSize // Not used, rowStart and rowEnd < lhsCrossSize are enough.
 
-	if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) { //alt:f32
-	//alt:bf16|f16 if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 {
-	//alt:f64 if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 16 {
-		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)", //alt:f32
-			//alt:bf16|f16 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)",
-			//alt:f64 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 16 respectively (params=%+v)",
+	if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) { //alt:f32|bf16|f16
+	//alt:f64 if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 16 && params.RHSL1KernelCols != 32) {
+		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)", //alt:f32|bf16|f16|f64
 			params.LHSL1KernelRows, params.RHSL1KernelCols, params))
 	}
 
@@ -208,14 +205,17 @@ func avx512LargeMatrixSliceFloat32( //alt:f32
 				lhsPanelHeight := min(params.LHSPanelCrossSize, rowEnd-lhsPanelRowIdx)
 				avx512PackLHSKernelRows4(lhsMatrix, packedLHS, lhsPanelRowIdx, contractingPanelIdx, contractingSize, lhsPanelHeight, contractingPanelWidth, params.LHSL1KernelRows) //alt:f32|bf16|f16|f64
 
-				if AVX512UseAsm { //alt:f32
+				if AVX512UseAsm { //alt:f32|bf16|f16|f64
 					avx512LargeKernelFloat32Asm( //alt:f32
-						packedLHS, packedRHS, packedOutput, //alt:f32
-						params.LHSPanelCrossSize, params.RHSPanelCrossSize, //alt:f32
-						contractingPanelWidth, //alt:f32
-						lhsPanelHeight, rhsPanelWidth, //alt:f32
-					) //alt:f32
-				} else { //alt:f32
+						//alt:bf16 avx512LargeKernelBFloat16Asm(
+						//alt:f16 avx512LargeKernelFloat16Asm(
+						//alt:f64 avx512LargeKernelFloat64Asm(
+						packedLHS, packedRHS, packedOutput,
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+						contractingPanelWidth,
+						lhsPanelHeight, rhsPanelWidth,
+					)
+				} else { //alt:f32|bf16|f16|f64
 					avx512LargeKernelFloat32( //alt:f32
 						//alt:bf16 avx512LargeKernelBFloat16(
 						//alt:f16 avx512LargeKernelFloat16(
@@ -225,7 +225,7 @@ func avx512LargeMatrixSliceFloat32( //alt:f32
 						contractingPanelWidth,
 						lhsPanelHeight, rhsPanelWidth,
 					) //alt:bf16|f16|f64
-				} //alt:f32
+				} //alt:f32|bf16|f16|f64
 
 				// Accumulate (or write) packedOutput to output.
 				isFirstContractingPanel := contractingPanelIdx == 0

--- a/internal/gobackend/dot/matmul/avx512_large.go
+++ b/internal/gobackend/dot/matmul/avx512_large.go
@@ -11,6 +11,7 @@ package matmul
 // - "f16": Implements the MatMul for Float16 -> Float32 dtypes.
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -178,9 +179,11 @@ func avx512LargeMatrixSliceFloat32( //alt:f32
 ) {
 	_ = lhsCrossSize // Not used, rowStart and rowEnd < lhsCrossSize are enough.
 
-	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 { //alt:f32|bf16|f16
+	if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) { //alt:f32
+	//alt:bf16|f16 if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 {
 	//alt:f64 if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 16 {
-		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)", //alt:f32|bf16|f16
+		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)", //alt:f32
+			//alt:bf16|f16 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)",
 			//alt:f64 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 16 respectively (params=%+v)",
 			params.LHSL1KernelRows, params.RHSL1KernelCols, params))
 	}
@@ -205,15 +208,24 @@ func avx512LargeMatrixSliceFloat32( //alt:f32
 				lhsPanelHeight := min(params.LHSPanelCrossSize, rowEnd-lhsPanelRowIdx)
 				avx512PackLHSKernelRows4(lhsMatrix, packedLHS, lhsPanelRowIdx, contractingPanelIdx, contractingSize, lhsPanelHeight, contractingPanelWidth, params.LHSL1KernelRows) //alt:f32|bf16|f16|f64
 
-				avx512LargeKernelFloat32( //alt:f32
-					//alt:bf16 avx512LargeKernelBFloat16(
-					//alt:f16 avx512LargeKernelFloat16(
-					//alt:f64 avx512LargeKernelFloat64(
-					packedLHS, packedRHS, packedOutput,
-					params.LHSPanelCrossSize, params.RHSPanelCrossSize,
-					contractingPanelWidth,
-					lhsPanelHeight, rhsPanelWidth,
-				)
+				if AVX512UseAsm { //alt:f32
+					avx512LargeKernelFloat32Asm( //alt:f32
+						packedLHS, packedRHS, packedOutput, //alt:f32
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize, //alt:f32
+						contractingPanelWidth, //alt:f32
+						lhsPanelHeight, rhsPanelWidth, //alt:f32
+					) //alt:f32
+				} else { //alt:f32
+					avx512LargeKernelFloat32( //alt:f32
+						//alt:bf16 avx512LargeKernelBFloat16(
+						//alt:f16 avx512LargeKernelFloat16(
+						//alt:f64 avx512LargeKernelFloat64(
+						packedLHS, packedRHS, packedOutput,
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+						contractingPanelWidth,
+						lhsPanelHeight, rhsPanelWidth,
+					) //alt:bf16|f16|f64
+				} //alt:f32
 
 				// Accumulate (or write) packedOutput to output.
 				isFirstContractingPanel := contractingPanelIdx == 0
@@ -251,7 +263,17 @@ func avx512LargeKernelFloat32( //alt:f32
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
+	defer func() {
+		runtime.KeepAlive(packedLHS)
+		runtime.KeepAlive(packedRHS)
+		runtime.KeepAlive(packedOutput)
+	}()
 	_ = lhsPanelRows // Not needed.
+
+	// BCE hints
+	_ = packedLHS[contractingLen*lhsActiveRows-1]
+	_ = packedRHS[contractingLen*rhsActiveCols-1]
+	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These much match params.LHSL1BlockRows and params.LHSL1BlockCols.

--- a/internal/gobackend/dot/matmul/avx512_large.go
+++ b/internal/gobackend/dot/matmul/avx512_large.go
@@ -11,7 +11,6 @@ package matmul
 // - "f16": Implements the MatMul for Float16 -> Float32 dtypes.
 
 import (
-	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -233,6 +232,11 @@ func avx512LargeMatrixSliceFloat32( //alt:f32
 
 // avx512LargeKernelFloat32 implements a kernel of the matrix multiplication for
 // a lhs and rhs packed panels into an intermediate output panel.
+//
+// Memory safety note: We use raw unsafe pointers to avoid bounds-checking (BCE) overhead
+// in the inner loops. Because the caller (parent function on the stack) owns and holds references
+// to packedLHS, packedRHS, and packedOutput throughout execution, they remain reachable and
+// do not need runtime.KeepAlive() calls at the end.
 func avx512LargeKernelFloat32( //alt:f32
 	//alt:bf16 func avx512LargeKernelBFloat16(
 	//alt:f16 func avx512LargeKernelFloat16(
@@ -247,17 +251,7 @@ func avx512LargeKernelFloat32( //alt:f32
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
-	defer func() {
-		runtime.KeepAlive(packedLHS)
-		runtime.KeepAlive(packedRHS)
-		runtime.KeepAlive(packedOutput)
-	}()
 	_ = lhsPanelRows // Not needed.
-
-	// BCE hints
-	_ = packedLHS[contractingLen*lhsActiveRows-1]
-	_ = packedRHS[contractingLen*rhsActiveCols-1]
-	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These much match params.LHSL1BlockRows and params.LHSL1BlockCols.

--- a/internal/gobackend/dot/matmul/avx512_large_amd64.go
+++ b/internal/gobackend/dot/matmul/avx512_large_amd64.go
@@ -1,0 +1,16 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+//go:build amd64
+
+package matmul
+
+// avx512LargeKernelFloat32Asm is the assembly implementation of the 4 rows x 64 cols GEMM microkernel.
+// Defined in avx512_large_amd64.s.
+//
+//go:noescape
+func avx512LargeKernelFloat32Asm(
+	packedLHS, packedRHS, packedOutput []float32,
+	lhsPanelRows, rhsPanelCols int,
+	contractingLen int,
+	lhsActiveRows, rhsActiveCols int,
+)

--- a/internal/gobackend/dot/matmul/avx512_large_amd64.go
+++ b/internal/gobackend/dot/matmul/avx512_large_amd64.go
@@ -4,8 +4,13 @@
 
 package matmul
 
-// avx512LargeKernelFloat32Asm is the assembly implementation of the 4 rows x 64 cols GEMM microkernel.
-// Defined in avx512_large_amd64.s.
+import (
+	"github.com/gomlx/compute/dtypes/bfloat16"
+	"github.com/gomlx/compute/dtypes/float16"
+)
+
+// avx512LargeKernelFloat32Asm is the assembly implementation of the 4 rows x 64 cols GEMM microkernel for Float32.
+// Defined in avx512_large_amd64_float32.s.
 //
 //go:noescape
 func avx512LargeKernelFloat32Asm(
@@ -14,3 +19,40 @@ func avx512LargeKernelFloat32Asm(
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 )
+
+// avx512LargeKernelFloat16Asm is the assembly implementation of the 4 rows x 64 cols GEMM microkernel for Float16.
+// Defined in avx512_large_amd64_float16.s.
+//
+//go:noescape
+func avx512LargeKernelFloat16Asm(
+	packedLHS, packedRHS []float16.Float16,
+	packedOutput []float32,
+	lhsPanelRows, rhsPanelCols int,
+	contractingLen int,
+	lhsActiveRows, rhsActiveCols int,
+)
+
+// avx512LargeKernelBFloat16Asm is the assembly implementation of the 4 rows x 64 cols GEMM microkernel for BFloat16.
+// Defined in avx512_large_amd64_bfloat16.s.
+//
+//go:noescape
+func avx512LargeKernelBFloat16Asm(
+	packedLHS, packedRHS []bfloat16.BFloat16,
+	packedOutput []float32,
+	lhsPanelRows, rhsPanelCols int,
+	contractingLen int,
+	lhsActiveRows, rhsActiveCols int,
+)
+
+// avx512LargeKernelFloat64Asm is the assembly implementation of the 4 rows x 32 cols GEMM microkernel for Float64.
+// Defined in avx512_large_amd64_float64.s.
+//
+//go:noescape
+func avx512LargeKernelFloat64Asm(
+	packedLHS, packedRHS, packedOutput []float64,
+	lhsPanelRows, rhsPanelCols int,
+	contractingLen int,
+	lhsActiveRows, rhsActiveCols int,
+)
+
+

--- a/internal/gobackend/dot/matmul/avx512_large_amd64.s
+++ b/internal/gobackend/dot/matmul/avx512_large_amd64.s
@@ -63,51 +63,191 @@ loop_rhs:
 	SHLQ $2, DI
 	LEAQ (R9)(DI*1), DI                  // DI = rhsPtr
 
-	// 3. K-loop
-	MOVQ R12, CX                         // CX = k counter = contractingLen
+	// 3. K-loop with 2-stage ping-pong pipeline (unroll by 2)
+	MOVQ R12, CX                         // CX = contractingLen
 	TESTQ CX, CX
 	JLE store_output
 
+	SHRQ $1, CX                          // CX = pairs = contractingLen / 2
+	JZ k_odd                             // If 0 pairs (contractingLen == 1), do odd iteration
+
+	// Prime Buffer A for Step 0 outside the loop
+	VMOVDQU32 (DI), Z16
+	VMOVDQU32 64(DI), Z17
+	VMOVDQU32 128(DI), Z18
+	VMOVDQU32 192(DI), Z19
+	VBROADCASTSS (SI), Z20
+	VBROADCASTSS 4(SI), Z21
+	VBROADCASTSS 8(SI), Z22
+	VBROADCASTSS 12(SI), Z23
+	ADDQ $16, SI                         // Advance past Step 0 (points to Step 1 = Buffer B)
+	ADDQ $256, DI
+
+	DECQ CX                              // CX = pairs - 1
+	JZ k_last_pair                       // If only 1 pair total, skip k_pair_loop directly to k_last_pair
+
 	PCALIGN $64
-k_loop:
-	// Load 4 RHS vectors (64 floats = 256 bytes)
+k_pair_loop:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads (Z24..Z27)
+	VFMADD231PS Z16, Z20, Z0
+	VMOVDQU32 (DI), Z24
+	VFMADD231PS Z17, Z20, Z1
+	VMOVDQU32 64(DI), Z25
+	VFMADD231PS Z18, Z20, Z2
+	VMOVDQU32 128(DI), Z26
+	VFMADD231PS Z19, Z20, Z3
+	VMOVDQU32 192(DI), Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads (Z28..Z31)
+	VFMADD231PS Z16, Z21, Z4
+	VBROADCASTSS (SI), Z28
+	VFMADD231PS Z17, Z21, Z5
+	VBROADCASTSS 4(SI), Z29
+	VFMADD231PS Z18, Z21, Z6
+	VBROADCASTSS 8(SI), Z30
+	VFMADD231PS Z19, Z21, Z7
+	VBROADCASTSS 12(SI), Z31
+
+	ADDQ $16, SI                         // Advance past Step B
+	ADDQ $256, DI
+
+	// Step A: Rows 2-3 pure FMAs (provides 4-cycle runway for Buffer B loads to settle)
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+	// Step B: Row 0 FMAs interleaved with next-iter Buffer A RHS loads (Z16..Z19)
+	VFMADD231PS Z24, Z28, Z0
+	VMOVDQU32 (DI), Z16
+	VFMADD231PS Z25, Z28, Z1
+	VMOVDQU32 64(DI), Z17
+	VFMADD231PS Z26, Z28, Z2
+	VMOVDQU32 128(DI), Z18
+	VFMADD231PS Z27, Z28, Z3
+	VMOVDQU32 192(DI), Z19
+
+	// Step B: Row 1 FMAs interleaved with next-iter Buffer A LHS loads (Z20..Z23)
+	VFMADD231PS Z24, Z29, Z4
+	VBROADCASTSS (SI), Z20
+	VFMADD231PS Z25, Z29, Z5
+	VBROADCASTSS 4(SI), Z21
+	VFMADD231PS Z26, Z29, Z6
+	VBROADCASTSS 8(SI), Z22
+	VFMADD231PS Z27, Z29, Z7
+	VBROADCASTSS 12(SI), Z23
+
+	ADDQ $16, SI                         // Advance past Step A of next iter
+	ADDQ $256, DI
+
+	// Step B: Rows 2-3 pure FMAs (provides 4-cycle runway for Buffer A loads to settle)
+	VFMADD231PS Z24, Z30, Z8
+	VFMADD231PS Z25, Z30, Z9
+	VFMADD231PS Z26, Z30, Z10
+	VFMADD231PS Z27, Z30, Z11
+
+	VFMADD231PS Z24, Z31, Z12
+	VFMADD231PS Z25, Z31, Z13
+	VFMADD231PS Z26, Z31, Z14
+	VFMADD231PS Z27, Z31, Z15
+
+	DECQ CX
+	JNZ k_pair_loop
+
+k_last_pair:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads (Z24..Z27)
+	VFMADD231PS Z16, Z20, Z0
+	VMOVDQU32 (DI), Z24
+	VFMADD231PS Z17, Z20, Z1
+	VMOVDQU32 64(DI), Z25
+	VFMADD231PS Z18, Z20, Z2
+	VMOVDQU32 128(DI), Z26
+	VFMADD231PS Z19, Z20, Z3
+	VMOVDQU32 192(DI), Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads (Z28..Z31)
+	VFMADD231PS Z16, Z21, Z4
+	VBROADCASTSS (SI), Z28
+	VFMADD231PS Z17, Z21, Z5
+	VBROADCASTSS 4(SI), Z29
+	VFMADD231PS Z18, Z21, Z6
+	VBROADCASTSS 8(SI), Z30
+	VFMADD231PS Z19, Z21, Z7
+	VBROADCASTSS 12(SI), Z31
+
+	ADDQ $16, SI
+	ADDQ $256, DI
+
+	// Step A: Rows 2-3 pure FMAs
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+	// Step B: 16 FMAs using Buffer B (NO loads for next iter to prevent OOB)
+	VFMADD231PS Z24, Z28, Z0
+	VFMADD231PS Z25, Z28, Z1
+	VFMADD231PS Z26, Z28, Z2
+	VFMADD231PS Z27, Z28, Z3
+
+	VFMADD231PS Z24, Z29, Z4
+	VFMADD231PS Z25, Z29, Z5
+	VFMADD231PS Z26, Z29, Z6
+	VFMADD231PS Z27, Z29, Z7
+
+	VFMADD231PS Z24, Z30, Z8
+	VFMADD231PS Z25, Z30, Z9
+	VFMADD231PS Z26, Z30, Z10
+	VFMADD231PS Z27, Z30, Z11
+
+	VFMADD231PS Z24, Z31, Z12
+	VFMADD231PS Z25, Z31, Z13
+	VFMADD231PS Z26, Z31, Z14
+	VFMADD231PS Z27, Z31, Z15
+
+k_odd:
+	// Handle remaining odd iteration if contractingLen % 2 != 0
+	TESTQ $1, R12
+	JZ store_output
+
 	VMOVDQU32 (DI), Z16
 	VMOVDQU32 64(DI), Z17
 	VMOVDQU32 128(DI), Z18
 	VMOVDQU32 192(DI), Z19
 
-	// Row 0
 	VBROADCASTSS (SI), Z20
 	VFMADD231PS Z16, Z20, Z0
 	VFMADD231PS Z17, Z20, Z1
 	VFMADD231PS Z18, Z20, Z2
 	VFMADD231PS Z19, Z20, Z3
 
-	// Row 1
 	VBROADCASTSS 4(SI), Z21
 	VFMADD231PS Z16, Z21, Z4
 	VFMADD231PS Z17, Z21, Z5
 	VFMADD231PS Z18, Z21, Z6
 	VFMADD231PS Z19, Z21, Z7
 
-	// Row 2
 	VBROADCASTSS 8(SI), Z22
 	VFMADD231PS Z16, Z22, Z8
 	VFMADD231PS Z17, Z22, Z9
 	VFMADD231PS Z18, Z22, Z10
 	VFMADD231PS Z19, Z22, Z11
 
-	// Row 3
 	VBROADCASTSS 12(SI), Z23
 	VFMADD231PS Z16, Z23, Z12
 	VFMADD231PS Z17, Z23, Z13
 	VFMADD231PS Z18, Z23, Z14
 	VFMADD231PS Z19, Z23, Z15
-
-	ADDQ $16, SI                         // lhsPtr += kernelRows * 4 = 16
-	ADDQ $256, DI                        // rhsPtr += kernelCols * 4 = 256
-	DECQ CX
-	JNZ k_loop
 
 store_output:
 	// 4. Write back 16 accumulators to output:

--- a/internal/gobackend/dot/matmul/avx512_large_amd64.s
+++ b/internal/gobackend/dot/matmul/avx512_large_amd64.s
@@ -1,0 +1,157 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+//go:build amd64
+
+#include "textflag.h"
+
+// func avx512LargeKernelFloat32Asm(
+//     packedLHS, packedRHS, packedOutput []float32,
+//     lhsPanelRows, rhsPanelCols int,
+//     contractingLen int,
+//     lhsActiveRows, rhsActiveCols int)
+TEXT ·avx512LargeKernelFloat32Asm(SB), NOSPLIT, $0-112
+	MOVQ packedLHS_base+0(FP), R8        // R8 = lhsBasePtr
+	MOVQ packedRHS_base+24(FP), R9       // R9 = rhsBasePtr
+	MOVQ packedOutput_base+48(FP), R10   // R10 = outBasePtr
+	MOVQ rhsPanelCols+80(FP), R11        // R11 = outputStride (cols)
+	MOVQ contractingLen+88(FP), R12      // R12 = contractingLen (K)
+	MOVQ lhsActiveRows+96(FP), R13       // R13 = lhsActiveRows (M)
+	MOVQ rhsActiveCols+104(FP), R14      // R14 = rhsActiveCols (N)
+
+	SHLQ $2, R11                         // R11 = outputStride in bytes
+
+	XORQ AX, AX                          // AX = lhsRowIdx = 0
+
+loop_lhs:
+	CMPQ AX, R13
+	JGE done
+
+	XORQ BX, BX                          // BX = rhsColIdx = 0
+
+loop_rhs:
+	CMPQ BX, R14
+	JGE next_lhs
+
+	// 1. Zero all 16 accumulators (Z0..Z15)
+	VXORPS Z0, Z0, Z0
+	VXORPS Z1, Z1, Z1
+	VXORPS Z2, Z2, Z2
+	VXORPS Z3, Z3, Z3
+	VXORPS Z4, Z4, Z4
+	VXORPS Z5, Z5, Z5
+	VXORPS Z6, Z6, Z6
+	VXORPS Z7, Z7, Z7
+	VXORPS Z8, Z8, Z8
+	VXORPS Z9, Z9, Z9
+	VXORPS Z10, Z10, Z10
+	VXORPS Z11, Z11, Z11
+	VXORPS Z12, Z12, Z12
+	VXORPS Z13, Z13, Z13
+	VXORPS Z14, Z14, Z14
+	VXORPS Z15, Z15, Z15
+
+	// 2. Compute lhsPtr and rhsPtr
+	// idxLHS = lhsRowIdx * contractingLen
+	MOVQ AX, SI
+	IMULQ R12, SI
+	SHLQ $2, SI
+	LEAQ (R8)(SI*1), SI                  // SI = lhsPtr
+
+	// idxRHS = rhsColIdx * contractingLen
+	MOVQ BX, DI
+	IMULQ R12, DI
+	SHLQ $2, DI
+	LEAQ (R9)(DI*1), DI                  // DI = rhsPtr
+
+	// 3. K-loop
+	MOVQ R12, CX                         // CX = k counter = contractingLen
+	TESTQ CX, CX
+	JLE store_output
+
+	PCALIGN $64
+k_loop:
+	// Load 4 RHS vectors (64 floats = 256 bytes)
+	VMOVDQU32 (DI), Z16
+	VMOVDQU32 64(DI), Z17
+	VMOVDQU32 128(DI), Z18
+	VMOVDQU32 192(DI), Z19
+
+	// Row 0
+	VBROADCASTSS (SI), Z20
+	VFMADD231PS Z16, Z20, Z0
+	VFMADD231PS Z17, Z20, Z1
+	VFMADD231PS Z18, Z20, Z2
+	VFMADD231PS Z19, Z20, Z3
+
+	// Row 1
+	VBROADCASTSS 4(SI), Z21
+	VFMADD231PS Z16, Z21, Z4
+	VFMADD231PS Z17, Z21, Z5
+	VFMADD231PS Z18, Z21, Z6
+	VFMADD231PS Z19, Z21, Z7
+
+	// Row 2
+	VBROADCASTSS 8(SI), Z22
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	// Row 3
+	VBROADCASTSS 12(SI), Z23
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+	ADDQ $16, SI                         // lhsPtr += kernelRows * 4 = 16
+	ADDQ $256, DI                        // rhsPtr += kernelCols * 4 = 256
+	DECQ CX
+	JNZ k_loop
+
+store_output:
+	// 4. Write back 16 accumulators to output:
+	// outputBase = outBasePtr + (lhsRowIdx * outputStrideBytes) + (rhsColIdx * 4)
+	MOVQ AX, DX                          // DX = lhsRowIdx
+	IMULQ R11, DX                        // DX = lhsRowIdx * outputStrideBytes
+	MOVQ BX, CX
+	SHLQ $2, CX                          // CX = rhsColIdx * 4
+	ADDQ CX, DX
+	LEAQ (R10)(DX*1), DX                 // DX = outRow0Ptr
+
+	// Row 0
+	VMOVDQU32 Z0, (DX)
+	VMOVDQU32 Z1, 64(DX)
+	VMOVDQU32 Z2, 128(DX)
+	VMOVDQU32 Z3, 192(DX)
+
+	// Row 1
+	ADDQ R11, DX                         // DX = outRow1Ptr
+	VMOVDQU32 Z4, (DX)
+	VMOVDQU32 Z5, 64(DX)
+	VMOVDQU32 Z6, 128(DX)
+	VMOVDQU32 Z7, 192(DX)
+
+	// Row 2
+	ADDQ R11, DX                         // DX = outRow2Ptr
+	VMOVDQU32 Z8, (DX)
+	VMOVDQU32 Z9, 64(DX)
+	VMOVDQU32 Z10, 128(DX)
+	VMOVDQU32 Z11, 192(DX)
+
+	// Row 3
+	ADDQ R11, DX                         // DX = outRow3Ptr
+	VMOVDQU32 Z12, (DX)
+	VMOVDQU32 Z13, 64(DX)
+	VMOVDQU32 Z14, 128(DX)
+	VMOVDQU32 Z15, 192(DX)
+
+	ADDQ $64, BX                         // rhsColIdx += 64
+	JMP loop_rhs
+
+next_lhs:
+	ADDQ $4, AX                          // lhsRowIdx += 4
+	JMP loop_lhs
+
+done:
+	RET

--- a/internal/gobackend/dot/matmul/avx512_large_amd64_bfloat16.s
+++ b/internal/gobackend/dot/matmul/avx512_large_amd64_bfloat16.s
@@ -1,0 +1,350 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+//go:build amd64
+
+#include "textflag.h"
+
+// func avx512LargeKernelBFloat16Asm(
+//     packedLHS, packedRHS []bfloat16.BFloat16,
+//     packedOutput []float32,
+//     lhsPanelRows, rhsPanelCols int,
+//     contractingLen int,
+//     lhsActiveRows, rhsActiveCols int)
+TEXT ·avx512LargeKernelBFloat16Asm(SB), NOSPLIT, $0-112
+	MOVQ packedLHS_base+0(FP), R8        // R8 = lhsBasePtr (bfloat16 = 2 bytes)
+	MOVQ packedRHS_base+24(FP), R9       // R9 = rhsBasePtr (bfloat16 = 2 bytes)
+	MOVQ packedOutput_base+48(FP), R10   // R10 = outBasePtr (float32 = 4 bytes)
+	MOVQ rhsPanelCols+80(FP), R11        // R11 = outputStride (cols)
+	MOVQ contractingLen+88(FP), R12      // R12 = contractingLen (K)
+	MOVQ lhsActiveRows+96(FP), R13       // R13 = lhsActiveRows (M)
+	MOVQ rhsActiveCols+104(FP), R14      // R14 = rhsActiveCols (N)
+
+	SHLQ $2, R11                         // R11 = outputStride in bytes (float32 = 4 bytes)
+
+	XORQ AX, AX                          // AX = lhsRowIdx = 0
+
+loop_lhs_bf16:
+	CMPQ AX, R13
+	JGE done_bf16
+
+	XORQ BX, BX                          // BX = rhsColIdx = 0
+
+loop_rhs_bf16:
+	CMPQ BX, R14
+	JGE next_lhs_bf16
+
+	// 1. Zero all 16 accumulators (Z0..Z15)
+	VXORPS Z0, Z0, Z0
+	VXORPS Z1, Z1, Z1
+	VXORPS Z2, Z2, Z2
+	VXORPS Z3, Z3, Z3
+	VXORPS Z4, Z4, Z4
+	VXORPS Z5, Z5, Z5
+	VXORPS Z6, Z6, Z6
+	VXORPS Z7, Z7, Z7
+	VXORPS Z8, Z8, Z8
+	VXORPS Z9, Z9, Z9
+	VXORPS Z10, Z10, Z10
+	VXORPS Z11, Z11, Z11
+	VXORPS Z12, Z12, Z12
+	VXORPS Z13, Z13, Z13
+	VXORPS Z14, Z14, Z14
+	VXORPS Z15, Z15, Z15
+
+	// 2. Compute lhsPtr and rhsPtr (elements are bfloat16 = 2 bytes)
+	// idxLHS = lhsRowIdx * contractingLen
+	MOVQ AX, SI
+	IMULQ R12, SI
+	SHLQ $1, SI                          // SI = byte offset (bfloat16 = 2 bytes)
+	LEAQ (R8)(SI*1), SI                  // SI = lhsPtr
+
+	// idxRHS = rhsColIdx * contractingLen
+	MOVQ BX, DI
+	IMULQ R12, DI
+	SHLQ $1, DI                          // DI = byte offset (bfloat16 = 2 bytes)
+	LEAQ (R9)(DI*1), DI                  // DI = rhsPtr
+
+	// 3. K-loop with 2-stage ping-pong pipeline (unroll by 2)
+	MOVQ R12, CX                         // CX = contractingLen
+	TESTQ CX, CX
+	JLE store_output_bf16
+
+	SHRQ $1, CX                          // CX = pairs = contractingLen / 2
+	JZ k_odd_bf16                        // If 0 pairs (contractingLen == 1), do odd iteration
+
+	// Prime Buffer A for Step 0 outside the loop
+	// 4 RHS vectors (64 bfloat16s = 128 bytes) converted to float32:
+	VPMOVZXWD (DI), Z16
+	VPSLLD $16, Z16, Z16
+	VPMOVZXWD 32(DI), Z17
+	VPSLLD $16, Z17, Z17
+	VPMOVZXWD 64(DI), Z18
+	VPSLLD $16, Z18, Z18
+	VPMOVZXWD 96(DI), Z19
+	VPSLLD $16, Z19, Z19
+
+	// 4 LHS scalars (4 bfloat16s = 8 bytes) converted to float32:
+	VPMOVZXWD (SI), X20
+	VPSLLD $16, X20, X20
+	VPERMILPS $0x55, X20, X21
+	VPERMILPS $0xAA, X20, X22
+	VPERMILPS $0xFF, X20, X23
+	VBROADCASTSS X20, Z20
+	VBROADCASTSS X21, Z21
+	VBROADCASTSS X22, Z22
+	VBROADCASTSS X23, Z23
+
+	ADDQ $8, SI                          // Advance past Step 0 (4 bfloat16s = 8 bytes)
+	ADDQ $128, DI                        // Advance past Step 0 (64 bfloat16s = 128 bytes)
+
+	DECQ CX                              // CX = pairs - 1
+	JZ k_last_pair_bf16                  // If only 1 pair total, skip loop directly to k_last_pair_bf16
+
+	PCALIGN $64
+k_pair_loop_bf16:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads (Z24..Z27)
+	VFMADD231PS Z16, Z20, Z0
+	VPMOVZXWD (DI), Z24
+	VPSLLD $16, Z24, Z24
+	VFMADD231PS Z17, Z20, Z1
+	VPMOVZXWD 32(DI), Z25
+	VPSLLD $16, Z25, Z25
+	VFMADD231PS Z18, Z20, Z2
+	VPMOVZXWD 64(DI), Z26
+	VPSLLD $16, Z26, Z26
+	VFMADD231PS Z19, Z20, Z3
+	VPMOVZXWD 96(DI), Z27
+	VPSLLD $16, Z27, Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads (Z28..Z31)
+	VFMADD231PS Z16, Z21, Z4
+	VPMOVZXWD (SI), X28
+	VPSLLD $16, X28, X28
+	VPERMILPS $0x55, X28, X29
+	VFMADD231PS Z17, Z21, Z5
+	VPERMILPS $0xAA, X28, X30
+	VPERMILPS $0xFF, X28, X31
+	VFMADD231PS Z18, Z21, Z6
+	VBROADCASTSS X28, Z28
+	VBROADCASTSS X29, Z29
+	VBROADCASTSS X30, Z30
+	VBROADCASTSS X31, Z31
+	VFMADD231PS Z19, Z21, Z7
+
+	ADDQ $8, SI                          // Advance past Step B
+	ADDQ $128, DI
+
+	// Step A: Rows 2-3 pure FMAs
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+	// Step B: Row 0 FMAs interleaved with next-iter Buffer A RHS loads (Z16..Z19)
+	VFMADD231PS Z24, Z28, Z0
+	VPMOVZXWD (DI), Z16
+	VPSLLD $16, Z16, Z16
+	VFMADD231PS Z25, Z28, Z1
+	VPMOVZXWD 32(DI), Z17
+	VPSLLD $16, Z17, Z17
+	VFMADD231PS Z26, Z28, Z2
+	VPMOVZXWD 64(DI), Z18
+	VPSLLD $16, Z18, Z18
+	VFMADD231PS Z27, Z28, Z3
+	VPMOVZXWD 96(DI), Z19
+	VPSLLD $16, Z19, Z19
+
+	// Step B: Row 1 FMAs interleaved with next-iter Buffer A LHS loads (Z20..Z23)
+	VFMADD231PS Z24, Z29, Z4
+	VPMOVZXWD (SI), X20
+	VPSLLD $16, X20, X20
+	VPERMILPS $0x55, X20, X21
+	VFMADD231PS Z25, Z29, Z5
+	VPERMILPS $0xAA, X20, X22
+	VPERMILPS $0xFF, X20, X23
+	VFMADD231PS Z26, Z29, Z6
+	VBROADCASTSS X20, Z20
+	VBROADCASTSS X21, Z21
+	VBROADCASTSS X22, Z22
+	VBROADCASTSS X23, Z23
+	VFMADD231PS Z27, Z29, Z7
+
+	ADDQ $8, SI                          // Advance past Step A of next iter
+	ADDQ $128, DI
+
+	// Step B: Rows 2-3 pure FMAs
+	VFMADD231PS Z24, Z30, Z8
+	VFMADD231PS Z25, Z30, Z9
+	VFMADD231PS Z26, Z30, Z10
+	VFMADD231PS Z27, Z30, Z11
+
+	VFMADD231PS Z24, Z31, Z12
+	VFMADD231PS Z25, Z31, Z13
+	VFMADD231PS Z26, Z31, Z14
+	VFMADD231PS Z27, Z31, Z15
+
+	DECQ CX
+	JNZ k_pair_loop_bf16
+
+k_last_pair_bf16:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads
+	VFMADD231PS Z16, Z20, Z0
+	VPMOVZXWD (DI), Z24
+	VPSLLD $16, Z24, Z24
+	VFMADD231PS Z17, Z20, Z1
+	VPMOVZXWD 32(DI), Z25
+	VPSLLD $16, Z25, Z25
+	VFMADD231PS Z18, Z20, Z2
+	VPMOVZXWD 64(DI), Z26
+	VPSLLD $16, Z26, Z26
+	VFMADD231PS Z19, Z20, Z3
+	VPMOVZXWD 96(DI), Z27
+	VPSLLD $16, Z27, Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads
+	VFMADD231PS Z16, Z21, Z4
+	VPMOVZXWD (SI), X28
+	VPSLLD $16, X28, X28
+	VPERMILPS $0x55, X28, X29
+	VFMADD231PS Z17, Z21, Z5
+	VPERMILPS $0xAA, X28, X30
+	VPERMILPS $0xFF, X28, X31
+	VFMADD231PS Z18, Z21, Z6
+	VBROADCASTSS X28, Z28
+	VBROADCASTSS X29, Z29
+	VBROADCASTSS X30, Z30
+	VBROADCASTSS X31, Z31
+	VFMADD231PS Z19, Z21, Z7
+
+	ADDQ $8, SI
+	ADDQ $128, DI
+
+	// Step A: Rows 2-3 pure FMAs
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+	// Step B: 16 FMAs using Buffer B (NO loads)
+	VFMADD231PS Z24, Z28, Z0
+	VFMADD231PS Z25, Z28, Z1
+	VFMADD231PS Z26, Z28, Z2
+	VFMADD231PS Z27, Z28, Z3
+
+	VFMADD231PS Z24, Z29, Z4
+	VFMADD231PS Z25, Z29, Z5
+	VFMADD231PS Z26, Z29, Z6
+	VFMADD231PS Z27, Z29, Z7
+
+	VFMADD231PS Z24, Z30, Z8
+	VFMADD231PS Z25, Z30, Z9
+	VFMADD231PS Z26, Z30, Z10
+	VFMADD231PS Z27, Z30, Z11
+
+	VFMADD231PS Z24, Z31, Z12
+	VFMADD231PS Z25, Z31, Z13
+	VFMADD231PS Z26, Z31, Z14
+	VFMADD231PS Z27, Z31, Z15
+
+k_odd_bf16:
+	TESTQ $1, R12
+	JZ store_output_bf16
+
+	VPMOVZXWD (DI), Z16
+	VPSLLD $16, Z16, Z16
+	VPMOVZXWD 32(DI), Z17
+	VPSLLD $16, Z17, Z17
+	VPMOVZXWD 64(DI), Z18
+	VPSLLD $16, Z18, Z18
+	VPMOVZXWD 96(DI), Z19
+	VPSLLD $16, Z19, Z19
+
+	VPMOVZXWD (SI), X20
+	VPSLLD $16, X20, X20
+	VPERMILPS $0x55, X20, X21
+	VPERMILPS $0xAA, X20, X22
+	VPERMILPS $0xFF, X20, X23
+	VBROADCASTSS X20, Z20
+	VBROADCASTSS X21, Z21
+	VBROADCASTSS X22, Z22
+	VBROADCASTSS X23, Z23
+
+	// Row 0
+	VFMADD231PS Z16, Z20, Z0
+	VFMADD231PS Z17, Z20, Z1
+	VFMADD231PS Z18, Z20, Z2
+	VFMADD231PS Z19, Z20, Z3
+
+	// Row 1
+	VFMADD231PS Z16, Z21, Z4
+	VFMADD231PS Z17, Z21, Z5
+	VFMADD231PS Z18, Z21, Z6
+	VFMADD231PS Z19, Z21, Z7
+
+	// Row 2
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	// Row 3
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+store_output_bf16:
+	// Output is []float32: write back exactly as in Float32
+	MOVQ AX, DX
+	IMULQ R11, DX
+	MOVQ BX, CX
+	SHLQ $2, CX
+	ADDQ CX, DX
+	LEAQ (R10)(DX*1), DX
+
+	// Row 0
+	VMOVDQU32 Z0, (DX)
+	VMOVDQU32 Z1, 64(DX)
+	VMOVDQU32 Z2, 128(DX)
+	VMOVDQU32 Z3, 192(DX)
+
+	// Row 1
+	ADDQ R11, DX
+	VMOVDQU32 Z4, (DX)
+	VMOVDQU32 Z5, 64(DX)
+	VMOVDQU32 Z6, 128(DX)
+	VMOVDQU32 Z7, 192(DX)
+
+	// Row 2
+	ADDQ R11, DX
+	VMOVDQU32 Z8, (DX)
+	VMOVDQU32 Z9, 64(DX)
+	VMOVDQU32 Z10, 128(DX)
+	VMOVDQU32 Z11, 192(DX)
+
+	// Row 3
+	ADDQ R11, DX
+	VMOVDQU32 Z12, (DX)
+	VMOVDQU32 Z13, 64(DX)
+	VMOVDQU32 Z14, 128(DX)
+	VMOVDQU32 Z15, 192(DX)
+
+	ADDQ $64, BX
+	JMP loop_rhs_bf16
+
+next_lhs_bf16:
+	ADDQ $4, AX
+	JMP loop_lhs_bf16
+
+done_bf16:
+	RET

--- a/internal/gobackend/dot/matmul/avx512_large_amd64_float16.s
+++ b/internal/gobackend/dot/matmul/avx512_large_amd64_float16.s
@@ -4,33 +4,34 @@
 
 #include "textflag.h"
 
-// func avx512LargeKernelFloat32Asm(
-//     packedLHS, packedRHS, packedOutput []float32,
+// func avx512LargeKernelFloat16Asm(
+//     packedLHS, packedRHS []float16.Float16,
+//     packedOutput []float32,
 //     lhsPanelRows, rhsPanelCols int,
 //     contractingLen int,
 //     lhsActiveRows, rhsActiveCols int)
-TEXT ·avx512LargeKernelFloat32Asm(SB), NOSPLIT, $0-112
-	MOVQ packedLHS_base+0(FP), R8        // R8 = lhsBasePtr
-	MOVQ packedRHS_base+24(FP), R9       // R9 = rhsBasePtr
-	MOVQ packedOutput_base+48(FP), R10   // R10 = outBasePtr
+TEXT ·avx512LargeKernelFloat16Asm(SB), NOSPLIT, $0-112
+	MOVQ packedLHS_base+0(FP), R8        // R8 = lhsBasePtr (float16 = 2 bytes)
+	MOVQ packedRHS_base+24(FP), R9       // R9 = rhsBasePtr (float16 = 2 bytes)
+	MOVQ packedOutput_base+48(FP), R10   // R10 = outBasePtr (float32 = 4 bytes)
 	MOVQ rhsPanelCols+80(FP), R11        // R11 = outputStride (cols)
 	MOVQ contractingLen+88(FP), R12      // R12 = contractingLen (K)
 	MOVQ lhsActiveRows+96(FP), R13       // R13 = lhsActiveRows (M)
 	MOVQ rhsActiveCols+104(FP), R14      // R14 = rhsActiveCols (N)
 
-	SHLQ $2, R11                         // R11 = outputStride in bytes
+	SHLQ $2, R11                         // R11 = outputStride in bytes (float32 = 4 bytes)
 
 	XORQ AX, AX                          // AX = lhsRowIdx = 0
 
-loop_lhs:
+loop_lhs_f16:
 	CMPQ AX, R13
-	JGE done
+	JGE done_f16
 
 	XORQ BX, BX                          // BX = rhsColIdx = 0
 
-loop_rhs:
+loop_rhs_f16:
 	CMPQ BX, R14
-	JGE next_lhs
+	JGE next_lhs_f16
 
 	// 1. Zero all 16 accumulators (Z0..Z15)
 	VXORPS Z0, Z0, Z0
@@ -50,138 +51,78 @@ loop_rhs:
 	VXORPS Z14, Z14, Z14
 	VXORPS Z15, Z15, Z15
 
-	// 2. Compute lhsPtr and rhsPtr
+	// 2. Compute lhsPtr and rhsPtr (elements are float16 = 2 bytes)
 	// idxLHS = lhsRowIdx * contractingLen
 	MOVQ AX, SI
 	IMULQ R12, SI
-	SHLQ $2, SI
+	SHLQ $1, SI                          // SI = byte offset (float16 = 2 bytes)
 	LEAQ (R8)(SI*1), SI                  // SI = lhsPtr
 
 	// idxRHS = rhsColIdx * contractingLen
 	MOVQ BX, DI
 	IMULQ R12, DI
-	SHLQ $2, DI
+	SHLQ $1, DI                          // DI = byte offset (float16 = 2 bytes)
 	LEAQ (R9)(DI*1), DI                  // DI = rhsPtr
 
 	// 3. K-loop with 2-stage ping-pong pipeline (unroll by 2)
 	MOVQ R12, CX                         // CX = contractingLen
 	TESTQ CX, CX
-	JLE store_output
+	JLE store_output_f16
 
 	SHRQ $1, CX                          // CX = pairs = contractingLen / 2
-	JZ k_odd                             // If 0 pairs (contractingLen == 1), do odd iteration
+	JZ k_odd_f16                         // If 0 pairs (contractingLen == 1), do odd iteration
 
 	// Prime Buffer A for Step 0 outside the loop
-	VMOVDQU32 (DI), Z16
-	VMOVDQU32 64(DI), Z17
-	VMOVDQU32 128(DI), Z18
-	VMOVDQU32 192(DI), Z19
-	VBROADCASTSS (SI), Z20
-	VBROADCASTSS 4(SI), Z21
-	VBROADCASTSS 8(SI), Z22
-	VBROADCASTSS 12(SI), Z23
-	ADDQ $16, SI                         // Advance past Step 0 (points to Step 1 = Buffer B)
-	ADDQ $256, DI
+	// 4 RHS vectors (64 float16s = 128 bytes) converted to float32:
+	VCVTPH2PS (DI), Z16
+	VCVTPH2PS 32(DI), Z17
+	VCVTPH2PS 64(DI), Z18
+	VCVTPH2PS 96(DI), Z19
+
+	// 4 LHS scalars (4 float16s = 8 bytes) converted to float32:
+	VCVTPH2PS (SI), X20
+	VPERMILPS $0x55, X20, X21
+	VPERMILPS $0xAA, X20, X22
+	VPERMILPS $0xFF, X20, X23
+	VBROADCASTSS X20, Z20
+	VBROADCASTSS X21, Z21
+	VBROADCASTSS X22, Z22
+	VBROADCASTSS X23, Z23
+
+	ADDQ $8, SI                          // Advance past Step 0 (4 float16s = 8 bytes)
+	ADDQ $128, DI                        // Advance past Step 0 (64 float16s = 128 bytes)
 
 	DECQ CX                              // CX = pairs - 1
-	JZ k_last_pair                       // If only 1 pair total, skip k_pair_loop directly to k_last_pair
+	JZ k_last_pair_f16                   // If only 1 pair total, skip loop directly to k_last_pair_f16
 
 	PCALIGN $64
-k_pair_loop:
+k_pair_loop_f16:
 	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads (Z24..Z27)
 	VFMADD231PS Z16, Z20, Z0
-	VMOVDQU32 (DI), Z24
+	VCVTPH2PS (DI), Z24
 	VFMADD231PS Z17, Z20, Z1
-	VMOVDQU32 64(DI), Z25
+	VCVTPH2PS 32(DI), Z25
 	VFMADD231PS Z18, Z20, Z2
-	VMOVDQU32 128(DI), Z26
+	VCVTPH2PS 64(DI), Z26
 	VFMADD231PS Z19, Z20, Z3
-	VMOVDQU32 192(DI), Z27
+	VCVTPH2PS 96(DI), Z27
 
 	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads (Z28..Z31)
 	VFMADD231PS Z16, Z21, Z4
-	VBROADCASTSS (SI), Z28
+	VCVTPH2PS (SI), X28
+	VPERMILPS $0x55, X28, X29
 	VFMADD231PS Z17, Z21, Z5
-	VBROADCASTSS 4(SI), Z29
+	VPERMILPS $0xAA, X28, X30
+	VPERMILPS $0xFF, X28, X31
 	VFMADD231PS Z18, Z21, Z6
-	VBROADCASTSS 8(SI), Z30
+	VBROADCASTSS X28, Z28
+	VBROADCASTSS X29, Z29
+	VBROADCASTSS X30, Z30
+	VBROADCASTSS X31, Z31
 	VFMADD231PS Z19, Z21, Z7
-	VBROADCASTSS 12(SI), Z31
 
-	ADDQ $16, SI                         // Advance past Step B
-	ADDQ $256, DI
-
-	// Step A: Rows 2-3 pure FMAs (provides 4-cycle runway for Buffer B loads to settle)
-	VFMADD231PS Z16, Z22, Z8
-	VFMADD231PS Z17, Z22, Z9
-	VFMADD231PS Z18, Z22, Z10
-	VFMADD231PS Z19, Z22, Z11
-
-	VFMADD231PS Z16, Z23, Z12
-	VFMADD231PS Z17, Z23, Z13
-	VFMADD231PS Z18, Z23, Z14
-	VFMADD231PS Z19, Z23, Z15
-
-	// Step B: Row 0 FMAs interleaved with next-iter Buffer A RHS loads (Z16..Z19)
-	VFMADD231PS Z24, Z28, Z0
-	VMOVDQU32 (DI), Z16
-	VFMADD231PS Z25, Z28, Z1
-	VMOVDQU32 64(DI), Z17
-	VFMADD231PS Z26, Z28, Z2
-	VMOVDQU32 128(DI), Z18
-	VFMADD231PS Z27, Z28, Z3
-	VMOVDQU32 192(DI), Z19
-
-	// Step B: Row 1 FMAs interleaved with next-iter Buffer A LHS loads (Z20..Z23)
-	VFMADD231PS Z24, Z29, Z4
-	VBROADCASTSS (SI), Z20
-	VFMADD231PS Z25, Z29, Z5
-	VBROADCASTSS 4(SI), Z21
-	VFMADD231PS Z26, Z29, Z6
-	VBROADCASTSS 8(SI), Z22
-	VFMADD231PS Z27, Z29, Z7
-	VBROADCASTSS 12(SI), Z23
-
-	ADDQ $16, SI                         // Advance past Step A of next iter
-	ADDQ $256, DI
-
-	// Step B: Rows 2-3 pure FMAs (provides 4-cycle runway for Buffer A loads to settle)
-	VFMADD231PS Z24, Z30, Z8
-	VFMADD231PS Z25, Z30, Z9
-	VFMADD231PS Z26, Z30, Z10
-	VFMADD231PS Z27, Z30, Z11
-
-	VFMADD231PS Z24, Z31, Z12
-	VFMADD231PS Z25, Z31, Z13
-	VFMADD231PS Z26, Z31, Z14
-	VFMADD231PS Z27, Z31, Z15
-
-	DECQ CX
-	JNZ k_pair_loop
-
-k_last_pair:
-	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads (Z24..Z27)
-	VFMADD231PS Z16, Z20, Z0
-	VMOVDQU32 (DI), Z24
-	VFMADD231PS Z17, Z20, Z1
-	VMOVDQU32 64(DI), Z25
-	VFMADD231PS Z18, Z20, Z2
-	VMOVDQU32 128(DI), Z26
-	VFMADD231PS Z19, Z20, Z3
-	VMOVDQU32 192(DI), Z27
-
-	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads (Z28..Z31)
-	VFMADD231PS Z16, Z21, Z4
-	VBROADCASTSS (SI), Z28
-	VFMADD231PS Z17, Z21, Z5
-	VBROADCASTSS 4(SI), Z29
-	VFMADD231PS Z18, Z21, Z6
-	VBROADCASTSS 8(SI), Z30
-	VFMADD231PS Z19, Z21, Z7
-	VBROADCASTSS 12(SI), Z31
-
-	ADDQ $16, SI
-	ADDQ $256, DI
+	ADDQ $8, SI                          // Advance past Step B
+	ADDQ $128, DI
 
 	// Step A: Rows 2-3 pure FMAs
 	VFMADD231PS Z16, Z22, Z8
@@ -194,7 +135,87 @@ k_last_pair:
 	VFMADD231PS Z18, Z23, Z14
 	VFMADD231PS Z19, Z23, Z15
 
-	// Step B: 16 FMAs using Buffer B (NO loads for next iter to prevent OOB)
+	// Step B: Row 0 FMAs interleaved with next-iter Buffer A RHS loads (Z16..Z19)
+	VFMADD231PS Z24, Z28, Z0
+	VCVTPH2PS (DI), Z16
+	VFMADD231PS Z25, Z28, Z1
+	VCVTPH2PS 32(DI), Z17
+	VFMADD231PS Z26, Z28, Z2
+	VCVTPH2PS 64(DI), Z18
+	VFMADD231PS Z27, Z28, Z3
+	VCVTPH2PS 96(DI), Z19
+
+	// Step B: Row 1 FMAs interleaved with next-iter Buffer A LHS loads (Z20..Z23)
+	VFMADD231PS Z24, Z29, Z4
+	VCVTPH2PS (SI), X20
+	VPERMILPS $0x55, X20, X21
+	VFMADD231PS Z25, Z29, Z5
+	VPERMILPS $0xAA, X20, X22
+	VPERMILPS $0xFF, X20, X23
+	VFMADD231PS Z26, Z29, Z6
+	VBROADCASTSS X20, Z20
+	VBROADCASTSS X21, Z21
+	VBROADCASTSS X22, Z22
+	VBROADCASTSS X23, Z23
+	VFMADD231PS Z27, Z29, Z7
+
+	ADDQ $8, SI                          // Advance past Step A of next iter
+	ADDQ $128, DI
+
+	// Step B: Rows 2-3 pure FMAs
+	VFMADD231PS Z24, Z30, Z8
+	VFMADD231PS Z25, Z30, Z9
+	VFMADD231PS Z26, Z30, Z10
+	VFMADD231PS Z27, Z30, Z11
+
+	VFMADD231PS Z24, Z31, Z12
+	VFMADD231PS Z25, Z31, Z13
+	VFMADD231PS Z26, Z31, Z14
+	VFMADD231PS Z27, Z31, Z15
+
+	DECQ CX
+	JNZ k_pair_loop_f16
+
+k_last_pair_f16:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads
+	VFMADD231PS Z16, Z20, Z0
+	VCVTPH2PS (DI), Z24
+	VFMADD231PS Z17, Z20, Z1
+	VCVTPH2PS 32(DI), Z25
+	VFMADD231PS Z18, Z20, Z2
+	VCVTPH2PS 64(DI), Z26
+	VFMADD231PS Z19, Z20, Z3
+	VCVTPH2PS 96(DI), Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads
+	VFMADD231PS Z16, Z21, Z4
+	VCVTPH2PS (SI), X28
+	VPERMILPS $0x55, X28, X29
+	VFMADD231PS Z17, Z21, Z5
+	VPERMILPS $0xAA, X28, X30
+	VPERMILPS $0xFF, X28, X31
+	VFMADD231PS Z18, Z21, Z6
+	VBROADCASTSS X28, Z28
+	VBROADCASTSS X29, Z29
+	VBROADCASTSS X30, Z30
+	VBROADCASTSS X31, Z31
+	VFMADD231PS Z19, Z21, Z7
+
+	ADDQ $8, SI
+	ADDQ $128, DI
+
+	// Step A: Rows 2-3 pure FMAs
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+	// Step B: 16 FMAs using Buffer B (NO loads)
 	VFMADD231PS Z24, Z28, Z0
 	VFMADD231PS Z25, Z28, Z1
 	VFMADD231PS Z26, Z28, Z2
@@ -215,49 +236,56 @@ k_last_pair:
 	VFMADD231PS Z26, Z31, Z14
 	VFMADD231PS Z27, Z31, Z15
 
-k_odd:
-	// Handle remaining odd iteration if contractingLen % 2 != 0
+k_odd_f16:
 	TESTQ $1, R12
-	JZ store_output
+	JZ store_output_f16
 
-	VMOVDQU32 (DI), Z16
-	VMOVDQU32 64(DI), Z17
-	VMOVDQU32 128(DI), Z18
-	VMOVDQU32 192(DI), Z19
+	VCVTPH2PS (DI), Z16
+	VCVTPH2PS 32(DI), Z17
+	VCVTPH2PS 64(DI), Z18
+	VCVTPH2PS 96(DI), Z19
 
-	VBROADCASTSS (SI), Z20
+	VCVTPH2PS (SI), X20
+	VPERMILPS $0x55, X20, X21
+	VPERMILPS $0xAA, X20, X22
+	VPERMILPS $0xFF, X20, X23
+	VBROADCASTSS X20, Z20
+	VBROADCASTSS X21, Z21
+	VBROADCASTSS X22, Z22
+	VBROADCASTSS X23, Z23
+
+	// Row 0
 	VFMADD231PS Z16, Z20, Z0
 	VFMADD231PS Z17, Z20, Z1
 	VFMADD231PS Z18, Z20, Z2
 	VFMADD231PS Z19, Z20, Z3
 
-	VBROADCASTSS 4(SI), Z21
+	// Row 1
 	VFMADD231PS Z16, Z21, Z4
 	VFMADD231PS Z17, Z21, Z5
 	VFMADD231PS Z18, Z21, Z6
 	VFMADD231PS Z19, Z21, Z7
 
-	VBROADCASTSS 8(SI), Z22
+	// Row 2
 	VFMADD231PS Z16, Z22, Z8
 	VFMADD231PS Z17, Z22, Z9
 	VFMADD231PS Z18, Z22, Z10
 	VFMADD231PS Z19, Z22, Z11
 
-	VBROADCASTSS 12(SI), Z23
+	// Row 3
 	VFMADD231PS Z16, Z23, Z12
 	VFMADD231PS Z17, Z23, Z13
 	VFMADD231PS Z18, Z23, Z14
 	VFMADD231PS Z19, Z23, Z15
 
-store_output:
-	// 4. Write back 16 accumulators to output:
-	// outputBase = outBasePtr + (lhsRowIdx * outputStrideBytes) + (rhsColIdx * 4)
-	MOVQ AX, DX                          // DX = lhsRowIdx
-	IMULQ R11, DX                        // DX = lhsRowIdx * outputStrideBytes
+store_output_f16:
+	// Output is []float32: write back exactly as in Float32
+	MOVQ AX, DX
+	IMULQ R11, DX
 	MOVQ BX, CX
-	SHLQ $2, CX                          // CX = rhsColIdx * 4
+	SHLQ $2, CX
 	ADDQ CX, DX
-	LEAQ (R10)(DX*1), DX                 // DX = outRow0Ptr
+	LEAQ (R10)(DX*1), DX
 
 	// Row 0
 	VMOVDQU32 Z0, (DX)
@@ -266,32 +294,34 @@ store_output:
 	VMOVDQU32 Z3, 192(DX)
 
 	// Row 1
-	ADDQ R11, DX                         // DX = outRow1Ptr
+	ADDQ R11, DX
 	VMOVDQU32 Z4, (DX)
 	VMOVDQU32 Z5, 64(DX)
 	VMOVDQU32 Z6, 128(DX)
 	VMOVDQU32 Z7, 192(DX)
 
 	// Row 2
-	ADDQ R11, DX                         // DX = outRow2Ptr
+	ADDQ R11, DX
 	VMOVDQU32 Z8, (DX)
 	VMOVDQU32 Z9, 64(DX)
 	VMOVDQU32 Z10, 128(DX)
 	VMOVDQU32 Z11, 192(DX)
 
 	// Row 3
-	ADDQ R11, DX                         // DX = outRow3Ptr
+	ADDQ R11, DX
 	VMOVDQU32 Z12, (DX)
 	VMOVDQU32 Z13, 64(DX)
 	VMOVDQU32 Z14, 128(DX)
 	VMOVDQU32 Z15, 192(DX)
 
-	ADDQ $64, BX                         // rhsColIdx += 64
-	JMP loop_rhs
+	ADDQ $64, BX
+	JMP loop_rhs_f16
 
-next_lhs:
-	ADDQ $4, AX                          // lhsRowIdx += 4
-	JMP loop_lhs
+next_lhs_f16:
+	ADDQ $4, AX
+	JMP loop_lhs_f16
 
-done:
+done_f16:
 	RET
+
+

--- a/internal/gobackend/dot/matmul/avx512_large_amd64_float32.s
+++ b/internal/gobackend/dot/matmul/avx512_large_amd64_float32.s
@@ -1,0 +1,298 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+//go:build amd64
+
+#include "textflag.h"
+
+// func avx512LargeKernelFloat32Asm(
+//     packedLHS, packedRHS, packedOutput []float32,
+//     lhsPanelRows, rhsPanelCols int,
+//     contractingLen int,
+//     lhsActiveRows, rhsActiveCols int)
+TEXT ·avx512LargeKernelFloat32Asm(SB), NOSPLIT, $0-112
+	MOVQ packedLHS_base+0(FP), R8        // R8 = lhsBasePtr
+	MOVQ packedRHS_base+24(FP), R9       // R9 = rhsBasePtr
+	MOVQ packedOutput_base+48(FP), R10   // R10 = outBasePtr
+	MOVQ rhsPanelCols+80(FP), R11        // R11 = outputStride (cols)
+	MOVQ contractingLen+88(FP), R12      // R12 = contractingLen (K)
+	MOVQ lhsActiveRows+96(FP), R13       // R13 = lhsActiveRows (M)
+	MOVQ rhsActiveCols+104(FP), R14      // R14 = rhsActiveCols (N)
+
+	SHLQ $2, R11                         // R11 = outputStride in bytes
+
+	XORQ AX, AX                          // AX = lhsRowIdx = 0
+
+loop_lhs:
+	CMPQ AX, R13
+	JGE done
+
+	XORQ BX, BX                          // BX = rhsColIdx = 0
+
+loop_rhs:
+	CMPQ BX, R14
+	JGE next_lhs
+
+	// 1. Zero all 16 accumulators (Z0..Z15)
+	VXORPS Z0, Z0, Z0
+	VXORPS Z1, Z1, Z1
+	VXORPS Z2, Z2, Z2
+	VXORPS Z3, Z3, Z3
+	VXORPS Z4, Z4, Z4
+	VXORPS Z5, Z5, Z5
+	VXORPS Z6, Z6, Z6
+	VXORPS Z7, Z7, Z7
+	VXORPS Z8, Z8, Z8
+	VXORPS Z9, Z9, Z9
+	VXORPS Z10, Z10, Z10
+	VXORPS Z11, Z11, Z11
+	VXORPS Z12, Z12, Z12
+	VXORPS Z13, Z13, Z13
+	VXORPS Z14, Z14, Z14
+	VXORPS Z15, Z15, Z15
+
+	// 2. Compute lhsPtr and rhsPtr
+	// idxLHS = lhsRowIdx * contractingLen
+	MOVQ AX, SI
+	IMULQ R12, SI
+	SHLQ $2, SI
+	LEAQ (R8)(SI*1), SI                  // SI = lhsPtr
+
+	// idxRHS = rhsColIdx * contractingLen
+	MOVQ BX, DI
+	IMULQ R12, DI
+	SHLQ $2, DI
+	LEAQ (R9)(DI*1), DI                  // DI = rhsPtr
+
+	// 3. K-loop with 2-stage ping-pong pipeline (unroll by 2)
+	MOVQ R12, CX                         // CX = contractingLen
+	TESTQ CX, CX
+	JLE store_output
+
+	SHRQ $1, CX                          // CX = pairs = contractingLen / 2
+	JZ k_odd                             // If 0 pairs (contractingLen == 1), do odd iteration
+
+	// Prime Buffer A for Step 0 outside the loop
+	VMOVDQU32 (DI), Z16
+	VMOVDQU32 64(DI), Z17
+	VMOVDQU32 128(DI), Z18
+	VMOVDQU32 192(DI), Z19
+	VBROADCASTSS (SI), Z20
+	VBROADCASTSS 4(SI), Z21
+	VBROADCASTSS 8(SI), Z22
+	VBROADCASTSS 12(SI), Z23
+	ADDQ $16, SI                         // Advance past Step 0 (points to Step 1 = Buffer B)
+	ADDQ $256, DI
+
+	DECQ CX                              // CX = pairs - 1
+	JZ k_last_pair                       // If only 1 pair total, skip k_pair_loop directly to k_last_pair
+
+	PCALIGN $64
+k_pair_loop:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads (Z24..Z27)
+	VFMADD231PS Z16, Z20, Z0
+	VMOVDQU32 (DI), Z24
+	VFMADD231PS Z17, Z20, Z1
+	VMOVDQU32 64(DI), Z25
+	VFMADD231PS Z18, Z20, Z2
+	VMOVDQU32 128(DI), Z26
+	VFMADD231PS Z19, Z20, Z3
+	VMOVDQU32 192(DI), Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads (Z28..Z31)
+	VFMADD231PS Z16, Z21, Z4
+	VBROADCASTSS (SI), Z28
+	VFMADD231PS Z17, Z21, Z5
+	VBROADCASTSS 4(SI), Z29
+	VFMADD231PS Z18, Z21, Z6
+	VBROADCASTSS 8(SI), Z30
+	VFMADD231PS Z19, Z21, Z7
+	VBROADCASTSS 12(SI), Z31
+
+	ADDQ $16, SI                         // Advance past Step B
+	ADDQ $256, DI
+
+	// Step A: Rows 2-3 pure FMAs (provides 4-cycle runway for Buffer B loads to settle)
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+	// Step B: Row 0 FMAs interleaved with next-iter Buffer A RHS loads (Z16..Z19)
+	VFMADD231PS Z24, Z28, Z0
+	VMOVDQU32 (DI), Z16
+	VFMADD231PS Z25, Z28, Z1
+	VMOVDQU32 64(DI), Z17
+	VFMADD231PS Z26, Z28, Z2
+	VMOVDQU32 128(DI), Z18
+	VFMADD231PS Z27, Z28, Z3
+	VMOVDQU32 192(DI), Z19
+
+	// Step B: Row 1 FMAs interleaved with next-iter Buffer A LHS loads (Z20..Z23)
+	VFMADD231PS Z24, Z29, Z4
+	VBROADCASTSS (SI), Z20
+	VFMADD231PS Z25, Z29, Z5
+	VBROADCASTSS 4(SI), Z21
+	VFMADD231PS Z26, Z29, Z6
+	VBROADCASTSS 8(SI), Z22
+	VFMADD231PS Z27, Z29, Z7
+	VBROADCASTSS 12(SI), Z23
+
+	ADDQ $16, SI                         // Advance past Step A of next iter
+	ADDQ $256, DI
+
+	// Step B: Rows 2-3 pure FMAs (provides 4-cycle runway for Buffer A loads to settle)
+	VFMADD231PS Z24, Z30, Z8
+	VFMADD231PS Z25, Z30, Z9
+	VFMADD231PS Z26, Z30, Z10
+	VFMADD231PS Z27, Z30, Z11
+
+	VFMADD231PS Z24, Z31, Z12
+	VFMADD231PS Z25, Z31, Z13
+	VFMADD231PS Z26, Z31, Z14
+	VFMADD231PS Z27, Z31, Z15
+
+	DECQ CX
+	JNZ k_pair_loop
+
+k_last_pair:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads (Z24..Z27)
+	VFMADD231PS Z16, Z20, Z0
+	VMOVDQU32 (DI), Z24
+	VFMADD231PS Z17, Z20, Z1
+	VMOVDQU32 64(DI), Z25
+	VFMADD231PS Z18, Z20, Z2
+	VMOVDQU32 128(DI), Z26
+	VFMADD231PS Z19, Z20, Z3
+	VMOVDQU32 192(DI), Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads (Z28..Z31)
+	VFMADD231PS Z16, Z21, Z4
+	VBROADCASTSS (SI), Z28
+	VFMADD231PS Z17, Z21, Z5
+	VBROADCASTSS 4(SI), Z29
+	VFMADD231PS Z18, Z21, Z6
+	VBROADCASTSS 8(SI), Z30
+	VFMADD231PS Z19, Z21, Z7
+	VBROADCASTSS 12(SI), Z31
+
+	ADDQ $16, SI
+	ADDQ $256, DI
+
+	// Step A: Rows 2-3 pure FMAs
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+	// Step B: 16 FMAs using Buffer B (NO loads for next iter to prevent OOB)
+	VFMADD231PS Z24, Z28, Z0
+	VFMADD231PS Z25, Z28, Z1
+	VFMADD231PS Z26, Z28, Z2
+	VFMADD231PS Z27, Z28, Z3
+
+	VFMADD231PS Z24, Z29, Z4
+	VFMADD231PS Z25, Z29, Z5
+	VFMADD231PS Z26, Z29, Z6
+	VFMADD231PS Z27, Z29, Z7
+
+	VFMADD231PS Z24, Z30, Z8
+	VFMADD231PS Z25, Z30, Z9
+	VFMADD231PS Z26, Z30, Z10
+	VFMADD231PS Z27, Z30, Z11
+
+	VFMADD231PS Z24, Z31, Z12
+	VFMADD231PS Z25, Z31, Z13
+	VFMADD231PS Z26, Z31, Z14
+	VFMADD231PS Z27, Z31, Z15
+
+k_odd:
+	// Handle remaining odd iteration if contractingLen % 2 != 0
+	TESTQ $1, R12
+	JZ store_output
+
+	VMOVDQU32 (DI), Z16
+	VMOVDQU32 64(DI), Z17
+	VMOVDQU32 128(DI), Z18
+	VMOVDQU32 192(DI), Z19
+
+	VBROADCASTSS (SI), Z20
+	VFMADD231PS Z16, Z20, Z0
+	VFMADD231PS Z17, Z20, Z1
+	VFMADD231PS Z18, Z20, Z2
+	VFMADD231PS Z19, Z20, Z3
+
+	VBROADCASTSS 4(SI), Z21
+	VFMADD231PS Z16, Z21, Z4
+	VFMADD231PS Z17, Z21, Z5
+	VFMADD231PS Z18, Z21, Z6
+	VFMADD231PS Z19, Z21, Z7
+
+	VBROADCASTSS 8(SI), Z22
+	VFMADD231PS Z16, Z22, Z8
+	VFMADD231PS Z17, Z22, Z9
+	VFMADD231PS Z18, Z22, Z10
+	VFMADD231PS Z19, Z22, Z11
+
+	VBROADCASTSS 12(SI), Z23
+	VFMADD231PS Z16, Z23, Z12
+	VFMADD231PS Z17, Z23, Z13
+	VFMADD231PS Z18, Z23, Z14
+	VFMADD231PS Z19, Z23, Z15
+
+store_output:
+	// 4. Write back 16 accumulators to output:
+	// outputBase = outBasePtr + (lhsRowIdx * outputStrideBytes) + (rhsColIdx * 4)
+	MOVQ AX, DX                          // DX = lhsRowIdx
+	IMULQ R11, DX                        // DX = lhsRowIdx * outputStrideBytes
+	MOVQ BX, CX
+	SHLQ $2, CX                          // CX = rhsColIdx * 4
+	ADDQ CX, DX
+	LEAQ (R10)(DX*1), DX                 // DX = outRow0Ptr
+
+	// Row 0
+	VMOVDQU32 Z0, (DX)
+	VMOVDQU32 Z1, 64(DX)
+	VMOVDQU32 Z2, 128(DX)
+	VMOVDQU32 Z3, 192(DX)
+
+	// Row 1
+	ADDQ R11, DX                         // DX = outRow1Ptr
+	VMOVDQU32 Z4, (DX)
+	VMOVDQU32 Z5, 64(DX)
+	VMOVDQU32 Z6, 128(DX)
+	VMOVDQU32 Z7, 192(DX)
+
+	// Row 2
+	ADDQ R11, DX                         // DX = outRow2Ptr
+	VMOVDQU32 Z8, (DX)
+	VMOVDQU32 Z9, 64(DX)
+	VMOVDQU32 Z10, 128(DX)
+	VMOVDQU32 Z11, 192(DX)
+
+	// Row 3
+	ADDQ R11, DX                         // DX = outRow3Ptr
+	VMOVDQU32 Z12, (DX)
+	VMOVDQU32 Z13, 64(DX)
+	VMOVDQU32 Z14, 128(DX)
+	VMOVDQU32 Z15, 192(DX)
+
+	ADDQ $64, BX                         // rhsColIdx += 64
+	JMP loop_rhs
+
+next_lhs:
+	ADDQ $4, AX                          // lhsRowIdx += 4
+	JMP loop_lhs
+
+done:
+	RET
+

--- a/internal/gobackend/dot/matmul/avx512_large_amd64_float64.s
+++ b/internal/gobackend/dot/matmul/avx512_large_amd64_float64.s
@@ -1,0 +1,304 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+//go:build amd64
+
+#include "textflag.h"
+
+// func avx512LargeKernelFloat64Asm(
+//     packedLHS, packedRHS, packedOutput []float64,
+//     lhsPanelRows, rhsPanelCols int,
+//     contractingLen int,
+//     lhsActiveRows, rhsActiveCols int)
+TEXT ·avx512LargeKernelFloat64Asm(SB), NOSPLIT, $0-112
+	MOVQ packedLHS_base+0(FP), R8        // R8 = lhsBasePtr (float64 = 8 bytes)
+	MOVQ packedRHS_base+24(FP), R9       // R9 = rhsBasePtr (float64 = 8 bytes)
+	MOVQ packedOutput_base+48(FP), R10   // R10 = outBasePtr (float64 = 8 bytes)
+	MOVQ rhsPanelCols+80(FP), R11        // R11 = outputStride (cols)
+	MOVQ contractingLen+88(FP), R12      // R12 = contractingLen (K)
+	MOVQ lhsActiveRows+96(FP), R13       // R13 = lhsActiveRows (M)
+	MOVQ rhsActiveCols+104(FP), R14      // R14 = rhsActiveCols (N)
+
+	SHLQ $3, R11                         // R11 = outputStride in bytes (float64 = 8 bytes)
+
+	XORQ AX, AX                          // AX = lhsRowIdx = 0
+
+loop_lhs_f64:
+	CMPQ AX, R13
+	JGE done_f64
+
+	XORQ BX, BX                          // BX = rhsColIdx = 0
+
+loop_rhs_f64:
+	CMPQ BX, R14
+	JGE next_lhs_f64
+
+	// 1. Zero all 16 accumulators (Z0..Z15)
+	VXORPD Z0, Z0, Z0
+	VXORPD Z1, Z1, Z1
+	VXORPD Z2, Z2, Z2
+	VXORPD Z3, Z3, Z3
+	VXORPD Z4, Z4, Z4
+	VXORPD Z5, Z5, Z5
+	VXORPD Z6, Z6, Z6
+	VXORPD Z7, Z7, Z7
+	VXORPD Z8, Z8, Z8
+	VXORPD Z9, Z9, Z9
+	VXORPD Z10, Z10, Z10
+	VXORPD Z11, Z11, Z11
+	VXORPD Z12, Z12, Z12
+	VXORPD Z13, Z13, Z13
+	VXORPD Z14, Z14, Z14
+	VXORPD Z15, Z15, Z15
+
+	// 2. Compute lhsPtr and rhsPtr (elements are float64 = 8 bytes)
+	// idxLHS = lhsRowIdx * contractingLen
+	MOVQ AX, SI
+	IMULQ R12, SI
+	SHLQ $3, SI                          // SI = byte offset (float64 = 8 bytes)
+	LEAQ (R8)(SI*1), SI                  // SI = lhsPtr
+
+	// idxRHS = rhsColIdx * contractingLen
+	MOVQ BX, DI
+	IMULQ R12, DI
+	SHLQ $3, DI                          // DI = byte offset (float64 = 8 bytes)
+	LEAQ (R9)(DI*1), DI                  // DI = rhsPtr
+
+	// 3. K-loop with 2-stage ping-pong pipeline (unroll by 2)
+	MOVQ R12, CX                         // CX = contractingLen
+	TESTQ CX, CX
+	JLE store_output_f64
+
+	SHRQ $1, CX                          // CX = pairs = contractingLen / 2
+	JZ k_odd_f64                         // If 0 pairs (contractingLen == 1), do odd iteration
+
+	// Prime Buffer A for Step 0 outside the loop
+	// 4 RHS vectors (32 float64s = 256 bytes):
+	VMOVDQU64 (DI), Z16
+	VMOVDQU64 64(DI), Z17
+	VMOVDQU64 128(DI), Z18
+	VMOVDQU64 192(DI), Z19
+
+	// 4 LHS scalars (4 float64s = 32 bytes):
+	VBROADCASTSD (SI), Z20
+	VBROADCASTSD 8(SI), Z21
+	VBROADCASTSD 16(SI), Z22
+	VBROADCASTSD 24(SI), Z23
+
+	ADDQ $32, SI                         // Advance past Step 0 (4 float64s = 32 bytes)
+	ADDQ $256, DI                        // Advance past Step 0 (32 float64s = 256 bytes)
+
+	DECQ CX                              // CX = pairs - 1
+	JZ k_last_pair_f64                   // If only 1 pair total, skip loop directly to k_last_pair_f64
+
+	PCALIGN $64
+k_pair_loop_f64:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads (Z24..Z27)
+	VFMADD231PD Z16, Z20, Z0
+	VMOVDQU64 (DI), Z24
+	VFMADD231PD Z17, Z20, Z1
+	VMOVDQU64 64(DI), Z25
+	VFMADD231PD Z18, Z20, Z2
+	VMOVDQU64 128(DI), Z26
+	VFMADD231PD Z19, Z20, Z3
+	VMOVDQU64 192(DI), Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads (Z28..Z31)
+	VFMADD231PD Z16, Z21, Z4
+	VBROADCASTSD (SI), Z28
+	VFMADD231PD Z17, Z21, Z5
+	VBROADCASTSD 8(SI), Z29
+	VFMADD231PD Z18, Z21, Z6
+	VBROADCASTSD 16(SI), Z30
+	VFMADD231PD Z19, Z21, Z7
+	VBROADCASTSD 24(SI), Z31
+
+	ADDQ $32, SI                         // Advance past Step B
+	ADDQ $256, DI
+
+	// Step A: Rows 2-3 pure FMAs
+	VFMADD231PD Z16, Z22, Z8
+	VFMADD231PD Z17, Z22, Z9
+	VFMADD231PD Z18, Z22, Z10
+	VFMADD231PD Z19, Z22, Z11
+
+	VFMADD231PD Z16, Z23, Z12
+	VFMADD231PD Z17, Z23, Z13
+	VFMADD231PD Z18, Z23, Z14
+	VFMADD231PD Z19, Z23, Z15
+
+	// Step B: Row 0 FMAs interleaved with next-iter Buffer A RHS loads (Z16..Z19)
+	VFMADD231PD Z24, Z28, Z0
+	VMOVDQU64 (DI), Z16
+	VFMADD231PD Z25, Z28, Z1
+	VMOVDQU64 64(DI), Z17
+	VFMADD231PD Z26, Z28, Z2
+	VMOVDQU64 128(DI), Z18
+	VFMADD231PD Z27, Z28, Z3
+	VMOVDQU64 192(DI), Z19
+
+	// Step B: Row 1 FMAs interleaved with next-iter Buffer A LHS loads (Z20..Z23)
+	VFMADD231PD Z24, Z29, Z4
+	VBROADCASTSD (SI), Z20
+	VFMADD231PD Z25, Z29, Z5
+	VBROADCASTSD 8(SI), Z21
+	VFMADD231PD Z26, Z29, Z6
+	VBROADCASTSD 16(SI), Z22
+	VFMADD231PD Z27, Z29, Z7
+	VBROADCASTSD 24(SI), Z23
+
+	ADDQ $32, SI                         // Advance past Step A of next iter
+	ADDQ $256, DI
+
+	// Step B: Rows 2-3 pure FMAs
+	VFMADD231PD Z24, Z30, Z8
+	VFMADD231PD Z25, Z30, Z9
+	VFMADD231PD Z26, Z30, Z10
+	VFMADD231PD Z27, Z30, Z11
+
+	VFMADD231PD Z24, Z31, Z12
+	VFMADD231PD Z25, Z31, Z13
+	VFMADD231PD Z26, Z31, Z14
+	VFMADD231PD Z27, Z31, Z15
+
+	DECQ CX
+	JNZ k_pair_loop_f64
+
+k_last_pair_f64:
+	// Step A: Row 0 FMAs interleaved with Buffer B RHS loads
+	VFMADD231PD Z16, Z20, Z0
+	VMOVDQU64 (DI), Z24
+	VFMADD231PD Z17, Z20, Z1
+	VMOVDQU64 64(DI), Z25
+	VFMADD231PD Z18, Z20, Z2
+	VMOVDQU64 128(DI), Z26
+	VFMADD231PD Z19, Z20, Z3
+	VMOVDQU64 192(DI), Z27
+
+	// Step A: Row 1 FMAs interleaved with Buffer B LHS loads
+	VFMADD231PD Z16, Z21, Z4
+	VBROADCASTSD (SI), Z28
+	VFMADD231PD Z17, Z21, Z5
+	VBROADCASTSD 8(SI), Z29
+	VFMADD231PD Z18, Z21, Z6
+	VBROADCASTSD 16(SI), Z30
+	VFMADD231PD Z19, Z21, Z7
+	VBROADCASTSD 24(SI), Z31
+
+	ADDQ $32, SI
+	ADDQ $256, DI
+
+	// Step A: Rows 2-3 pure FMAs
+	VFMADD231PD Z16, Z22, Z8
+	VFMADD231PD Z17, Z22, Z9
+	VFMADD231PD Z18, Z22, Z10
+	VFMADD231PD Z19, Z22, Z11
+
+	VFMADD231PD Z16, Z23, Z12
+	VFMADD231PD Z17, Z23, Z13
+	VFMADD231PD Z18, Z23, Z14
+	VFMADD231PD Z19, Z23, Z15
+
+	// Step B: 16 FMAs using Buffer B (NO loads)
+	VFMADD231PD Z24, Z28, Z0
+	VFMADD231PD Z25, Z28, Z1
+	VFMADD231PD Z26, Z28, Z2
+	VFMADD231PD Z27, Z28, Z3
+
+	VFMADD231PD Z24, Z29, Z4
+	VFMADD231PD Z25, Z29, Z5
+	VFMADD231PD Z26, Z29, Z6
+	VFMADD231PD Z27, Z29, Z7
+
+	VFMADD231PD Z24, Z30, Z8
+	VFMADD231PD Z25, Z30, Z9
+	VFMADD231PD Z26, Z30, Z10
+	VFMADD231PD Z27, Z30, Z11
+
+	VFMADD231PD Z24, Z31, Z12
+	VFMADD231PD Z25, Z31, Z13
+	VFMADD231PD Z26, Z31, Z14
+	VFMADD231PD Z27, Z31, Z15
+
+k_odd_f64:
+	TESTQ $1, R12
+	JZ store_output_f64
+
+	VMOVDQU64 (DI), Z16
+	VMOVDQU64 64(DI), Z17
+	VMOVDQU64 128(DI), Z18
+	VMOVDQU64 192(DI), Z19
+
+	VBROADCASTSD (SI), Z20
+	VBROADCASTSD 8(SI), Z21
+	VBROADCASTSD 16(SI), Z22
+	VBROADCASTSD 24(SI), Z23
+
+	// Row 0
+	VFMADD231PD Z16, Z20, Z0
+	VFMADD231PD Z17, Z20, Z1
+	VFMADD231PD Z18, Z20, Z2
+	VFMADD231PD Z19, Z20, Z3
+
+	// Row 1
+	VFMADD231PD Z16, Z21, Z4
+	VFMADD231PD Z17, Z21, Z5
+	VFMADD231PD Z18, Z21, Z6
+	VFMADD231PD Z19, Z21, Z7
+
+	// Row 2
+	VFMADD231PD Z16, Z22, Z8
+	VFMADD231PD Z17, Z22, Z9
+	VFMADD231PD Z18, Z22, Z10
+	VFMADD231PD Z19, Z22, Z11
+
+	// Row 3
+	VFMADD231PD Z16, Z23, Z12
+	VFMADD231PD Z17, Z23, Z13
+	VFMADD231PD Z18, Z23, Z14
+	VFMADD231PD Z19, Z23, Z15
+
+store_output_f64:
+	// Output is []float64: write back
+	MOVQ AX, DX
+	IMULQ R11, DX
+	MOVQ BX, CX
+	SHLQ $3, CX                          // float64 = 8 bytes
+	ADDQ CX, DX
+	LEAQ (R10)(DX*1), DX
+
+	// Row 0
+	VMOVDQU64 Z0, (DX)
+	VMOVDQU64 Z1, 64(DX)
+	VMOVDQU64 Z2, 128(DX)
+	VMOVDQU64 Z3, 192(DX)
+
+	// Row 1
+	ADDQ R11, DX
+	VMOVDQU64 Z4, (DX)
+	VMOVDQU64 Z5, 64(DX)
+	VMOVDQU64 Z6, 128(DX)
+	VMOVDQU64 Z7, 192(DX)
+
+	// Row 2
+	ADDQ R11, DX
+	VMOVDQU64 Z8, (DX)
+	VMOVDQU64 Z9, 64(DX)
+	VMOVDQU64 Z10, 128(DX)
+	VMOVDQU64 Z11, 192(DX)
+
+	// Row 3
+	ADDQ R11, DX
+	VMOVDQU64 Z12, (DX)
+	VMOVDQU64 Z13, 64(DX)
+	VMOVDQU64 Z14, 128(DX)
+	VMOVDQU64 Z15, 192(DX)
+
+	ADDQ $32, BX                         // rhsColIdx += 32
+	JMP loop_rhs_f64
+
+next_lhs_f64:
+	ADDQ $4, AX                          // lhsRowIdx += 4
+	JMP loop_lhs_f64
+
+done_f64:
+	RET

--- a/internal/gobackend/dot/matmul/gen_avx2_large_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_bf16.go
@@ -9,6 +9,7 @@
 package matmul
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -251,7 +252,17 @@ func avx2LargeKernelBFloat16( //alt:bf16
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
+	defer func() {
+		runtime.KeepAlive(packedLHS)
+		runtime.KeepAlive(packedRHS)
+		runtime.KeepAlive(packedOutput)
+	}()
 	_ = lhsPanelRows // Not needed.
+
+	// BCE hints
+	_ = packedLHS[contractingLen*lhsActiveRows-1]
+	_ = packedRHS[contractingLen*rhsActiveCols-1]
+	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These must match params.LHSL1KernelRows and params.RHSL1KernelCols.

--- a/internal/gobackend/dot/matmul/gen_avx2_large_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_bf16.go
@@ -9,7 +9,6 @@
 package matmul
 
 import (
-	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -233,6 +232,11 @@ func avx2LargeMatrixSliceBFloat16( //alt:bf16
 // avx2LargeKernelFloat32 implements a kernel of the matrix multiplication for
 // a lhs and rhs packed panels into an intermediate output panel.
 //
+// Memory safety note: We use raw unsafe pointers to avoid bounds-checking (BCE) overhead
+// in the inner loops. Because the caller (parent function on the stack) owns and holds references
+// to packedLHS, packedRHS, and packedOutput throughout execution, they remain reachable and
+// do not need runtime.KeepAlive() calls at the end.
+//
 //alt:f32 func avx2LargeKernelFloat32(
 func avx2LargeKernelBFloat16( //alt:bf16
 	//alt:f16  func avx2LargeKernelFloat16(
@@ -247,17 +251,7 @@ func avx2LargeKernelBFloat16( //alt:bf16
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
-	defer func() {
-		runtime.KeepAlive(packedLHS)
-		runtime.KeepAlive(packedRHS)
-		runtime.KeepAlive(packedOutput)
-	}()
 	_ = lhsPanelRows // Not needed.
-
-	// BCE hints
-	_ = packedLHS[contractingLen*lhsActiveRows-1]
-	_ = packedRHS[contractingLen*rhsActiveCols-1]
-	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These must match params.LHSL1KernelRows and params.RHSL1KernelCols.

--- a/internal/gobackend/dot/matmul/gen_avx2_large_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_f16.go
@@ -9,7 +9,6 @@
 package matmul
 
 import (
-	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -233,6 +232,11 @@ func avx2LargeMatrixSliceFloat16( //alt:f16
 // avx2LargeKernelFloat32 implements a kernel of the matrix multiplication for
 // a lhs and rhs packed panels into an intermediate output panel.
 //
+// Memory safety note: We use raw unsafe pointers to avoid bounds-checking (BCE) overhead
+// in the inner loops. Because the caller (parent function on the stack) owns and holds references
+// to packedLHS, packedRHS, and packedOutput throughout execution, they remain reachable and
+// do not need runtime.KeepAlive() calls at the end.
+//
 //alt:f32 func avx2LargeKernelFloat32(
 //alt:bf16  func avx2LargeKernelBFloat16(
 func avx2LargeKernelFloat16( //alt:f16
@@ -247,17 +251,7 @@ func avx2LargeKernelFloat16( //alt:f16
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
-	defer func() {
-		runtime.KeepAlive(packedLHS)
-		runtime.KeepAlive(packedRHS)
-		runtime.KeepAlive(packedOutput)
-	}()
 	_ = lhsPanelRows // Not needed.
-
-	// BCE hints
-	_ = packedLHS[contractingLen*lhsActiveRows-1]
-	_ = packedRHS[contractingLen*rhsActiveCols-1]
-	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These must match params.LHSL1KernelRows and params.RHSL1KernelCols.

--- a/internal/gobackend/dot/matmul/gen_avx2_large_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_f16.go
@@ -9,6 +9,7 @@
 package matmul
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -251,7 +252,17 @@ func avx2LargeKernelFloat16( //alt:f16
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
+	defer func() {
+		runtime.KeepAlive(packedLHS)
+		runtime.KeepAlive(packedRHS)
+		runtime.KeepAlive(packedOutput)
+	}()
 	_ = lhsPanelRows // Not needed.
+
+	// BCE hints
+	_ = packedLHS[contractingLen*lhsActiveRows-1]
+	_ = packedRHS[contractingLen*rhsActiveCols-1]
+	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These must match params.LHSL1KernelRows and params.RHSL1KernelCols.

--- a/internal/gobackend/dot/matmul/gen_avx2_large_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_f64.go
@@ -9,7 +9,6 @@
 package matmul
 
 import (
-	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -233,6 +232,11 @@ func avx2LargeMatrixSliceFloat64( //alt:f64
 // avx2LargeKernelFloat32 implements a kernel of the matrix multiplication for
 // a lhs and rhs packed panels into an intermediate output panel.
 //
+// Memory safety note: We use raw unsafe pointers to avoid bounds-checking (BCE) overhead
+// in the inner loops. Because the caller (parent function on the stack) owns and holds references
+// to packedLHS, packedRHS, and packedOutput throughout execution, they remain reachable and
+// do not need runtime.KeepAlive() calls at the end.
+//
 //alt:f32 func avx2LargeKernelFloat32(
 //alt:bf16  func avx2LargeKernelBFloat16(
 //alt:f16  func avx2LargeKernelFloat16(
@@ -247,17 +251,7 @@ func avx2LargeKernelFloat64( //alt:f64
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
-	defer func() {
-		runtime.KeepAlive(packedLHS)
-		runtime.KeepAlive(packedRHS)
-		runtime.KeepAlive(packedOutput)
-	}()
 	_ = lhsPanelRows // Not needed.
-
-	// BCE hints
-	_ = packedLHS[contractingLen*lhsActiveRows-1]
-	_ = packedRHS[contractingLen*rhsActiveCols-1]
-	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These must match params.LHSL1KernelRows and params.RHSL1KernelCols.

--- a/internal/gobackend/dot/matmul/gen_avx2_large_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx2_large_f64.go
@@ -9,6 +9,7 @@
 package matmul
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -251,7 +252,17 @@ func avx2LargeKernelFloat64( //alt:f64
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
+	defer func() {
+		runtime.KeepAlive(packedLHS)
+		runtime.KeepAlive(packedRHS)
+		runtime.KeepAlive(packedOutput)
+	}()
 	_ = lhsPanelRows // Not needed.
+
+	// BCE hints
+	_ = packedLHS[contractingLen*lhsActiveRows-1]
+	_ = packedRHS[contractingLen*rhsActiveCols-1]
+	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These must match params.LHSL1KernelRows and params.RHSL1KernelCols.

--- a/internal/gobackend/dot/matmul/gen_avx512_large_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_bf16.go
@@ -185,12 +185,9 @@ func avx512LargeMatrixSliceBFloat16( //alt:bf16
 ) {
 	_ = lhsCrossSize // Not used, rowStart and rowEnd < lhsCrossSize are enough.
 
-	//alt:f32 if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) {
-	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 { //alt:bf16|f16
-		//alt:f64  if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 16 {
-		//alt:f32 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)",
-		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)", //alt:bf16|f16
-			//alt:f64  panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 16 respectively (params=%+v)",
+	if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) { //alt:f32|bf16|f16
+		//alt:f64  if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 16 && params.RHSL1KernelCols != 32) {
+		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)", //alt:f32|bf16|f16|f64
 			params.LHSL1KernelRows, params.RHSL1KernelCols, params))
 	}
 
@@ -214,24 +211,27 @@ func avx512LargeMatrixSliceBFloat16( //alt:bf16
 				lhsPanelHeight := min(params.LHSPanelCrossSize, rowEnd-lhsPanelRowIdx)
 				avx512PackLHSKernelRows4(lhsMatrix, packedLHS, lhsPanelRowIdx, contractingPanelIdx, contractingSize, lhsPanelHeight, contractingPanelWidth, params.LHSL1KernelRows) //alt:f32|bf16|f16|f64
 
-				//alt:f32 if AVX512UseAsm {
-				//alt:f32 avx512LargeKernelFloat32Asm(
-				//alt:f32 packedLHS, packedRHS, packedOutput,
-				//alt:f32 params.LHSPanelCrossSize, params.RHSPanelCrossSize,
-				//alt:f32 contractingPanelWidth,
-				//alt:f32 lhsPanelHeight, rhsPanelWidth,
-				//alt:f32 )
-				//alt:f32 } else {
-				//alt:f32 avx512LargeKernelFloat32(
-				avx512LargeKernelBFloat16( //alt:bf16
-					//alt:f16  avx512LargeKernelFloat16(
-					//alt:f64  avx512LargeKernelFloat64(
-					packedLHS, packedRHS, packedOutput,
-					params.LHSPanelCrossSize, params.RHSPanelCrossSize,
-					contractingPanelWidth,
-					lhsPanelHeight, rhsPanelWidth,
-				) //alt:bf16|f16|f64
-				//alt:f32 }
+				if AVX512UseAsm { //alt:f32|bf16|f16|f64
+					//alt:f32 avx512LargeKernelFloat32Asm(
+					avx512LargeKernelBFloat16Asm( //alt:bf16
+						//alt:f16  avx512LargeKernelFloat16Asm(
+						//alt:f64  avx512LargeKernelFloat64Asm(
+						packedLHS, packedRHS, packedOutput,
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+						contractingPanelWidth,
+						lhsPanelHeight, rhsPanelWidth,
+					)
+				} else { //alt:f32|bf16|f16|f64
+					//alt:f32 avx512LargeKernelFloat32(
+					avx512LargeKernelBFloat16( //alt:bf16
+						//alt:f16  avx512LargeKernelFloat16(
+						//alt:f64  avx512LargeKernelFloat64(
+						packedLHS, packedRHS, packedOutput,
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+						contractingPanelWidth,
+						lhsPanelHeight, rhsPanelWidth,
+					) //alt:bf16|f16|f64
+				} //alt:f32|bf16|f16|f64
 
 				// Accumulate (or write) packedOutput to output.
 				isFirstContractingPanel := contractingPanelIdx == 0

--- a/internal/gobackend/dot/matmul/gen_avx512_large_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_bf16.go
@@ -15,7 +15,6 @@ package matmul
 // - "f16": Implements the MatMul for Float16 -> Float32 dtypes.
 
 import (
-	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -240,6 +239,11 @@ func avx512LargeMatrixSliceBFloat16( //alt:bf16
 // avx512LargeKernelFloat32 implements a kernel of the matrix multiplication for
 // a lhs and rhs packed panels into an intermediate output panel.
 //
+// Memory safety note: We use raw unsafe pointers to avoid bounds-checking (BCE) overhead
+// in the inner loops. Because the caller (parent function on the stack) owns and holds references
+// to packedLHS, packedRHS, and packedOutput throughout execution, they remain reachable and
+// do not need runtime.KeepAlive() calls at the end.
+//
 //alt:f32 func avx512LargeKernelFloat32(
 func avx512LargeKernelBFloat16( //alt:bf16
 	//alt:f16  func avx512LargeKernelFloat16(
@@ -254,17 +258,7 @@ func avx512LargeKernelBFloat16( //alt:bf16
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
-	defer func() {
-		runtime.KeepAlive(packedLHS)
-		runtime.KeepAlive(packedRHS)
-		runtime.KeepAlive(packedOutput)
-	}()
 	_ = lhsPanelRows // Not needed.
-
-	// BCE hints
-	_ = packedLHS[contractingLen*lhsActiveRows-1]
-	_ = packedRHS[contractingLen*rhsActiveCols-1]
-	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These much match params.LHSL1BlockRows and params.LHSL1BlockCols.

--- a/internal/gobackend/dot/matmul/gen_avx512_large_bf16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_bf16.go
@@ -15,6 +15,7 @@ package matmul
 // - "f16": Implements the MatMul for Float16 -> Float32 dtypes.
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -184,9 +185,11 @@ func avx512LargeMatrixSliceBFloat16( //alt:bf16
 ) {
 	_ = lhsCrossSize // Not used, rowStart and rowEnd < lhsCrossSize are enough.
 
-	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 { //alt:f32|bf16|f16
+	//alt:f32 if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) {
+	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 { //alt:bf16|f16
 		//alt:f64  if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 16 {
-		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)", //alt:f32|bf16|f16
+		//alt:f32 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)",
+		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)", //alt:bf16|f16
 			//alt:f64  panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 16 respectively (params=%+v)",
 			params.LHSL1KernelRows, params.RHSL1KernelCols, params))
 	}
@@ -211,6 +214,14 @@ func avx512LargeMatrixSliceBFloat16( //alt:bf16
 				lhsPanelHeight := min(params.LHSPanelCrossSize, rowEnd-lhsPanelRowIdx)
 				avx512PackLHSKernelRows4(lhsMatrix, packedLHS, lhsPanelRowIdx, contractingPanelIdx, contractingSize, lhsPanelHeight, contractingPanelWidth, params.LHSL1KernelRows) //alt:f32|bf16|f16|f64
 
+				//alt:f32 if AVX512UseAsm {
+				//alt:f32 avx512LargeKernelFloat32Asm(
+				//alt:f32 packedLHS, packedRHS, packedOutput,
+				//alt:f32 params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+				//alt:f32 contractingPanelWidth,
+				//alt:f32 lhsPanelHeight, rhsPanelWidth,
+				//alt:f32 )
+				//alt:f32 } else {
 				//alt:f32 avx512LargeKernelFloat32(
 				avx512LargeKernelBFloat16( //alt:bf16
 					//alt:f16  avx512LargeKernelFloat16(
@@ -219,7 +230,8 @@ func avx512LargeMatrixSliceBFloat16( //alt:bf16
 					params.LHSPanelCrossSize, params.RHSPanelCrossSize,
 					contractingPanelWidth,
 					lhsPanelHeight, rhsPanelWidth,
-				)
+				) //alt:bf16|f16|f64
+				//alt:f32 }
 
 				// Accumulate (or write) packedOutput to output.
 				isFirstContractingPanel := contractingPanelIdx == 0
@@ -258,7 +270,17 @@ func avx512LargeKernelBFloat16( //alt:bf16
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
+	defer func() {
+		runtime.KeepAlive(packedLHS)
+		runtime.KeepAlive(packedRHS)
+		runtime.KeepAlive(packedOutput)
+	}()
 	_ = lhsPanelRows // Not needed.
+
+	// BCE hints
+	_ = packedLHS[contractingLen*lhsActiveRows-1]
+	_ = packedRHS[contractingLen*rhsActiveCols-1]
+	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These much match params.LHSL1BlockRows and params.LHSL1BlockCols.

--- a/internal/gobackend/dot/matmul/gen_avx512_large_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_f16.go
@@ -15,6 +15,7 @@ package matmul
 // - "f16": Implements the MatMul for Float16 -> Float32 dtypes.
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -184,9 +185,11 @@ func avx512LargeMatrixSliceFloat16( //alt:f16
 ) {
 	_ = lhsCrossSize // Not used, rowStart and rowEnd < lhsCrossSize are enough.
 
-	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 { //alt:f32|bf16|f16
+	//alt:f32 if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) {
+	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 { //alt:bf16|f16
 		//alt:f64  if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 16 {
-		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)", //alt:f32|bf16|f16
+		//alt:f32 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)",
+		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)", //alt:bf16|f16
 			//alt:f64  panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 16 respectively (params=%+v)",
 			params.LHSL1KernelRows, params.RHSL1KernelCols, params))
 	}
@@ -211,6 +214,14 @@ func avx512LargeMatrixSliceFloat16( //alt:f16
 				lhsPanelHeight := min(params.LHSPanelCrossSize, rowEnd-lhsPanelRowIdx)
 				avx512PackLHSKernelRows4(lhsMatrix, packedLHS, lhsPanelRowIdx, contractingPanelIdx, contractingSize, lhsPanelHeight, contractingPanelWidth, params.LHSL1KernelRows) //alt:f32|bf16|f16|f64
 
+				//alt:f32 if AVX512UseAsm {
+				//alt:f32 avx512LargeKernelFloat32Asm(
+				//alt:f32 packedLHS, packedRHS, packedOutput,
+				//alt:f32 params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+				//alt:f32 contractingPanelWidth,
+				//alt:f32 lhsPanelHeight, rhsPanelWidth,
+				//alt:f32 )
+				//alt:f32 } else {
 				//alt:f32 avx512LargeKernelFloat32(
 				//alt:bf16  avx512LargeKernelBFloat16(
 				avx512LargeKernelFloat16( //alt:f16
@@ -219,7 +230,8 @@ func avx512LargeMatrixSliceFloat16( //alt:f16
 					params.LHSPanelCrossSize, params.RHSPanelCrossSize,
 					contractingPanelWidth,
 					lhsPanelHeight, rhsPanelWidth,
-				)
+				) //alt:bf16|f16|f64
+				//alt:f32 }
 
 				// Accumulate (or write) packedOutput to output.
 				isFirstContractingPanel := contractingPanelIdx == 0
@@ -258,7 +270,17 @@ func avx512LargeKernelFloat16( //alt:f16
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
+	defer func() {
+		runtime.KeepAlive(packedLHS)
+		runtime.KeepAlive(packedRHS)
+		runtime.KeepAlive(packedOutput)
+	}()
 	_ = lhsPanelRows // Not needed.
+
+	// BCE hints
+	_ = packedLHS[contractingLen*lhsActiveRows-1]
+	_ = packedRHS[contractingLen*rhsActiveCols-1]
+	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These much match params.LHSL1BlockRows and params.LHSL1BlockCols.

--- a/internal/gobackend/dot/matmul/gen_avx512_large_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_f16.go
@@ -15,7 +15,6 @@ package matmul
 // - "f16": Implements the MatMul for Float16 -> Float32 dtypes.
 
 import (
-	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -240,6 +239,11 @@ func avx512LargeMatrixSliceFloat16( //alt:f16
 // avx512LargeKernelFloat32 implements a kernel of the matrix multiplication for
 // a lhs and rhs packed panels into an intermediate output panel.
 //
+// Memory safety note: We use raw unsafe pointers to avoid bounds-checking (BCE) overhead
+// in the inner loops. Because the caller (parent function on the stack) owns and holds references
+// to packedLHS, packedRHS, and packedOutput throughout execution, they remain reachable and
+// do not need runtime.KeepAlive() calls at the end.
+//
 //alt:f32 func avx512LargeKernelFloat32(
 //alt:bf16  func avx512LargeKernelBFloat16(
 func avx512LargeKernelFloat16( //alt:f16
@@ -254,17 +258,7 @@ func avx512LargeKernelFloat16( //alt:f16
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
-	defer func() {
-		runtime.KeepAlive(packedLHS)
-		runtime.KeepAlive(packedRHS)
-		runtime.KeepAlive(packedOutput)
-	}()
 	_ = lhsPanelRows // Not needed.
-
-	// BCE hints
-	_ = packedLHS[contractingLen*lhsActiveRows-1]
-	_ = packedRHS[contractingLen*rhsActiveCols-1]
-	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These much match params.LHSL1BlockRows and params.LHSL1BlockCols.

--- a/internal/gobackend/dot/matmul/gen_avx512_large_f16.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_f16.go
@@ -185,12 +185,9 @@ func avx512LargeMatrixSliceFloat16( //alt:f16
 ) {
 	_ = lhsCrossSize // Not used, rowStart and rowEnd < lhsCrossSize are enough.
 
-	//alt:f32 if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) {
-	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 { //alt:bf16|f16
-		//alt:f64  if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 16 {
-		//alt:f32 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)",
-		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)", //alt:bf16|f16
-			//alt:f64  panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 16 respectively (params=%+v)",
+	if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) { //alt:f32|bf16|f16
+		//alt:f64  if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 16 && params.RHSL1KernelCols != 32) {
+		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)", //alt:f32|bf16|f16|f64
 			params.LHSL1KernelRows, params.RHSL1KernelCols, params))
 	}
 
@@ -214,24 +211,27 @@ func avx512LargeMatrixSliceFloat16( //alt:f16
 				lhsPanelHeight := min(params.LHSPanelCrossSize, rowEnd-lhsPanelRowIdx)
 				avx512PackLHSKernelRows4(lhsMatrix, packedLHS, lhsPanelRowIdx, contractingPanelIdx, contractingSize, lhsPanelHeight, contractingPanelWidth, params.LHSL1KernelRows) //alt:f32|bf16|f16|f64
 
-				//alt:f32 if AVX512UseAsm {
-				//alt:f32 avx512LargeKernelFloat32Asm(
-				//alt:f32 packedLHS, packedRHS, packedOutput,
-				//alt:f32 params.LHSPanelCrossSize, params.RHSPanelCrossSize,
-				//alt:f32 contractingPanelWidth,
-				//alt:f32 lhsPanelHeight, rhsPanelWidth,
-				//alt:f32 )
-				//alt:f32 } else {
-				//alt:f32 avx512LargeKernelFloat32(
-				//alt:bf16  avx512LargeKernelBFloat16(
-				avx512LargeKernelFloat16( //alt:f16
-					//alt:f64  avx512LargeKernelFloat64(
-					packedLHS, packedRHS, packedOutput,
-					params.LHSPanelCrossSize, params.RHSPanelCrossSize,
-					contractingPanelWidth,
-					lhsPanelHeight, rhsPanelWidth,
-				) //alt:bf16|f16|f64
-				//alt:f32 }
+				if AVX512UseAsm { //alt:f32|bf16|f16|f64
+					//alt:f32 avx512LargeKernelFloat32Asm(
+					//alt:bf16  avx512LargeKernelBFloat16Asm(
+					avx512LargeKernelFloat16Asm( //alt:f16
+						//alt:f64  avx512LargeKernelFloat64Asm(
+						packedLHS, packedRHS, packedOutput,
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+						contractingPanelWidth,
+						lhsPanelHeight, rhsPanelWidth,
+					)
+				} else { //alt:f32|bf16|f16|f64
+					//alt:f32 avx512LargeKernelFloat32(
+					//alt:bf16  avx512LargeKernelBFloat16(
+					avx512LargeKernelFloat16( //alt:f16
+						//alt:f64  avx512LargeKernelFloat64(
+						packedLHS, packedRHS, packedOutput,
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+						contractingPanelWidth,
+						lhsPanelHeight, rhsPanelWidth,
+					) //alt:bf16|f16|f64
+				} //alt:f32|bf16|f16|f64
 
 				// Accumulate (or write) packedOutput to output.
 				isFirstContractingPanel := contractingPanelIdx == 0

--- a/internal/gobackend/dot/matmul/gen_avx512_large_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_f64.go
@@ -185,12 +185,9 @@ func avx512LargeMatrixSliceFloat64( //alt:f64
 ) {
 	_ = lhsCrossSize // Not used, rowStart and rowEnd < lhsCrossSize are enough.
 
-	//alt:f32 if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) {
-	//alt:bf16|f16  if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 {
-	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 16 { //alt:f64
-		//alt:f32 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)",
-		//alt:bf16|f16  panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)",
-		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 16 respectively (params=%+v)", //alt:f64
+	//alt:f32|bf16|f16 if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) {
+	if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 16 && params.RHSL1KernelCols != 32) { //alt:f64
+		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)", //alt:f32|bf16|f16|f64
 			params.LHSL1KernelRows, params.RHSL1KernelCols, params))
 	}
 
@@ -214,24 +211,27 @@ func avx512LargeMatrixSliceFloat64( //alt:f64
 				lhsPanelHeight := min(params.LHSPanelCrossSize, rowEnd-lhsPanelRowIdx)
 				avx512PackLHSKernelRows4(lhsMatrix, packedLHS, lhsPanelRowIdx, contractingPanelIdx, contractingSize, lhsPanelHeight, contractingPanelWidth, params.LHSL1KernelRows) //alt:f32|bf16|f16|f64
 
-				//alt:f32 if AVX512UseAsm {
-				//alt:f32 avx512LargeKernelFloat32Asm(
-				//alt:f32 packedLHS, packedRHS, packedOutput,
-				//alt:f32 params.LHSPanelCrossSize, params.RHSPanelCrossSize,
-				//alt:f32 contractingPanelWidth,
-				//alt:f32 lhsPanelHeight, rhsPanelWidth,
-				//alt:f32 )
-				//alt:f32 } else {
-				//alt:f32 avx512LargeKernelFloat32(
-				//alt:bf16  avx512LargeKernelBFloat16(
-				//alt:f16  avx512LargeKernelFloat16(
-				avx512LargeKernelFloat64( //alt:f64
-					packedLHS, packedRHS, packedOutput,
-					params.LHSPanelCrossSize, params.RHSPanelCrossSize,
-					contractingPanelWidth,
-					lhsPanelHeight, rhsPanelWidth,
-				) //alt:bf16|f16|f64
-				//alt:f32 }
+				if AVX512UseAsm { //alt:f32|bf16|f16|f64
+					//alt:f32 avx512LargeKernelFloat32Asm(
+					//alt:bf16  avx512LargeKernelBFloat16Asm(
+					//alt:f16  avx512LargeKernelFloat16Asm(
+					avx512LargeKernelFloat64Asm( //alt:f64
+						packedLHS, packedRHS, packedOutput,
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+						contractingPanelWidth,
+						lhsPanelHeight, rhsPanelWidth,
+					)
+				} else { //alt:f32|bf16|f16|f64
+					//alt:f32 avx512LargeKernelFloat32(
+					//alt:bf16  avx512LargeKernelBFloat16(
+					//alt:f16  avx512LargeKernelFloat16(
+					avx512LargeKernelFloat64( //alt:f64
+						packedLHS, packedRHS, packedOutput,
+						params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+						contractingPanelWidth,
+						lhsPanelHeight, rhsPanelWidth,
+					) //alt:bf16|f16|f64
+				} //alt:f32|bf16|f16|f64
 
 				// Accumulate (or write) packedOutput to output.
 				isFirstContractingPanel := contractingPanelIdx == 0

--- a/internal/gobackend/dot/matmul/gen_avx512_large_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_f64.go
@@ -15,7 +15,6 @@ package matmul
 // - "f16": Implements the MatMul for Float16 -> Float32 dtypes.
 
 import (
-	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -240,6 +239,11 @@ func avx512LargeMatrixSliceFloat64( //alt:f64
 // avx512LargeKernelFloat32 implements a kernel of the matrix multiplication for
 // a lhs and rhs packed panels into an intermediate output panel.
 //
+// Memory safety note: We use raw unsafe pointers to avoid bounds-checking (BCE) overhead
+// in the inner loops. Because the caller (parent function on the stack) owns and holds references
+// to packedLHS, packedRHS, and packedOutput throughout execution, they remain reachable and
+// do not need runtime.KeepAlive() calls at the end.
+//
 //alt:f32 func avx512LargeKernelFloat32(
 //alt:bf16  func avx512LargeKernelBFloat16(
 //alt:f16  func avx512LargeKernelFloat16(
@@ -254,17 +258,7 @@ func avx512LargeKernelFloat64( //alt:f64
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
-	defer func() {
-		runtime.KeepAlive(packedLHS)
-		runtime.KeepAlive(packedRHS)
-		runtime.KeepAlive(packedOutput)
-	}()
 	_ = lhsPanelRows // Not needed.
-
-	// BCE hints
-	_ = packedLHS[contractingLen*lhsActiveRows-1]
-	_ = packedRHS[contractingLen*rhsActiveCols-1]
-	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These much match params.LHSL1BlockRows and params.LHSL1BlockCols.

--- a/internal/gobackend/dot/matmul/gen_avx512_large_f64.go
+++ b/internal/gobackend/dot/matmul/gen_avx512_large_f64.go
@@ -15,6 +15,7 @@ package matmul
 // - "f16": Implements the MatMul for Float16 -> Float32 dtypes.
 
 import (
+	"runtime"
 	"simd/archsimd"
 	"sync"
 	"unsafe"
@@ -184,9 +185,11 @@ func avx512LargeMatrixSliceFloat64( //alt:f64
 ) {
 	_ = lhsCrossSize // Not used, rowStart and rowEnd < lhsCrossSize are enough.
 
-	//alt:f32|bf16|f16 if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 {
+	//alt:f32 if params.LHSL1KernelRows != 4 || (params.RHSL1KernelCols != 32 && params.RHSL1KernelCols != 64) {
+	//alt:bf16|f16  if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 32 {
 	if params.LHSL1KernelRows != 4 || params.RHSL1KernelCols != 16 { //alt:f64
-		//alt:f32|bf16|f16 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)",
+		//alt:f32 panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d (params=%+v)",
+		//alt:bf16|f16  panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 32 respectively (params=%+v)",
 		panic(errors.Errorf("unsupported kernel L1 block sizes for avx512 kernel: lhsL1BlockRows=%d, rhsL1BlockCols=%d, wanted 4 and 16 respectively (params=%+v)", //alt:f64
 			params.LHSL1KernelRows, params.RHSL1KernelCols, params))
 	}
@@ -211,6 +214,14 @@ func avx512LargeMatrixSliceFloat64( //alt:f64
 				lhsPanelHeight := min(params.LHSPanelCrossSize, rowEnd-lhsPanelRowIdx)
 				avx512PackLHSKernelRows4(lhsMatrix, packedLHS, lhsPanelRowIdx, contractingPanelIdx, contractingSize, lhsPanelHeight, contractingPanelWidth, params.LHSL1KernelRows) //alt:f32|bf16|f16|f64
 
+				//alt:f32 if AVX512UseAsm {
+				//alt:f32 avx512LargeKernelFloat32Asm(
+				//alt:f32 packedLHS, packedRHS, packedOutput,
+				//alt:f32 params.LHSPanelCrossSize, params.RHSPanelCrossSize,
+				//alt:f32 contractingPanelWidth,
+				//alt:f32 lhsPanelHeight, rhsPanelWidth,
+				//alt:f32 )
+				//alt:f32 } else {
 				//alt:f32 avx512LargeKernelFloat32(
 				//alt:bf16  avx512LargeKernelBFloat16(
 				//alt:f16  avx512LargeKernelFloat16(
@@ -219,7 +230,8 @@ func avx512LargeMatrixSliceFloat64( //alt:f64
 					params.LHSPanelCrossSize, params.RHSPanelCrossSize,
 					contractingPanelWidth,
 					lhsPanelHeight, rhsPanelWidth,
-				)
+				) //alt:bf16|f16|f64
+				//alt:f32 }
 
 				// Accumulate (or write) packedOutput to output.
 				isFirstContractingPanel := contractingPanelIdx == 0
@@ -258,7 +270,17 @@ func avx512LargeKernelFloat64( //alt:f64
 	contractingLen int,
 	lhsActiveRows, rhsActiveCols int,
 ) {
+	defer func() {
+		runtime.KeepAlive(packedLHS)
+		runtime.KeepAlive(packedRHS)
+		runtime.KeepAlive(packedOutput)
+	}()
 	_ = lhsPanelRows // Not needed.
+
+	// BCE hints
+	_ = packedLHS[contractingLen*lhsActiveRows-1]
+	_ = packedRHS[contractingLen*rhsActiveCols-1]
+	_ = packedOutput[lhsActiveRows*rhsPanelCols-1]
 
 	const (
 		// These much match params.LHSL1BlockRows and params.LHSL1BlockCols.

--- a/internal/gobackend/dot/matmul/matmul.go
+++ b/internal/gobackend/dot/matmul/matmul.go
@@ -13,7 +13,7 @@ const (
 	// EnabledEnv is the environment variable that controls whether the default matmul
 	// implementations are enabled.
 	// It's on by default, and can be disabled by setting it to false.
-	EnabledEnv = "GOMLX_DOT_MATMUL"
+	EnabledEnv = envutil.GoBackendDotMatmul
 )
 
 // Block/packs parameters for current architecture.
@@ -53,9 +53,9 @@ const (
 )
 
 func init() {
-	avx512Enabled, err := envutil.ReadBool(envutil.SIMD_AVX512_Env, true)
+	avx512Enabled, err := envutil.ReadBool(envutil.GoBackendSIMD_AVX512, true)
 	if err != nil {
-		klog.Fatalf("Invalid value for %q: %+v", envutil.SIMD_AVX512_Env, err)
+		klog.Fatalf("Invalid value for %q: %+v", envutil.GoBackendSIMD_AVX512, err)
 	}
 	_ = avx512Enabled
 }

--- a/support/backendtest/bench_dotgeneral.go
+++ b/support/backendtest/bench_dotgeneral.go
@@ -3,6 +3,7 @@
 package backendtest
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gomlx/compute"
@@ -536,6 +537,9 @@ func BenchmarkDotGeneral(b *testing.B, backend compute.Backend) {
 							return f.DotGeneral(params[0], benchCase.lhsContract, benchCase.lhsBatch, params[1], benchCase.rhsContract, benchCase.rhsBatch, config)
 						})
 					if err != nil {
+						if errors.Is(err, compute.ErrNotImplemented) {
+							b.Skipf("Skipping benchmark %s: %+v", benchCase.name, err)
+						}
 						b.Fatalf("Failed to create benchmark %s: %+v", benchCase.name, err)
 					}
 					b.ResetTimer()

--- a/support/backendtest/bench_dotgeneral.go
+++ b/support/backendtest/bench_dotgeneral.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gomlx/compute"
 	"github.com/gomlx/compute/dtypes"
+	"github.com/gomlx/compute/shapeinference"
 	"github.com/gomlx/compute/shapes"
 )
 
@@ -493,6 +494,34 @@ func BenchmarkDotGeneral(b *testing.B, backend compute.Backend) {
 			lhsBatch:    []int{},
 			rhsBatch:    []int{},
 		},
+		{
+			model: "Large",
+		},
+		{
+			name:        "NoBatch-Large",
+			lhsShape:    shapes.Make(dtypes.Float32, 1536, 1920),
+			rhsShape:    shapes.Make(dtypes.Float32, 1920, 1024),
+			lhsContract: []int{1},
+			rhsContract: []int{0},
+		},
+		{
+			name:        "Batched-Large-1",
+			lhsShape:    shapes.Make(dtypes.Float32, 16, 1536, 1920),
+			rhsShape:    shapes.Make(dtypes.Float32, 16, 1920, 1024),
+			lhsContract: []int{2},
+			lhsBatch:    []int{0},
+			rhsContract: []int{1},
+			rhsBatch:    []int{0},
+		},
+		{
+			name:        "Batched-Large-2",
+			lhsShape:    shapes.Make(dtypes.Float32, 16, 1024, 1920),
+			rhsShape:    shapes.Make(dtypes.Float32, 16, 1920, 1536),
+			lhsContract: []int{2},
+			lhsBatch:    []int{0},
+			rhsContract: []int{1},
+			rhsBatch:    []int{0},
+		},
 	}
 
 	benchIdx := 0
@@ -528,12 +557,12 @@ func BenchmarkDotGeneral(b *testing.B, backend compute.Backend) {
 					rhsData = randomBFloat16(benchCase.rhsShape.Size())
 				}
 				b.Run(benchCase.name, func(b *testing.B) {
+					config := compute.DotGeneralConfig{}
+					if benchCase.lhsShape.DType == dtypes.BFloat16 {
+						config.OutputDType = dtypes.Float32
+					}
 					be, err := newBenchExec(backend, []shapes.Shape{benchCase.lhsShape, benchCase.rhsShape}, []any{lhsData, rhsData},
 						func(f compute.Function, params []compute.Value) (compute.Value, error) {
-							config := compute.DotGeneralConfig{}
-							if benchCase.lhsShape.DType == dtypes.BFloat16 {
-								config.OutputDType = dtypes.Float32
-							}
 							return f.DotGeneral(params[0], benchCase.lhsContract, benchCase.lhsBatch, params[1], benchCase.rhsContract, benchCase.rhsBatch, config)
 						})
 					if err != nil {
@@ -542,8 +571,27 @@ func BenchmarkDotGeneral(b *testing.B, backend compute.Backend) {
 						}
 						b.Fatalf("Failed to create benchmark %s: %+v", benchCase.name, err)
 					}
-					b.ResetTimer()
+					outShape, err := shapeinference.DotGeneral(
+						benchCase.lhsShape, benchCase.lhsContract, benchCase.lhsBatch,
+						benchCase.rhsShape, benchCase.rhsContract, benchCase.rhsBatch,
+						config,
+					)
+					var flops float64
+					if err == nil {
+						contractingSize := 1
+						for _, axis := range benchCase.lhsContract {
+							contractingSize *= benchCase.lhsShape.Dimensions[axis]
+						}
+						flops = float64(2 * outShape.Size() * contractingSize)
+					}
+
 					be.run(b)
+
+					elapsed := b.Elapsed()
+					if flops > 0 && elapsed > 0 && b.N > 0 {
+						gflops := (flops * float64(b.N)) / (elapsed.Seconds() * 1e9)
+						b.ReportMetric(gflops, "GFlops/s")
+					}
 				})
 			}
 		})

--- a/support/backendtest/benchmarks.go
+++ b/support/backendtest/benchmarks.go
@@ -54,6 +54,20 @@ type benchExec struct {
 
 func (be *benchExec) run(b *testing.B) {
 	b.Helper()
+	// Warm up before the benchmark loop. b.Loop() automatically resets
+	// the timer on its first call, so warm-up iterations are not measured.
+	for range 3 {
+		outputs, err := be.exec.Execute(be.inputs, nil, 0)
+		if err != nil {
+			b.Fatalf("Execute failed: %+v", err)
+		}
+		for _, buf := range outputs {
+			err = buf.Finalize()
+			if err != nil {
+				b.Fatalf("Failed to finalize buffer: %+v", err)
+			}
+		}
+	}
 	for b.Loop() {
 		outputs, err := be.exec.Execute(be.inputs, nil, 0)
 		if err != nil {
@@ -65,6 +79,11 @@ func (be *benchExec) run(b *testing.B) {
 				b.Fatalf("Failed to finalize buffer: %+v", err)
 			}
 		}
+	}
+	elapsed := b.Elapsed()
+	if elapsed > 0 && b.N > 0 {
+		msPerOp := (elapsed.Seconds() * 1000) / float64(b.N)
+		b.ReportMetric(msPerOp, "ms/op")
 	}
 }
 

--- a/support/envutil/envutil.go
+++ b/support/envutil/envutil.go
@@ -68,3 +68,16 @@ func ReadInt(name string, defaultValue int) (int, error) {
 	}
 	return valInt, nil
 }
+
+// MustReadInt reads the integer value of the environment variable with the given name.
+// If not set, it returns the defaultValue.
+//
+// It panics with an informative error if the value is set but it is not able to parse a valid integer value.
+func MustReadInt(name string, defaultValue int) int {
+	result, err := ReadInt(name, defaultValue)
+	if err != nil {
+		panic(errors.Errorf("Invalid value for %q: %+v", name, err))
+	}
+	return result
+}
+

--- a/support/envutil/envutil.go
+++ b/support/envutil/envutil.go
@@ -16,11 +16,17 @@ var (
 	TrueValues  = sets.MakeWith("1", "true", "t", "yes", "on", "enabled")
 )
 
-// Environment variables to control usage of SIMD instructions.
+// Environment variables used by the Go backend: mostly SIMD instructions and optimizations.
 // By default it uses whatever the CPU supports, but this allows one to disable them in case of issues.
 const (
-	SIMD_AVX512_Env = "GOMLX_SIMD_AVX512"
-	SIMD_AVX2_Env   = "GOMLX_SIMD_AVX2"
+	GoBackendSIMD_AVX512 = "GOMLX_GO_SIMD_AVX512"
+	GoBackendSIMD_AVX2   = "GOMLX_GO_SIMD_AVX2"
+	GoBackendFusion      = "GOMLX_GO_FUSION"
+	GoBackendDotMatmul   = "GOMLX_GO_DOT_MATMUL"
+	GoBackendAVX512_ASM  = "GOMLX_GO_AVX512_ASM"
+	GoBackendAVX512_KC   = "GOMLX_GO_AVX512_KC"
+	GoBackendAVX512_MC   = "GOMLX_GO_AVX512_MC"
+	GoBackendAVX512_NC   = "GOMLX_GO_AVX512_NC"
 )
 
 // ReadBool reads the boolean value of the environment variable with the given name.
@@ -80,4 +86,3 @@ func MustReadInt(name string, defaultValue int) int {
 	}
 	return result
 }
-


### PR DESCRIPTION
## Summary

This PR introduces hand-optimized AVX-512 assembly microkernels for large matrix multiplications (GEMM) across all floating-point datatypes, adds comprehensive GEMM performance benchmarks with GFlops/s reporting, and configures multi-platform GitHub Actions CI workflows.

### Key Changes

- **AVX-512 Assembly Microkernels**:
  - Implemented assembly versions of large GEMM microkernels for `amd64` supporting `float32`, `float64`, `float16`, and `bfloat16` (`avx512_large_amd64_*.s`).
  - Added "ping-pong" double buffering with interleaved load-ahead and FMA operations to maximize instruction pipeline throughput.
  - Tuned GEMM panel sizing for cache efficiency.
  - Cleaned up redundant bounds check elimination (BCE) hints and `runtime.KeepAlive()` calls.
  - Generated and updated kernel dispatchers and wrappers (`gen_avx512_large_*.go`, `avx512_large_amd64.go`).

- **Benchmarking & Performance Metrics**:
  - Added "Large" `DotGeneral` performance benchmarks to `support/backendtest`.
  - Added GFlops/s and duration metrics reporting to benchmark summaries.
  - Skipped non-implemented variations of `DotGeneral` in benchmark suites.

- **GitHub Actions CI**:
  - Added test workflows for Darwin, Linux (`amd64`, `arm64`), and Windows (`amd64`).

- **Documentation**:
  - Greatly improved README.md.
  - Updated `.agents/AGENTS.md` with guidelines and repo structure updates.
