### PR TITLE
gobackend: Fix float16/bfloat16 reduce fallbacks and centralize SIMD AVX checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ some of the example models to benchmark your backend against some of the others.
     One can install PJRTs built for NVIDIA GPUs (there is an installation script for that), there is also one for ROCm (not tested by the author),
     for TPU (Google Cloud) and reports of PJRTs being built for even newer accelerators (e.g.: [TensTorrent XLA](https://github.com/tenstorrent/tt-xla)).
 - For the native Go backend:
-  - `GOMLX_GO_SIMD_AVX512`: set to `0` or `false` to disable AVX512 SIMD implementation in the native Go backend. The default is enabled if AVX512 is present.
-  - `GOMLX_GO_SIMD_AVX2`: set to `0` or `false` to disable AVX2 SIMD implementation in the native Go backend. The default is enabled if AVX2 is present.
+  - `GOMLX_GO_SIMD_AVX512`: set to `0` or `false` to disable AVX512-specific SIMD implementations in the native Go backend (e.g. optimized matmul and activation kernels). Note: this only controls AVX512-specific code; generic portable SIMD operations will still use hardware vector features if available. The default is enabled if AVX512 is present.
+  - `GOMLX_GO_SIMD_AVX2`: set to `0` or `false` to disable AVX2-specific SIMD implementations in the native Go backend (e.g. optimized matmul and activation kernels). Note: this only controls AVX2-specific code; generic portable SIMD operations will still use hardware vector features if available. The default is enabled if AVX2 is present.
   - `GOMLX_GO_AVX512_ASM`: set to `0` or `false` to disable the assembly microkernel for Float32 and use the Go SIMD kernel instead.
   - `GOMLX_GO_AVX512_KC`, `GOMLX_GO_AVX512_MC`, `GOMLX_GO_AVX512_NC`: cache blocking tuning parameters for AVX512 matrix multiplication.
   - `GOMLX_GO_DOT_MATMUL`: set to `0` or `false` to disable the default matrix multiplication implementation in the native Go backend. The default is enabled.

--- a/internal/gobackend/activations/avx2/avx2.go
+++ b/internal/gobackend/activations/avx2/avx2.go
@@ -13,14 +13,12 @@ import (
 	"github.com/gomlx/compute/dtypes/float16"
 	"github.com/gomlx/compute/internal/gobackend"
 	"github.com/gomlx/compute/internal/gobackend/activations"
-	"github.com/gomlx/compute/support/envutil"
 )
 
 const PriorityAVX2 = gobackend.PriorityArch
 
 func init() {
-	allowed := envutil.MustReadBool(envutil.GoBackendSIMD_AVX2, true)
-	if allowed && archsimd.X86.AVX2() {
+	if gobackend.IsAVX2Allowed() {
 		registerAVX2()
 	}
 }

--- a/internal/gobackend/activations/avx512/avx512.go
+++ b/internal/gobackend/activations/avx512/avx512.go
@@ -13,14 +13,12 @@ import (
 	"github.com/gomlx/compute/dtypes/float16"
 	"github.com/gomlx/compute/internal/gobackend"
 	"github.com/gomlx/compute/internal/gobackend/activations"
-	"github.com/gomlx/compute/support/envutil"
 )
 
 const PriorityAVX512 = gobackend.PriorityArch + 1
 
 func init() {
-	allowed := envutil.MustReadBool(envutil.GoBackendSIMD_AVX512, true)
-	if allowed && archsimd.X86.AVX512() {
+	if gobackend.IsAVX512Allowed() {
 		registerAVX512()
 	}
 }

--- a/internal/gobackend/dot/dot.go
+++ b/internal/gobackend/dot/dot.go
@@ -17,8 +17,8 @@
 //
 //   - GOMLX_GO_DOT_MATMUL: set to false to disable the default matmul implementation.
 //     if you haven't added other plugin implementations, it will effectively disable DotGeneral.
-//   - GOMLX_GO_SIMD_AVX512: set to false to disable the AVX512 implementation, even if the runtime architecture allows it.
-//   - GOMLX_GO_SIMD_AVX2: set to false to disable the AVX2 implementation, even if the runtime architecture allows it.
+//   - GOMLX_GO_SIMD_AVX512: set to false to disable AVX512-specific implementations, even if the runtime architecture allows it.
+//   - GOMLX_GO_SIMD_AVX2: set to false to disable AVX2-specific implementations, even if the runtime architecture allows it.
 package dot
 
 import (

--- a/internal/gobackend/dot/matmul/avx2/avx2.go
+++ b/internal/gobackend/dot/matmul/avx2/avx2.go
@@ -80,8 +80,7 @@ func init() {
 		return
 	}
 
-	allowed := envutil.MustReadBool(envutil.GoBackendSIMD_AVX2, true)
-	if allowed && archsimd.X86.AVX2() {
+	if gobackend.IsAVX2Allowed() {
 		registerAVX2(false)
 	}
 }

--- a/internal/gobackend/dot/matmul/avx512/avx512.go
+++ b/internal/gobackend/dot/matmul/avx512/avx512.go
@@ -97,8 +97,7 @@ func init() {
 		return
 	}
 
-	allowed := envutil.MustReadBool(envutil.GoBackendSIMD_AVX512, true)
-	if allowed && archsimd.X86.AVX512() {
+	if gobackend.IsAVX512Allowed() {
 		registerAVX512(false)
 	}
 }

--- a/internal/gobackend/ops/reduce.go
+++ b/internal/gobackend/ops/reduce.go
@@ -457,6 +457,9 @@ func NewReduceOutputIterator(dimensions []int, reduceAxes []int) *ReduceOutputIt
 
 // Next returns the next flat index in the output.
 func (it *ReduceOutputIterator) Next() int {
+	if len(it.perAxisIdx) == 0 {
+		panic("ReduceOutputIterator.Next called on uninitialized iterator")
+	}
 	returnIdx := it.flatIdx
 	// Move pointer.
 	for axis := len(it.perAxisIdx) - 1; axis >= 0; axis-- {
@@ -613,33 +616,187 @@ func execReduceMaxGeneric[T gobackend.PODNumericConstraints](operand, output *go
 }
 
 func execReduceMaxBFloat16(operand, output *gobackend.Buffer, it *ReduceOutputIterator, dtype dtypes.DType) error {
-	initialValue := dtype.LowestValue().(bfloat16.BFloat16)
 	outputFlat := output.Flat.([]bfloat16.BFloat16)
-	for outputIdx := range outputFlat {
-		outputFlat[outputIdx] = initialValue
-	}
 	operandFlat := operand.Flat.([]bfloat16.BFloat16)
-	for _, value := range operandFlat {
-		outputIdx := it.Next()
-		a, b := outputFlat[outputIdx].Float32(), value.Float32()
-		outputFlat[outputIdx] = bfloat16.FromFloat32(max(a, b))
+
+	switch it.Config.Pattern {
+	case ReduceAll:
+		m := operandFlat[0].Float32()
+		for _, v := range operandFlat[1:] {
+			m = max(m, v.Float32())
+		}
+		outputFlat[0] = bfloat16.FromFloat32(m)
+		return nil
+
+	case ReduceTrailing:
+		A, B := it.Config.A, it.Config.B
+		if B == 0 {
+			lowest := dtype.LowestValue().(bfloat16.BFloat16)
+			for a := range A {
+				outputFlat[a] = lowest
+			}
+			return nil
+		}
+		for a := range A {
+			offset := a * B
+			row := operandFlat[offset : offset+B]
+			m := row[0].Float32()
+			for _, v := range row[1:] {
+				m = max(m, v.Float32())
+			}
+			outputFlat[a] = bfloat16.FromFloat32(m)
+		}
+		return nil
+
+	case ReduceLeading:
+		A, B := it.Config.A, it.Config.B
+		if A == 0 || B == 0 {
+			lowest := dtype.LowestValue().(bfloat16.BFloat16)
+			for b := range B {
+				outputFlat[b] = lowest
+			}
+			return nil
+		}
+		copy(outputFlat, operandFlat[:B])
+		for a := 1; a < A; a++ {
+			offset := a * B
+			sliceA := operandFlat[offset : offset+B]
+			for b, v := range sliceA {
+				aF, bF := outputFlat[b].Float32(), v.Float32()
+				outputFlat[b] = bfloat16.FromFloat32(max(aF, bF))
+			}
+		}
+		return nil
+
+	case ReduceMiddle:
+		A, B, C := it.Config.A, it.Config.B, it.Config.C
+		if A == 0 || B == 0 || C == 0 {
+			lowest := dtype.LowestValue().(bfloat16.BFloat16)
+			for i := range outputFlat {
+				outputFlat[i] = lowest
+			}
+			return nil
+		}
+		for a := range A {
+			outOffset := a * C
+			outSlice := outputFlat[outOffset : outOffset+C]
+			inOffset0 := a * B * C
+			copy(outSlice, operandFlat[inOffset0 : inOffset0+C])
+			for b := 1; b < B; b++ {
+				inOffset := inOffset0 + b*C
+				inSlice := operandFlat[inOffset : inOffset+C]
+				for c, v := range inSlice {
+					aF, bF := outSlice[c].Float32(), v.Float32()
+					outSlice[c] = bfloat16.FromFloat32(max(aF, bF))
+				}
+			}
+		}
+		return nil
+
+	default:
+		initialValue := dtype.LowestValue().(bfloat16.BFloat16)
+		for outputIdx := range outputFlat {
+			outputFlat[outputIdx] = initialValue
+		}
+		for _, value := range operandFlat {
+			outputIdx := it.Next()
+			a, b := outputFlat[outputIdx].Float32(), value.Float32()
+			outputFlat[outputIdx] = bfloat16.FromFloat32(max(a, b))
+		}
+		return nil
 	}
-	return nil
 }
 
 func execReduceMaxFloat16(operand, output *gobackend.Buffer, it *ReduceOutputIterator, dtype dtypes.DType) error {
-	initialValue := dtype.LowestValue().(float16.Float16)
 	outputFlat := output.Flat.([]float16.Float16)
-	for outputIdx := range outputFlat {
-		outputFlat[outputIdx] = initialValue
-	}
 	operandFlat := operand.Flat.([]float16.Float16)
-	for _, value := range operandFlat {
-		outputIdx := it.Next()
-		a, b := outputFlat[outputIdx].Float32(), value.Float32()
-		outputFlat[outputIdx] = float16.FromFloat32(max(a, b))
+
+	switch it.Config.Pattern {
+	case ReduceAll:
+		m := operandFlat[0].Float32()
+		for _, v := range operandFlat[1:] {
+			m = max(m, v.Float32())
+		}
+		outputFlat[0] = float16.FromFloat32(m)
+		return nil
+
+	case ReduceTrailing:
+		A, B := it.Config.A, it.Config.B
+		if B == 0 {
+			lowest := dtype.LowestValue().(float16.Float16)
+			for a := range A {
+				outputFlat[a] = lowest
+			}
+			return nil
+		}
+		for a := range A {
+			offset := a * B
+			row := operandFlat[offset : offset+B]
+			m := row[0].Float32()
+			for _, v := range row[1:] {
+				m = max(m, v.Float32())
+			}
+			outputFlat[a] = float16.FromFloat32(m)
+		}
+		return nil
+
+	case ReduceLeading:
+		A, B := it.Config.A, it.Config.B
+		if A == 0 || B == 0 {
+			lowest := dtype.LowestValue().(float16.Float16)
+			for b := range B {
+				outputFlat[b] = lowest
+			}
+			return nil
+		}
+		copy(outputFlat, operandFlat[:B])
+		for a := 1; a < A; a++ {
+			offset := a * B
+			sliceA := operandFlat[offset : offset+B]
+			for b, v := range sliceA {
+				aF, bF := outputFlat[b].Float32(), v.Float32()
+				outputFlat[b] = float16.FromFloat32(max(aF, bF))
+			}
+		}
+		return nil
+
+	case ReduceMiddle:
+		A, B, C := it.Config.A, it.Config.B, it.Config.C
+		if A == 0 || B == 0 || C == 0 {
+			lowest := dtype.LowestValue().(float16.Float16)
+			for i := range outputFlat {
+				outputFlat[i] = lowest
+			}
+			return nil
+		}
+		for a := range A {
+			outOffset := a * C
+			outSlice := outputFlat[outOffset : outOffset+C]
+			inOffset0 := a * B * C
+			copy(outSlice, operandFlat[inOffset0 : inOffset0+C])
+			for b := 1; b < B; b++ {
+				inOffset := inOffset0 + b*C
+				inSlice := operandFlat[inOffset : inOffset+C]
+				for c, v := range inSlice {
+					aF, bF := outSlice[c].Float32(), v.Float32()
+					outSlice[c] = float16.FromFloat32(max(aF, bF))
+				}
+			}
+		}
+		return nil
+
+	default:
+		initialValue := dtype.LowestValue().(float16.Float16)
+		for outputIdx := range outputFlat {
+			outputFlat[outputIdx] = initialValue
+		}
+		for _, value := range operandFlat {
+			outputIdx := it.Next()
+			a, b := outputFlat[outputIdx].Float32(), value.Float32()
+			outputFlat[outputIdx] = float16.FromFloat32(max(a, b))
+		}
+		return nil
 	}
-	return nil
 }
 
 func execReduceMinGeneric[T gobackend.PODNumericConstraints](operand, output *gobackend.Buffer, it *ReduceOutputIterator, dtype dtypes.DType) error {
@@ -736,33 +893,187 @@ func execReduceMinGeneric[T gobackend.PODNumericConstraints](operand, output *go
 }
 
 func execReduceMinBFloat16(operand, output *gobackend.Buffer, it *ReduceOutputIterator, dtype dtypes.DType) error {
-	initialValue := dtype.HighestValue().(bfloat16.BFloat16)
 	outputFlat := output.Flat.([]bfloat16.BFloat16)
-	for outputIdx := range outputFlat {
-		outputFlat[outputIdx] = initialValue
-	}
 	operandFlat := operand.Flat.([]bfloat16.BFloat16)
-	for _, value := range operandFlat {
-		outputIdx := it.Next()
-		a, b := outputFlat[outputIdx].Float32(), value.Float32()
-		outputFlat[outputIdx] = bfloat16.FromFloat32(min(a, b))
+
+	switch it.Config.Pattern {
+	case ReduceAll:
+		m := operandFlat[0].Float32()
+		for _, v := range operandFlat[1:] {
+			m = min(m, v.Float32())
+		}
+		outputFlat[0] = bfloat16.FromFloat32(m)
+		return nil
+
+	case ReduceTrailing:
+		A, B := it.Config.A, it.Config.B
+		if B == 0 {
+			highest := dtype.HighestValue().(bfloat16.BFloat16)
+			for a := range A {
+				outputFlat[a] = highest
+			}
+			return nil
+		}
+		for a := range A {
+			offset := a * B
+			row := operandFlat[offset : offset+B]
+			m := row[0].Float32()
+			for _, v := range row[1:] {
+				m = min(m, v.Float32())
+			}
+			outputFlat[a] = bfloat16.FromFloat32(m)
+		}
+		return nil
+
+	case ReduceLeading:
+		A, B := it.Config.A, it.Config.B
+		if A == 0 || B == 0 {
+			highest := dtype.HighestValue().(bfloat16.BFloat16)
+			for b := range B {
+				outputFlat[b] = highest
+			}
+			return nil
+		}
+		copy(outputFlat, operandFlat[:B])
+		for a := 1; a < A; a++ {
+			offset := a * B
+			sliceA := operandFlat[offset : offset+B]
+			for b, v := range sliceA {
+				aF, bF := outputFlat[b].Float32(), v.Float32()
+				outputFlat[b] = bfloat16.FromFloat32(min(aF, bF))
+			}
+		}
+		return nil
+
+	case ReduceMiddle:
+		A, B, C := it.Config.A, it.Config.B, it.Config.C
+		if A == 0 || B == 0 || C == 0 {
+			highest := dtype.HighestValue().(bfloat16.BFloat16)
+			for i := range outputFlat {
+				outputFlat[i] = highest
+			}
+			return nil
+		}
+		for a := range A {
+			outOffset := a * C
+			outSlice := outputFlat[outOffset : outOffset+C]
+			inOffset0 := a * B * C
+			copy(outSlice, operandFlat[inOffset0 : inOffset0+C])
+			for b := 1; b < B; b++ {
+				inOffset := inOffset0 + b*C
+				inSlice := operandFlat[inOffset : inOffset+C]
+				for c, v := range inSlice {
+					aF, bF := outSlice[c].Float32(), v.Float32()
+					outSlice[c] = bfloat16.FromFloat32(min(aF, bF))
+				}
+			}
+		}
+		return nil
+
+	default:
+		initialValue := dtype.HighestValue().(bfloat16.BFloat16)
+		for outputIdx := range outputFlat {
+			outputFlat[outputIdx] = initialValue
+		}
+		for _, value := range operandFlat {
+			outputIdx := it.Next()
+			a, b := outputFlat[outputIdx].Float32(), value.Float32()
+			outputFlat[outputIdx] = bfloat16.FromFloat32(min(a, b))
+		}
+		return nil
 	}
-	return nil
 }
 
 func execReduceMinFloat16(operand, output *gobackend.Buffer, it *ReduceOutputIterator, dtype dtypes.DType) error {
-	initialValue := dtype.HighestValue().(float16.Float16)
 	outputFlat := output.Flat.([]float16.Float16)
-	for outputIdx := range outputFlat {
-		outputFlat[outputIdx] = initialValue
-	}
 	operandFlat := operand.Flat.([]float16.Float16)
-	for _, value := range operandFlat {
-		outputIdx := it.Next()
-		a, b := outputFlat[outputIdx].Float32(), value.Float32()
-		outputFlat[outputIdx] = float16.FromFloat32(min(a, b))
+
+	switch it.Config.Pattern {
+	case ReduceAll:
+		m := operandFlat[0].Float32()
+		for _, v := range operandFlat[1:] {
+			m = min(m, v.Float32())
+		}
+		outputFlat[0] = float16.FromFloat32(m)
+		return nil
+
+	case ReduceTrailing:
+		A, B := it.Config.A, it.Config.B
+		if B == 0 {
+			highest := dtype.HighestValue().(float16.Float16)
+			for a := range A {
+				outputFlat[a] = highest
+			}
+			return nil
+		}
+		for a := range A {
+			offset := a * B
+			row := operandFlat[offset : offset+B]
+			m := row[0].Float32()
+			for _, v := range row[1:] {
+				m = min(m, v.Float32())
+			}
+			outputFlat[a] = float16.FromFloat32(m)
+		}
+		return nil
+
+	case ReduceLeading:
+		A, B := it.Config.A, it.Config.B
+		if A == 0 || B == 0 {
+			highest := dtype.HighestValue().(float16.Float16)
+			for b := range B {
+				outputFlat[b] = highest
+			}
+			return nil
+		}
+		copy(outputFlat, operandFlat[:B])
+		for a := 1; a < A; a++ {
+			offset := a * B
+			sliceA := operandFlat[offset : offset+B]
+			for b, v := range sliceA {
+				aF, bF := outputFlat[b].Float32(), v.Float32()
+				outputFlat[b] = float16.FromFloat32(min(aF, bF))
+			}
+		}
+		return nil
+
+	case ReduceMiddle:
+		A, B, C := it.Config.A, it.Config.B, it.Config.C
+		if A == 0 || B == 0 || C == 0 {
+			highest := dtype.HighestValue().(float16.Float16)
+			for i := range outputFlat {
+				outputFlat[i] = highest
+			}
+			return nil
+		}
+		for a := range A {
+			outOffset := a * C
+			outSlice := outputFlat[outOffset : outOffset+C]
+			inOffset0 := a * B * C
+			copy(outSlice, operandFlat[inOffset0 : inOffset0+C])
+			for b := 1; b < B; b++ {
+				inOffset := inOffset0 + b*C
+				inSlice := operandFlat[inOffset : inOffset+C]
+				for c, v := range inSlice {
+					aF, bF := outSlice[c].Float32(), v.Float32()
+					outSlice[c] = float16.FromFloat32(min(aF, bF))
+				}
+			}
+		}
+		return nil
+
+	default:
+		initialValue := dtype.HighestValue().(float16.Float16)
+		for outputIdx := range outputFlat {
+			outputFlat[outputIdx] = initialValue
+		}
+		for _, value := range operandFlat {
+			outputIdx := it.Next()
+			a, b := outputFlat[outputIdx].Float32(), value.Float32()
+			outputFlat[outputIdx] = float16.FromFloat32(min(a, b))
+		}
+		return nil
 	}
-	return nil
 }
 
 func execReduceSumGeneric[T gobackend.PODNumericConstraints](operand, output *gobackend.Buffer, it *ReduceOutputIterator, _ dtypes.DType) error {

--- a/internal/gobackend/ops/reduce_test.go
+++ b/internal/gobackend/ops/reduce_test.go
@@ -145,4 +145,44 @@ func TestReduceFastPaths(t *testing.T) {
 		expected := []float16.Float16{float16.FromFloat32(6), float16.FromFloat32(15)}
 		runReduceTest(t, "ReduceTrailing_Float16_Sum", ops.ReduceSum, s2x3_f16, data_f16, []int{1}, expected)
 	})
+
+	t.Run("ReduceTrailing_BFloat16_Max", func(t *testing.T) {
+		s2x3_bf16 := shapes.Make(dtypes.BFloat16, 2, 3)
+		data_bf16 := make([]bfloat16.BFloat16, 6)
+		for i, v := range data2x3 {
+			data_bf16[i] = bfloat16.FromFloat32(v)
+		}
+		expected := []bfloat16.BFloat16{bfloat16.FromFloat32(3), bfloat16.FromFloat32(6)}
+		runReduceTest(t, "ReduceTrailing_BFloat16_Max", ops.ReduceMax, s2x3_bf16, data_bf16, []int{1}, expected)
+	})
+
+	t.Run("ReduceTrailing_Float16_Max", func(t *testing.T) {
+		s2x3_f16 := shapes.Make(dtypes.Float16, 2, 3)
+		data_f16 := make([]float16.Float16, 6)
+		for i, v := range data2x3 {
+			data_f16[i] = float16.FromFloat32(v)
+		}
+		expected := []float16.Float16{float16.FromFloat32(3), float16.FromFloat32(6)}
+		runReduceTest(t, "ReduceTrailing_Float16_Max", ops.ReduceMax, s2x3_f16, data_f16, []int{1}, expected)
+	})
+
+	t.Run("ReduceLeading_BFloat16_Min", func(t *testing.T) {
+		s2x3_bf16 := shapes.Make(dtypes.BFloat16, 2, 3)
+		data_bf16 := make([]bfloat16.BFloat16, 6)
+		for i, v := range data2x3 {
+			data_bf16[i] = bfloat16.FromFloat32(v)
+		}
+		expected := []bfloat16.BFloat16{bfloat16.FromFloat32(1), bfloat16.FromFloat32(2), bfloat16.FromFloat32(3)}
+		runReduceTest(t, "ReduceLeading_BFloat16_Min", ops.ReduceMin, s2x3_bf16, data_bf16, []int{0}, expected)
+	})
+
+	t.Run("ReduceLeading_Float16_Min", func(t *testing.T) {
+		s2x3_f16 := shapes.Make(dtypes.Float16, 2, 3)
+		data_f16 := make([]float16.Float16, 6)
+		for i, v := range data2x3 {
+			data_f16[i] = float16.FromFloat32(v)
+		}
+		expected := []float16.Float16{float16.FromFloat32(1), float16.FromFloat32(2), float16.FromFloat32(3)}
+		runReduceTest(t, "ReduceLeading_Float16_Min", ops.ReduceMin, s2x3_f16, data_f16, []int{0}, expected)
+	})
 }

--- a/internal/gobackend/simd_x86.go
+++ b/internal/gobackend/simd_x86.go
@@ -11,11 +11,15 @@ import (
 )
 
 // IsAVX512Allowed returns true if AVX-512 is supported by the CPU and not disabled by GOMLX_GO_SIMD_AVX512.
+// Note that this only controls AVX512-specific implementations (e.g. specialized matmul and activations);
+// generic portable SIMD operations will still use hardware vector features if available.
 func IsAVX512Allowed() bool {
 	return envutil.MustReadBool(envutil.GoBackendSIMD_AVX512, true) && archsimd.X86.AVX512()
 }
 
 // IsAVX2Allowed returns true if AVX2 is supported by the CPU and not disabled by GOMLX_GO_SIMD_AVX2.
+// Note that this only controls AVX2-specific implementations (e.g. specialized matmul and activations);
+// generic portable SIMD operations will still use hardware vector features if available.
 func IsAVX2Allowed() bool {
 	return envutil.MustReadBool(envutil.GoBackendSIMD_AVX2, true) && archsimd.X86.AVX2()
 }

--- a/internal/gobackend/simd_x86.go
+++ b/internal/gobackend/simd_x86.go
@@ -1,0 +1,21 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+//go:build amd64 && goexperiment.simd
+
+package gobackend
+
+import (
+	"simd/archsimd"
+
+	"github.com/gomlx/compute/support/envutil"
+)
+
+// IsAVX512Allowed returns true if AVX-512 is supported by the CPU and not disabled by GOMLX_GO_SIMD_AVX512.
+func IsAVX512Allowed() bool {
+	return envutil.MustReadBool(envutil.GoBackendSIMD_AVX512, true) && archsimd.X86.AVX512()
+}
+
+// IsAVX2Allowed returns true if AVX2 is supported by the CPU and not disabled by GOMLX_GO_SIMD_AVX2.
+func IsAVX2Allowed() bool {
+	return envutil.MustReadBool(envutil.GoBackendSIMD_AVX2, true) && archsimd.X86.AVX2()
+}

--- a/support/envutil/envutil.go
+++ b/support/envutil/envutil.go
@@ -18,6 +18,8 @@ var (
 
 // Environment variables used by the Go backend: mostly SIMD instructions and optimizations.
 // By default it uses whatever the CPU supports, but this allows one to disable them in case of issues.
+// Note that GOMLX_GO_SIMD_AVX512 and GOMLX_GO_SIMD_AVX2 only control AVX512/AVX2-specific implementations
+// (e.g. specialized matmul and activations), while generic portable SIMD code will still use available vector instructions.
 const (
 	GoBackendSIMD_AVX512 = "GOMLX_GO_SIMD_AVX512"
 	GoBackendSIMD_AVX2   = "GOMLX_GO_SIMD_AVX2"


### PR DESCRIPTION
## Summary

This PR addresses fallback execution for Float16 and BFloat16 reductions, centralizes AVX2 / AVX-512 capability and configuration checks, and clarifies documentation for SIMD environment variables:

1. **Reduce Fallbacks for Float16 and BFloat16**:
   - Implemented fast-path reduction patterns (`ReduceAll`, `ReduceTrailing`, `ReduceLeading`, `ReduceMiddle`) for `execReduceMaxBFloat16`, `execReduceMaxFloat16`, `execReduceMinBFloat16`, and `execReduceMinFloat16`.
   - Prevents panics/errors caused when fallback routines expected arbitrary iteration but the iterator was configured for structured fast-paths without per-axis tracking.
   - Added a safeguard panic in `ReduceOutputIterator.Next()` to catch uninitialized iterators early.
   - Added unit tests in `reduce_test.go` for trailing and leading reductions across Float16 and BFloat16 for min and max operations.

2. **Centralized SIMD AVX Selection**:
   - Added `gobackend.IsAVX512Allowed()` and `gobackend.IsAVX2Allowed()` in `simd_x86.go` (guarded by `amd64 && goexperiment.simd`).
   - Replaced duplicate environment variable parsing (`GOMLX_GO_SIMD_AVX512`, `GOMLX_GO_SIMD_AVX2`) and CPU capability checks in matmul and activation packages.

3. **SIMD Documentation Updates**:
   - Updated `README.md`, `dot/dot.go`, and `envutil.go` clarifying that `GOMLX_GO_SIMD_AVX512` and `GOMLX_GO_SIMD_AVX2` disable architecture-specific AVX implementations (e.g. optimized matmuls and activations), while generic portable SIMD operations continue to leverage hardware vector support.