### PR TITLE
gobackend: Fix DotGeneral for dynamic shapes, Pad boundaries, and Float16 conversion overflow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+- 2026-09-10:
+  - Fixed and streamlined `gobackend.DotGeneral` for both static and dynamic shapes:
+    - Removed `MergeAxes` calls in `reshapeToSupportedLayout` and `TransposeToLayout`. Contiguous row-major axis groups naturally match GEMM strides, eliminating unnecessary reshape overhead and cleanly supporting multi-batch or multi-contracting dynamic dimensions.
+    - Updated `LayoutForDotGeneral` to accept multiple leading batch axes and sequential trailing contracting axes without merging.
+    - Simplified `DotGeneral` to directly construct the node with the desired `outputShape`, eliminating redundant intermediate 3D normalized shapes and subsequent reshapes.
+    - Documented flat row-major layout invariants across `LayoutForDotGeneral`, `TransposeToLayout`, `reshapeToSupportedLayout`, `DotGeneral`, and `execDotGeneral`.
+  - Added unit test `TestDotGeneralDynamic` in `internal/gobackend/dot/dot_test.go` verifying multi-batch dynamic attention score dot products.
+
 - 2026-09-09:
   - Added adaptive SIMD vs. non-SIMD thresholding for `Reduce` operations (`ReduceSum`, `ReduceMax`, `ReduceMin`, `ReduceProduct`) in the Go backend. When the reduced axis or tensor size is below the architecture-specific threshold, SIMD executors decline with `ErrFallback` to allow the faster scalar implementation to execute.
   - Implemented thread-safe node-level executor caching (`cachedExecutorIdx` on `*Node`), eliminating dispatch loop and fallback check overhead for subsequent runs across both static graphs and dynamic shape specializations.

--- a/dtypes/float16/float16.go
+++ b/dtypes/float16/float16.go
@@ -103,65 +103,39 @@ func FromNumbers[T numberTypes](values ...T) []Float16 {
 func FromFloat32(x float32) Float16 {
 	bits := math.Float32bits(x)
 	sign := uint16((bits >> 16) & 0x8000)
-	exp := int((bits >> 23) & 0xFF)
-	mantissa := bits & 0x007FFFFF
+	uAbs := bits & 0x7FFFFFFF
 
-	if exp == 0xFF {
-		// NaN or Infinity
-		if mantissa == 0 {
-			return Float16(sign | 0x7C00)
+	const f16MantissaMask = 0x03FF
+
+	if uAbs >= 0x47800000 { // >= 65536.0f overflows to Inf or is NaN
+		if uAbs > 0x7F800000 {
+			// NaN: preserve payload bits and ensure non-zero mantissa
+			return Float16(sign | 0x7C00 | uint16((uAbs>>13)&f16MantissaMask) | 1)
 		}
-		// NaN: keep some bits of mantissa
-		return Float16(sign | 0x7C00 | uint16(mantissa>>13) | 1)
-	}
-
-	exp -= 127 // Unbias
-
-	if exp > 15 {
-		// Overflow -> Infinity
+		// Infinity
 		return Float16(sign | 0x7C00)
 	}
 
-	if exp < -24 {
-		// Underflow -> Zero
-		return Float16(sign)
-	}
-
-	if exp < -14 {
-		// Denormalized
-		mantissa |= 0x00800000 // Add implicit leading bit
-		shift := uint(14 - exp)
-		// Rounding to nearest even
-		mantissa = (mantissa >> (shift - 1))
-		if (mantissa & 1) != 0 {
-			// Round up
-			mantissa = (mantissa >> 1) + 1
-		} else {
-			mantissa >>= 1
+	if uAbs < 0x38800000 { // < 2^-14: subnormal or zero
+		if uAbs < 0x33000000 { // < 2^-25: rounds to zero
+			return Float16(sign)
 		}
-		return Float16(sign | uint16(mantissa))
+		fAbs := math.Float32frombits(uAbs)
+		const denormMagicBits = 126 << 23
+		fDenorm := fAbs + math.Float32frombits(denormMagicBits)
+		denormMant := uint16((math.Float32bits(fDenorm) - denormMagicBits) & f16MantissaMask)
+		return Float16(sign | denormMant)
 	}
 
-	// Normalized
-	resExp := uint16(exp+15) << 10
-	resMantissa := uint16(mantissa >> 13)
-
-	// Rounding to nearest even
-	if (mantissa & 0x1000) != 0 {
-		if (mantissa&0x0FFF) != 0 || (resMantissa&1) != 0 {
-			resMantissa++
-			if resMantissa&0x0400 != 0 {
-				resMantissa = 0
-				resExp += 0x0400
-				if resExp >= 0x7C00 {
-					// Overflow to infinity
-					return Float16(sign | 0x7C00)
-				}
-			}
-		}
+	// Normalized: round to nearest even
+	bias := uint32(0x0FFF) + ((uAbs >> 13) & 1)
+	rounded := uAbs + bias
+	normExpAdjusted := rounded - (112 << 23)
+	if normExpAdjusted >= (0x1F << 23) {
+		// Overflow to infinity
+		return Float16(sign | 0x7C00)
 	}
-
-	return Float16(sign | resExp | resMantissa)
+	return Float16(sign | uint16(normExpAdjusted>>13))
 }
 
 // FromFloat64 converts a float64 to a Float16.

--- a/dtypes/float16/float16_test.go
+++ b/dtypes/float16/float16_test.go
@@ -47,4 +47,20 @@ func TestFloat16(t *testing.T) {
 	if SmallestNonzero.Bits() != 0x0001 {
 		t.Errorf("SmallestNonzero bits got 0x%X, want 0x0001", SmallestNonzero.Bits())
 	}
+
+	// Test Subnormals roundtrip
+	subnormals := []Float16{
+		SmallestNonzero,
+		FromBits(0x8001), // -SmallestNonzero
+		FromBits(0x0002),
+		FromBits(0x03FF),
+		FromBits(0x83FF),
+	}
+	for _, expected := range subnormals {
+		f32 := expected.Float32()
+		got := FromFloat32(f32)
+		if got != expected {
+			t.Errorf("Subnormal roundtrip failed for 0x%04X: got 0x%04X (float32 %g)", expected.Bits(), got.Bits(), f32)
+		}
+	}
 }

--- a/dtypes/float16/simd.go
+++ b/dtypes/float16/simd.go
@@ -82,9 +82,11 @@ func float32sToF16Bits(f simd.Float32s) simd.Uint32s {
 	sign := u.ShiftAllRight(16).And(simd.BroadcastUint32s(0x8000))
 	uAbs := u.And(simd.BroadcastUint32s(0x7FFFFFFF))
 
-	isOverflow := uAbs.GreaterEqual(simd.BroadcastUint32s(0x477F8000))
+	f16MantissaMask := simd.BroadcastUint32s(0x03FF)
+
+	isOverflow := uAbs.GreaterEqual(simd.BroadcastUint32s(0x47800000))
 	isNan := uAbs.Greater(simd.BroadcastUint32s(0x7F800000))
-	nanRes := sign.Or(simd.BroadcastUint32s(0x7C00)).Or(uAbs.ShiftAllRight(13).And(simd.BroadcastUint32s(0x03FF))).Or(simd.BroadcastUint32s(1))
+	nanRes := sign.Or(simd.BroadcastUint32s(0x7C00)).Or(uAbs.ShiftAllRight(13).And(f16MantissaMask)).Or(simd.BroadcastUint32s(1))
 	infRes := sign.Or(simd.BroadcastUint32s(0x7C00))
 	overRes := selectBits(isNan, nanRes, infRes)
 
@@ -92,9 +94,18 @@ func float32sToF16Bits(f simd.Float32s) simd.Uint32s {
 	isZero := uAbs.Less(simd.BroadcastUint32s(0x33000000))
 
 	fAbs := uAbs.BitsToFloat32()
-	magicF32 := simd.BroadcastUint32s(113 << 23).BitsToFloat32()
-	fDenorm := fAbs.Add(magicF32)
-	denormMant := fDenorm.ToBits().Sub(simd.BroadcastUint32s(113 << 23)).And(simd.BroadcastUint32s(0x03FF))
+	// denormMagicBits uses biased exponent 126 (0x3F000000, value 0.5f: sign=0, exp=126, mantissa=0).
+	// Float16 denormals range from 2^-24 (SmallestNonzero) to 2^-14 with 10 mantissa bits. Float32 has 23 mantissa bits.
+	// We want the smallest float16 denormal (2^-24) to align with bit 0 (2^-23 * 2^-1 = 2^-24) of the float32 mantissa:
+	//   biased_exp = (127 - 15) [float16 normal bias] + (23 - 10) [mantissa width diff] + 1 = 126 (2^-1 = 0.5f).
+	// When fAbs is added to denormMagic:
+	//   - Hardware floating-point addition aligns fAbs to exponent -1, providing round-to-nearest-even.
+	//   - The resulting float32 has sign=0, exp=126, mantissa bits [22:10]=0, and bits [9:0] containing the 10-bit denormal mantissa.
+	// Subtracting denormMagicBits in integer arithmetic removes the float32 exponent, leaving the 10-bit denormal mantissa in bits [9:0].
+	denormMagicBits := simd.BroadcastUint32s(126 << 23)
+	denormMagic := denormMagicBits.BitsToFloat32()
+	fDenorm := fAbs.Add(denormMagic)
+	denormMant := fDenorm.ToBits().Sub(denormMagicBits).And(f16MantissaMask)
 	denormRes := selectBits(isZero, sign, sign.Or(denormMant))
 
 	bias := simd.BroadcastUint32s(0x0FFF).Add(uAbs.ShiftAllRight(13).And(simd.BroadcastUint32s(1)))

--- a/dtypes/float16/simd_test.go
+++ b/dtypes/float16/simd_test.go
@@ -18,7 +18,9 @@ func TestFloat16SIMD(t *testing.T) {
 	for x := -10.0; x <= 10.0; x += 0.25 {
 		testFloats = append(testFloats, float32(x))
 	}
-	testFloats = append(testFloats, 0, -0.0, float32(math.Inf(1)), float32(math.Inf(-1)), 1.2345, -7.891)
+	testFloats = append(testFloats, 0, -0.0, float32(math.Inf(1)), float32(math.Inf(-1)), 1.2345, -7.891,
+		SmallestNonzero.Float32(), -SmallestNonzero.Float32(),
+		FromBits(0x0002).Float32(), FromBits(0x03FF).Float32(), FromBits(0x83FF).Float32())
 	for len(testFloats)%vecLen != 0 {
 		testFloats = append(testFloats, 0)
 	}

--- a/internal/gobackend/dot/dot.go
+++ b/internal/gobackend/dot/dot.go
@@ -61,12 +61,22 @@ func (d *NodeData) SetSizes(lhsShape, rhsShape shapes.Shape) {
 	numBatchAxes := len(d.LHSBatchAxes)
 	d.BatchSize = 1
 	for i := range numBatchAxes {
-		d.BatchSize *= lhsShape.Dimensions[d.LHSBatchAxes[i]]
+		dim := lhsShape.Dimensions[d.LHSBatchAxes[i]]
+		if dim == shapes.DynamicDim {
+			d.BatchSize = shapes.DynamicDim
+			break
+		}
+		d.BatchSize *= dim
 	}
 
 	d.ContractingSize = 1
 	for _, axis := range d.LHSContractingAxes {
-		d.ContractingSize *= lhsShape.Dimensions[axis]
+		dim := lhsShape.Dimensions[axis]
+		if dim == shapes.DynamicDim {
+			d.ContractingSize = shapes.DynamicDim
+			break
+		}
+		d.ContractingSize *= dim
 	}
 
 	lhsRank := lhsShape.Rank()
@@ -78,9 +88,14 @@ func (d *NodeData) SetSizes(lhsShape, rhsShape shapes.Shape) {
 	for _, axis := range d.LHSContractingAxes {
 		isBatchOrContractingLHS[axis] = true
 	}
-	for axis := 0; axis < lhsRank; axis++ {
+	for axis := range lhsRank {
 		if !isBatchOrContractingLHS[axis] {
-			d.LHSCrossSize *= lhsShape.Dimensions[axis]
+			dim := lhsShape.Dimensions[axis]
+			if dim == shapes.DynamicDim {
+				d.LHSCrossSize = shapes.DynamicDim
+				break
+			}
+			d.LHSCrossSize *= dim
 		}
 	}
 
@@ -93,9 +108,14 @@ func (d *NodeData) SetSizes(lhsShape, rhsShape shapes.Shape) {
 	for _, axis := range d.RHSContractingAxes {
 		isBatchOrContractingRHS[axis] = true
 	}
-	for axis := 0; axis < rhsRank; axis++ {
+	for axis := range rhsRank {
 		if !isBatchOrContractingRHS[axis] {
-			d.RHSCrossSize *= rhsShape.Dimensions[axis]
+			dim := rhsShape.Dimensions[axis]
+			if dim == shapes.DynamicDim {
+				d.RHSCrossSize = shapes.DynamicDim
+				break
+			}
+			d.RHSCrossSize *= dim
 		}
 	}
 }
@@ -144,7 +164,6 @@ func (d *NodeData) Recompute(backend *gobackend.Backend, resolvedNodes []*goback
 
 	return newData, nil
 }
-
 
 // DotGeneral takes as input lhs (left-hand-side) and rhs (right-hand-side) specifications
 // for a general vector product -- a generalized "Einsum". Each axis can be:
@@ -239,32 +258,27 @@ func DotGeneral(f *gobackend.Function,
 			params.Layout, params.InputDType, params.OutputDType)
 	}
 
-	// Create dot-general node: it will generate a normalized output [batchSize, lhsCrossSize, rhsCrossSize].
-	var normalizedOutputShape shapes.Shape
-	if params.BatchSize == shapes.DynamicDim || params.LHSCrossSize == shapes.DynamicDim || params.RHSCrossSize == shapes.DynamicDim {
-		axisNames := make([]string, 3)
-		if params.BatchSize == shapes.DynamicDim {
-			axisNames[0] = findDynamicAxisName(lhs.Shape, params.LHSBatchAxes)
-		}
-		if params.LHSCrossSize == shapes.DynamicDim {
-			axisNames[1] = findDynamicCrossAxisName(lhs.Shape, params.LHSBatchAxes, params.LHSContractingAxes)
-		}
-		if params.RHSCrossSize == shapes.DynamicDim {
-			axisNames[2] = findDynamicCrossAxisName(rhs.Shape, params.RHSBatchAxes, params.RHSContractingAxes)
-		}
-		normalizedOutputShape = shapes.MakeDynamic(params.OutputDType,
-			[]int{params.BatchSize, params.LHSCrossSize, params.RHSCrossSize},
-			axisNames)
-	} else {
-		normalizedOutputShape = shapes.Make(params.OutputDType, params.BatchSize, params.LHSCrossSize, params.RHSCrossSize)
+	// Create dot-general node: it directly generates outputShape (with OutputDType).
+	//
+	// Output Shape & Row-Major Layout Invariant:
+	// Standard DotGeneral specifies output dimensions in the order:
+	//   [BatchAxes..., LHSCrossAxes..., RHSCrossAxes...]
+	// The underlying GEMM computes C[b, n, m] = sum_k A[b, n, k] * B[b, m, k] (or B[b, k, m])
+	// and writes sequentially into output.Flat in row-major order:
+	//   outer loop: batch (b)
+	//   middle loop: lhs cross (n)
+	//   inner loop: rhs cross (m)
+	// In row-major layout of any multi-dimensional tensor with shape [B..., N..., M...],
+	// the flat index b_flat * (N * M) + n_flat * M + m_flat exactly matches this GEMM output order.
+	// Therefore, the node directly outputs outputShape (preserving all original dimensions, dynamic
+	// axes, and names). No subsequent reshape (static or DynamicReshape) is needed.
+	nodeOutputShape := outputShape
+	if params.OutputDType != outputShape.DType {
+		nodeOutputShape = outputShape.Clone()
+		nodeOutputShape.DType = params.OutputDType
 	}
-	result, _ := f.GetOrCreateNode(compute.OpTypeDotGeneral, normalizedOutputShape, inputs, params)
-	if result.Shape.Equal(outputShape) {
-		// If no de-normalization is needed, return the result immediately.
-		return result, nil
-	}
+	result, _ := f.GetOrCreateNode(compute.OpTypeDotGeneral, nodeOutputShape, inputs, params)
 
-	// Reshape result to recover batch and cross dimensions.
 	if result.Shape.DType != outputShape.DType {
 		// Requires final DType conversion:
 		resultValue, err := f.ConvertDType(result, outputShape.DType)
@@ -273,55 +287,18 @@ func DotGeneral(f *gobackend.Function,
 		}
 		result = resultValue.(*gobackend.Node)
 	}
-	if !result.Shape.Equal(outputShape) {
-		// Reshape to axes that may have been merged during layout normalization.
-		if outputShape.IsDynamic() || result.Shape.IsDynamic() {
-			specs := make([]compute.DynamicDimensionSpec, outputShape.Rank())
-			for i, dim := range outputShape.Dimensions {
-				name := outputShape.AxisName(i)
-				if dim == shapes.DynamicDim {
-					var val compute.Value
-					for j, rDim := range result.Shape.Dimensions {
-						if rDim == shapes.DynamicDim && result.Shape.AxisName(j) == name && name != "" {
-							val, err = f.DynamicDimensionSize(result, j)
-							if err != nil {
-								return nil, err
-							}
-							break
-						}
-					}
-					specs[i] = compute.DynamicDimensionSpec{
-						Name:  name,
-						Value: val,
-					}
-				} else {
-					specs[i] = compute.DynamicDimensionSpec{
-						Static: dim,
-						Name:   name,
-					}
-				}
-			}
-			resultValue, err := f.DynamicReshape(result, specs...)
-			if err != nil {
-				return nil, err
-			}
-			result = resultValue.(*gobackend.Node)
-		} else {
-			resultValue, err := f.Reshape(result, outputShape.Dimensions...)
-			if err != nil {
-				return nil, err
-			}
-			result = resultValue.(*gobackend.Node)
-		}
-	}
 	return result, nil
 }
 
-// reshapeToSupportedLayout reshapes/transposes lhs and rhs to a layout
-// supported by the underlying execution backends.
+// reshapeToSupportedLayout checks if lhs and rhs already match a layout supported
+// by GEMM kernels (LayoutTransposed or LayoutNonTransposed).
+// If not, it transposes the inputs via TransposeToLayout to LayoutTransposed.
 //
-// It returns the updated lhs, rhs and params (same as the input, with fields updated).
-// The params.Layout field will be set to the supported layout.
+// Note on axis merging:
+// No reshape is performed here for non-incompatible layouts. Contiguous axes belonging to the same semantic category
+// (all batch axes, all cross axes, or all contracting axes) already have contiguous element
+// offsets in row-major memory. The GEMM kernels operate on flat slices using total combined
+// sizes (SetSizes), so preserving unmerged axes is both faster and fully compatible with dynamic dims.
 func reshapeToSupportedLayout(
 	f *gobackend.Function,
 	lhs, rhs *gobackend.Node,
@@ -335,25 +312,7 @@ func reshapeToSupportedLayout(
 		return lhs, rhs, params, nil
 	}
 
-	// First attempt to merge axes with same function:
-	lhs, params.LHSContractingAxes, params.LHSBatchAxes,
-		rhs, params.RHSContractingAxes, params.RHSBatchAxes, err = MergeAxes(
-		f, lhs, params.LHSContractingAxes, params.LHSBatchAxes,
-		rhs, params.RHSContractingAxes, params.RHSBatchAxes)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	params.Layout = LayoutForDotGeneral(lhs.Shape, params.LHSContractingAxes, params.LHSBatchAxes,
-		rhs.Shape, params.RHSContractingAxes, params.RHSBatchAxes)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if params.Layout != LayoutIncompatible {
-		// Merged axes make a supported layout.
-		return lhs, rhs, params, nil
-	}
-
-	// We need to transpose inputs to a supported layout. Since the
+	// We need to transpose inputs to a supported layout. Since
 	// LayoutTransposed is the fastest, we transpose to that.
 	targetLayout := LayoutTransposed
 	lhs, params.LHSContractingAxes, params.LHSBatchAxes,
@@ -405,6 +364,14 @@ func convertToAccumulatorDType(f *gobackend.Function, lhs, rhs *gobackend.Node, 
 }
 
 // execDotGeneral executes the DotGeneral operation.
+//
+// The output buffer is allocated with node.Shape (which is outputShape).
+// The GEMM kernels write into output.Flat in row-major order:
+//
+//	b_flat * (lhsCrossSize * rhsCrossSize) + lhsCross_flat * rhsCrossSize + rhsCross_flat
+//
+// This matches the row-major flat layout of [BatchAxes..., LHSCrossAxes..., RHSCrossAxes...] exactly,
+// so the allocated buffer immediately possesses the target N-dimensional shape without any reshape.
 func execDotGeneral(backend *gobackend.Backend, node *gobackend.Node, inputs []*gobackend.Buffer, _ []bool) (*gobackend.Buffer, error) {
 	lhs, rhs := inputs[0], inputs[1]
 	params := node.Data.(*NodeData)
@@ -427,31 +394,4 @@ func execDotGeneral(backend *gobackend.Backend, node *gobackend.Node, inputs []*
 	// Use registered implementation.
 	CallRegisteredImplementation(backend, params.implementation, lhs, rhs, output, params)
 	return output, nil
-}
-
-func findDynamicAxisName(shape shapes.Shape, axes []int) string {
-	for _, axis := range axes {
-		if shape.Dimensions[axis] == shapes.DynamicDim {
-			return shape.AxisName(axis)
-		}
-	}
-	return ""
-}
-
-func findDynamicCrossAxisName(shape shapes.Shape, batchAxes, contractingAxes []int) string {
-	isSpecial := make([]bool, shape.Rank())
-	for _, axis := range batchAxes {
-		isSpecial[axis] = true
-	}
-	for _, axis := range contractingAxes {
-		isSpecial[axis] = true
-	}
-	for axis := 0; axis < shape.Rank(); axis++ {
-		if !isSpecial[axis] {
-			if shape.Dimensions[axis] == shapes.DynamicDim {
-				return shape.AxisName(axis)
-			}
-		}
-	}
-	return ""
 }

--- a/internal/gobackend/dot/dot_test.go
+++ b/internal/gobackend/dot/dot_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/gomlx/compute"
+	"github.com/gomlx/compute/dtypes"
 	"github.com/gomlx/compute/internal/gobackend"
 	_ "github.com/gomlx/compute/internal/gobackend/defaultpkgs"
 	"github.com/gomlx/compute/internal/must"
+	"github.com/gomlx/compute/shapes"
 	"github.com/gomlx/compute/support/testutil"
 	"k8s.io/klog/v2"
 )
@@ -61,5 +63,56 @@ func TestDotGeneral(t *testing.T) {
 	}
 	if ok, diff := testutil.IsEqual(want, y1); !ok {
 		t.Fatalf("Unexpected result (-want +got):\n%s", diff)
+	}
+}
+
+func TestDotGeneralDynamic(t *testing.T) {
+	if _, ok := backend.(*gobackend.Backend); !ok {
+		t.Skip("Skipping test because backend is not the Go backend")
+	}
+
+	// Dynamic test simulating attention score Einsum: [batch, heads, seq, dim] x [batch, heads, seq, dim] -> [batch, heads, seq, seq]
+	// Batch axes: [0, 1] (batch is dynamic, heads is static 2).
+	// Contracting axis: [3] (dim is 4).
+	// Cross axis: [2] (seq is dynamic).
+	builder := backend.Builder("TestDotGeneralDynamic")
+	mainFn := builder.Main()
+	sLHS := shapes.MakeDynamic(dtypes.Float32, []int{shapes.DynamicDim, 2, shapes.DynamicDim, 4}, []string{"batch", "", "seq", ""})
+	sRHS := shapes.MakeDynamic(dtypes.Float32, []int{shapes.DynamicDim, 2, shapes.DynamicDim, 4}, []string{"batch", "", "seq", ""})
+	lhsParam, err := mainFn.Parameter("lhs", sLHS, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rhsParam, err := mainFn.Parameter("rhs", sRHS, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dotNode, err := mainFn.DotGeneral(lhsParam, []int{3}, []int{0, 1}, rhsParam, []int{3}, []int{0, 1}, compute.DotGeneralConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = mainFn.Return([]compute.Value{dotNode}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exec, err := builder.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Concrete shapes: batch=3, heads=2, seq=5, dim=4
+	concreteShape := shapes.Make(dtypes.Float32, 3, 2, 5, 4)
+	lhsBuf, _ := backend.BufferFromFlatData(0, make([]float32, concreteShape.Size()), concreteShape)
+	rhsBuf, _ := backend.BufferFromFlatData(0, make([]float32, concreteShape.Size()), concreteShape)
+	outputs, err := exec.Execute([]compute.Buffer{lhsBuf, rhsBuf}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outShape, err := outputs[0].Shape()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := outShape.Check(dtypes.Float32, 3, 2, 5, 5); err != nil {
+		t.Fatalf("unexpected output shape: %v", err)
 	}
 }

--- a/internal/gobackend/dot/layout.go
+++ b/internal/gobackend/dot/layout.go
@@ -32,18 +32,28 @@ const (
 
 // LayoutForDotGeneral returns the layout for DotGeneral given the shapes of the
 // inputs and the axes to contract and batch over.
+//
+// Memory Layout Expectations:
+// The underlying GEMM implementations (CallRegisteredImplementation) operate on flat 1D
+// memory buffers. In row-major memory order, adjacent dimensions of the same semantic
+// type (batch, cross, or contracting) have linear strides identical to their scalar product.
+// Therefore, tensors with any rank can be executed directly by the GEMM kernels as long as:
+//   - All batch axes are leading and sequential: [0, 1, ..., numBatchAxes-1] on both LHS and RHS.
+//   - Contracting axes match in count and are contiguous in memory.
+//   - For LHS: contracting axes are trailing: [B..., N..., K...].
+//   - For RHS LayoutTransposed: contracting axes are trailing: [B..., M..., K...].
+//   - For RHS LayoutNonTransposed: contracting axes immediately follow batch axes: [B..., K..., M...].
+//
+// No reshape or axis merging is required when these conditions are met.
 func LayoutForDotGeneral(lhsShape shapes.Shape, lhsContractingAxes, lhsBatchAxes []int,
 	rhsShape shapes.Shape, rhsContractingAxes, rhsBatchAxes []int) Layout {
-	// Require exactly one contracting axis.
-	if len(lhsContractingAxes) != 1 || len(rhsContractingAxes) != 1 {
+	numContractingAxes := len(lhsContractingAxes)
+	if numContractingAxes == 0 || len(rhsContractingAxes) != numContractingAxes {
 		return LayoutIncompatible
 	}
 
-	// Batch axes must match in count, must be 0 or 1, and must be leading and sequential (0, 1, 2, ...).
+	// Batch axes must match in count, and must be leading and sequential (0, 1, 2, ...).
 	numBatchAxes := len(lhsBatchAxes)
-	if numBatchAxes > 1 {
-		return LayoutIncompatible
-	}
 	if len(rhsBatchAxes) != numBatchAxes {
 		return LayoutIncompatible
 	}
@@ -56,18 +66,34 @@ func LayoutForDotGeneral(lhsShape shapes.Shape, lhsContractingAxes, lhsBatchAxes
 	lhsRank := lhsShape.Rank()
 	rhsRank := rhsShape.Rank()
 
-	// LHS contracting axis must be the last axis: [B..., N, K]
-	if lhsContractingAxes[0] != lhsRank-1 {
-		return LayoutIncompatible
+	// LHS contracting axes must be trailing and sequential: [B..., N..., K...]
+	for i := range numContractingAxes {
+		if lhsContractingAxes[i] != lhsRank-numContractingAxes+i {
+			return LayoutIncompatible
+		}
 	}
 
-	// For LayoutNonTransposed (MatMul): RHS contracting axis is first after batch axes [B..., K, M]
-	if rhsContractingAxes[0] == numBatchAxes {
+	// Check if RHS contracting axes are leading after batch axes [B..., K..., M...] -> LayoutNonTransposed
+	isNonTransposed := true
+	for i := range numContractingAxes {
+		if rhsContractingAxes[i] != numBatchAxes+i {
+			isNonTransposed = false
+			break
+		}
+	}
+	if isNonTransposed {
 		return LayoutNonTransposed
 	}
 
-	// For LayoutTransposed (Normal-Transposed): RHS contracting axis is last [B..., M, K]
-	if rhsContractingAxes[0] == rhsRank-1 {
+	// Check if RHS contracting axes are trailing [B..., M..., K...] -> LayoutTransposed
+	isTransposed := true
+	for i := range numContractingAxes {
+		if rhsContractingAxes[i] != rhsRank-numContractingAxes+i {
+			isTransposed = false
+			break
+		}
+	}
+	if isTransposed {
 		return LayoutTransposed
 	}
 
@@ -100,189 +126,6 @@ func getAxisInfo(axis int, batchAxes, contractingAxes []int) axisInfo {
 		}
 	}
 	return axisInfo{AxisTypeCross, -1}
-}
-
-// MergeAxes checks if adjacent axes in lhs and rhs are used for the same purpose
-// (batch, contracting or cross), and if so, merges them by reshaping.
-// This simplifies the shape of the tensors, making it more likely that the
-// operation can be matched to a fast execution path (like SmallMatMul or Packgemm).
-//
-// It returns the reshaped lhs and rhs, the new contracting and batch axes.
-func MergeAxes(f *gobackend.Function,
-	lhs *gobackend.Node, lhsContractingAxes, lhsBatchAxes []int,
-	rhs *gobackend.Node, rhsContractingAxes, rhsBatchAxes []int) (
-	newLhs *gobackend.Node, newLhsContractingAxes, newLhsBatchAxes []int,
-	newRhs *gobackend.Node, newRhsContractingAxes, newRhsBatchAxes []int,
-	err error) {
-
-	lhsRank := lhs.Shape.Rank()
-	rhsRank := rhs.Shape.Rank()
-
-	// 1. Group adjacent mergable axes in LHS
-	var lhsGroups [][]int
-	if lhsRank > 0 {
-		currentGroup := []int{0}
-		for i := 1; i < lhsRank; i++ {
-			prev := currentGroup[len(currentGroup)-1]
-			infoPrev := getAxisInfo(prev, lhsBatchAxes, lhsContractingAxes)
-			infoCurr := getAxisInfo(i, lhsBatchAxes, lhsContractingAxes)
-
-			canMerge := false
-			if infoPrev.typ == infoCurr.typ {
-				switch infoPrev.typ {
-				case AxisTypeCross:
-					canMerge = true
-				case AxisTypeBatch:
-					// Batch axes must be adjacent in the axes list and in correct order.
-					if infoCurr.idx == infoPrev.idx+1 {
-						rhsPrev := rhsBatchAxes[infoPrev.idx]
-						rhsCurr := rhsBatchAxes[infoCurr.idx]
-						// The corresponding RHS axes must be physically adjacent and in order.
-						if rhsCurr == rhsPrev+1 {
-							canMerge = true
-						}
-					}
-				case AxisTypeContracting:
-					// Contracting axes must map to adjacent physical axes in RHS.
-					rhsPrev := rhsContractingAxes[infoPrev.idx]
-					rhsCurr := rhsContractingAxes[infoCurr.idx]
-					if rhsCurr == rhsPrev+1 {
-						canMerge = true
-					}
-				}
-			}
-
-			if canMerge {
-				currentGroup = append(currentGroup, i)
-			} else {
-				lhsGroups = append(lhsGroups, currentGroup)
-				currentGroup = []int{i}
-			}
-		}
-		if len(currentGroup) > 0 {
-			lhsGroups = append(lhsGroups, currentGroup)
-		}
-	}
-
-	// 2. Group adjacent mergable axes in RHS
-	var rhsGroups [][]int
-	if rhsRank > 0 {
-		currentGroup := []int{0}
-		for j := 1; j < rhsRank; j++ {
-			prev := currentGroup[len(currentGroup)-1]
-			infoPrev := getAxisInfo(prev, rhsBatchAxes, rhsContractingAxes)
-			infoCurr := getAxisInfo(j, rhsBatchAxes, rhsContractingAxes)
-
-			canMerge := false
-			if infoPrev.typ == infoCurr.typ {
-				switch infoPrev.typ {
-				case AxisTypeCross:
-					canMerge = true
-				case AxisTypeBatch:
-					// Check if LHS merged them
-					if infoCurr.idx == infoPrev.idx+1 {
-						lhsPrev := lhsBatchAxes[infoPrev.idx]
-						lhsCurr := lhsBatchAxes[infoCurr.idx]
-						if lhsCurr == lhsPrev+1 {
-							canMerge = true
-						}
-					}
-				case AxisTypeContracting:
-					// Check if LHS merged them
-					lhsPrev := lhsContractingAxes[infoPrev.idx]
-					lhsCurr := lhsContractingAxes[infoCurr.idx]
-					if lhsCurr == lhsPrev+1 {
-						canMerge = true
-					}
-				}
-			}
-
-			if canMerge {
-				currentGroup = append(currentGroup, j)
-			} else {
-				rhsGroups = append(rhsGroups, currentGroup)
-				currentGroup = []int{j}
-			}
-		}
-		if len(currentGroup) > 0 {
-			rhsGroups = append(rhsGroups, currentGroup)
-		}
-	}
-
-	// Calculate new shapes
-	newLhsDims := make([]int, len(lhsGroups))
-	lhsOldToNew := make([]int, lhsRank)
-	for newAxis, group := range lhsGroups {
-		size := 1
-		for _, oldAxis := range group {
-			size *= lhs.Shape.Dimensions[oldAxis]
-			lhsOldToNew[oldAxis] = newAxis
-		}
-		newLhsDims[newAxis] = size
-	}
-
-	newRhsDims := make([]int, len(rhsGroups))
-	rhsOldToNew := make([]int, rhsRank)
-	for newAxis, group := range rhsGroups {
-		size := 1
-		for _, oldAxis := range group {
-			size *= rhs.Shape.Dimensions[oldAxis]
-			rhsOldToNew[oldAxis] = newAxis
-		}
-		newRhsDims[newAxis] = size
-	}
-
-	// Reshape nodes if needed
-	newLhs = lhs
-	if len(newLhsDims) != lhsRank {
-		reshaped, err := f.Reshape(lhs, newLhsDims...)
-		if err != nil {
-			return nil, nil, nil, nil, nil, nil, err
-		}
-		newLhs = reshaped.(*gobackend.Node)
-	}
-
-	newRhs = rhs
-	if len(newRhsDims) != rhsRank {
-		reshaped, err := f.Reshape(rhs, newRhsDims...)
-		if err != nil {
-			return nil, nil, nil, nil, nil, nil, err
-		}
-		newRhs = reshaped.(*gobackend.Node)
-	}
-
-	// Generate new batch and contracting axes mapping
-	newLhsBatchAxes = make([]int, 0)
-	for _, oldAxis := range lhsBatchAxes {
-		newAxis := lhsOldToNew[oldAxis]
-		if len(newLhsBatchAxes) == 0 || newLhsBatchAxes[len(newLhsBatchAxes)-1] != newAxis {
-			newLhsBatchAxes = append(newLhsBatchAxes, newAxis)
-		}
-	}
-
-	newRhsBatchAxes = make([]int, 0)
-	for _, oldAxis := range rhsBatchAxes {
-		newAxis := rhsOldToNew[oldAxis]
-		if len(newRhsBatchAxes) == 0 || newRhsBatchAxes[len(newRhsBatchAxes)-1] != newAxis {
-			newRhsBatchAxes = append(newRhsBatchAxes, newAxis)
-		}
-	}
-
-	newLhsContractingAxes = make([]int, 0)
-	newRhsContractingAxes = make([]int, 0)
-	seenLhsContracting := make(map[int]bool)
-	for i := range lhsContractingAxes {
-		newLhsAxis := lhsOldToNew[lhsContractingAxes[i]]
-		newRhsAxis := rhsOldToNew[rhsContractingAxes[i]]
-		if !seenLhsContracting[newLhsAxis] {
-			seenLhsContracting[newLhsAxis] = true
-			newLhsContractingAxes = append(newLhsContractingAxes, newLhsAxis)
-			newRhsContractingAxes = append(newRhsContractingAxes, newRhsAxis)
-		}
-	}
-
-	return newLhs, newLhsContractingAxes, newLhsBatchAxes,
-		newRhs, newRhsContractingAxes, newRhsBatchAxes, nil
 }
 
 // transposeSide is a helper to transpose one side to a specific ordering of (batch, cross, contracting).
@@ -360,9 +203,18 @@ func transposeSide(f *gobackend.Function, node *gobackend.Node, contractingAxes,
 	return newNode, newContractingAxes, newBatchAxes, nil
 }
 
-// TransposeToLayout attempts to transpose the axes of lhs and rhs to match a the given layout: LayoutTransposed or LayoutNonTranposed.
+// TransposeToLayout transposes the axes of lhs and rhs so that their semantic groups
+// (batch, cross, and contracting axes) form contiguous blocks matching the target layout:
+//   - LHS: [Batch..., Cross..., Contracting...] (LayoutTransposed)
+//   - RHS: [Batch..., Cross..., Contracting...] (LayoutTransposed) or [Batch..., Contracting..., Cross...] (LayoutNonTransposed)
 //
-// Consider running MergeAxes first, it will make the transposing faster.
+// Memory Layout Invariant:
+// In row-major format, any sequence of contiguous dimensions of the same semantic category
+// (e.g. B0, B1 or N0, N1, N2 or K0, K1) has flat memory offsets that are identical to a single
+// collapsed dimension with size equal to their product. The GEMM implementation operates directly
+// on the flat data slices using the total combined sizes (batchSize, crossSize, contractingSize).
+// Therefore, no physical or logical MergeAxes reshape is needed; keeping the original (unmerged)
+// dimensions avoids reshape overhead and seamlessly supports dynamic dimensions.
 func TransposeToLayout(f *gobackend.Function,
 	lhs *gobackend.Node, lhsContractingAxes, lhsBatchAxes []int,
 	rhs *gobackend.Node, rhsContractingAxes, rhsBatchAxes []int,
@@ -377,15 +229,6 @@ func TransposeToLayout(f *gobackend.Function,
 	}
 
 	newRhs, newRhsContractingAxes, newRhsBatchAxes, err = transposeSide(f, rhs, rhsContractingAxes, rhsBatchAxes, layout)
-	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
-	}
-
-	// Merge axes
-	newLhs, newLhsContractingAxes, newLhsBatchAxes,
-		newRhs, newRhsContractingAxes, newRhsBatchAxes, err = MergeAxes(
-		f, newLhs, newLhsContractingAxes, newLhsBatchAxes,
-		newRhs, newRhsContractingAxes, newRhsBatchAxes)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}

--- a/internal/gobackend/dot/layout_test.go
+++ b/internal/gobackend/dot/layout_test.go
@@ -38,8 +38,8 @@ func TestTransposeToLayout(t *testing.T) {
 			rhsContract:     []int{2},
 			rhsBatch:        []int{0},
 			layout:          dot.LayoutTransposed,
-			wantLhsDims:     []int{2, 12, 5}, // Batch=2, Cross=3*4=12, Contracting=5
-			wantLhsContract: []int{2},
+			wantLhsDims:     []int{2, 3, 4, 5}, // Batch=2, Cross=(3,4) unmerged, Contracting=5
+			wantLhsContract: []int{3},
 			wantLhsBatch:    []int{0},
 			wantRhsDims:     []int{2, 6, 5},
 			wantRhsContract: []int{2},
@@ -54,8 +54,8 @@ func TestTransposeToLayout(t *testing.T) {
 			rhsContract:     []int{2},
 			rhsBatch:        []int{0},
 			layout:          dot.LayoutNonTransposed,
-			wantLhsDims:     []int{2, 12, 5}, // Batch=2, Cross=3*4=12, Contracting=5
-			wantLhsContract: []int{2},
+			wantLhsDims:     []int{2, 3, 4, 5}, // Batch=2, Cross=(3,4) unmerged, Contracting=5
+			wantLhsContract: []int{3},
 			wantLhsBatch:    []int{0},
 			wantRhsDims:     []int{2, 5, 6}, // LayoutNonTransposed for RHS -> [Batch, Contracting, Cross] -> [2, 5, 6]
 			wantRhsContract: []int{1},
@@ -70,12 +70,28 @@ func TestTransposeToLayout(t *testing.T) {
 			rhsContract:     []int{0},
 			rhsBatch:        []int{1},
 			layout:          dot.LayoutNonTransposed,
-			wantLhsDims:     []int{2, 12, 5}, // Batch=2, Cross=4*3=12, Contracting=5
-			wantLhsContract: []int{2},
+			wantLhsDims:     []int{2, 4, 3, 5}, // Batch=2, Cross=(4,3) unmerged, Contracting=5
+			wantLhsContract: []int{3},
 			wantLhsBatch:    []int{0},
 			wantRhsDims:     []int{2, 5, 6}, // Batch=2, Contracting=5, Cross=6
 			wantRhsContract: []int{1},
 			wantRhsBatch:    []int{0},
+		},
+		{
+			name:            "Multiple batch and contracting axes",
+			lhsShape:        shapes.Make(dtypes.Float32, 2, 3, 4, 5, 6), // Batch=(2,3), Cross=4, Contracting=(5,6)
+			lhsContract:     []int{3, 4},
+			lhsBatch:        []int{0, 1},
+			rhsShape:        shapes.Make(dtypes.Float32, 2, 3, 7, 5, 6), // Batch=(2,3), Cross=7, Contracting=(5,6)
+			rhsContract:     []int{3, 4},
+			rhsBatch:        []int{0, 1},
+			layout:          dot.LayoutTransposed,
+			wantLhsDims:     []int{2, 3, 4, 5, 6},
+			wantLhsContract: []int{3, 4},
+			wantLhsBatch:    []int{0, 1},
+			wantRhsDims:     []int{2, 3, 7, 5, 6},
+			wantRhsContract: []int{3, 4},
+			wantRhsBatch:    []int{0, 1},
 		},
 	}
 

--- a/internal/gobackend/ops/pad.go
+++ b/internal/gobackend/ops/pad.go
@@ -222,7 +222,7 @@ func padWithConcreteConfig(backend *gobackend.Backend, operand, fillValue *gobac
 		}
 	}
 
-	if len(operandBytes) == 0 {
+	if len(outputBytes) == 0 || len(operandBytes) == 0 {
 		return output, nil // Nothing to copy
 	}
 
@@ -299,15 +299,42 @@ func padWithConcreteConfig(backend *gobackend.Backend, operand, fillValue *gobac
 		}
 
 		mAxis := mergedAxes[axis]
+		step := 1 + mAxis.config.Interior
+
+		// Determine valid range [startI, endI) of operand indices
+		// such that 0 <= outIdx < mAxis.outputDim,
+		// where outIdx = mAxis.config.Start + i * step.
+		minI := 0
+		if -mAxis.config.Start > 0 {
+			minI = (-mAxis.config.Start + step - 1) / step
+		}
+		maxI := 0
+		if mAxis.outputDim-mAxis.config.Start > 0 {
+			maxI = (mAxis.outputDim - mAxis.config.Start - 1) / step + 1
+		}
+		startI := max(0, minI)
+		endI := min(mAxis.operandDim, maxI)
+		if startI >= endI {
+			return
+		}
+
 		outStride := outputStrides[axis]
+		outOffset := outputOffset + (mAxis.config.Start+startI*step)*outStride
+		opOffset := operandOffset + startI*operandStrides[axis]
 
-		outOffset := outputOffset + mAxis.config.Start*outStride
-		opOffset := operandOffset
+		if axis == numMerged-1 && mAxis.config.Interior == 0 {
+			count := endI - startI
+			copy(outputBytes[outOffset:outOffset+count*virtualElementSize],
+				operandBytes[opOffset:opOffset+count*virtualElementSize])
+			return
+		}
 
-		for i := 0; i < mAxis.operandDim; i++ {
+		outStep := outStride * step
+		opStep := operandStrides[axis]
+		for i := startI; i < endI; i++ {
 			copyND(axis+1, opOffset, outOffset)
-			opOffset += operandStrides[axis]
-			outOffset += outStride * (1 + mAxis.config.Interior)
+			opOffset += opStep
+			outOffset += outStep
 		}
 	}
 

--- a/internal/gobackend/ops/pad_test.go
+++ b/internal/gobackend/ops/pad_test.go
@@ -1,0 +1,106 @@
+// Copyright 2023-2026 The GoMLX Authors. SPDX-License-Identifier: Apache-2.0
+
+package ops_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/gomlx/compute"
+	"github.com/gomlx/compute/dtypes"
+	"github.com/gomlx/compute/shapes"
+)
+
+func TestPadNegative(t *testing.T) {
+	// Test Pad with negative start and end padding (cropping)
+	builder := backend.Builder("test_pad_negative")
+	mainFn := builder.Main()
+	xParam, err := mainFn.Parameter("x", shapes.Make(dtypes.Float32, 5), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fillVal, err := mainFn.Constant([]float32{0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	padded, err := mainFn.Pad(xParam, fillVal, compute.PadAxis{Start: -1, End: -1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mainFn.Return([]compute.Value{padded}, nil); err != nil {
+		t.Fatal(err)
+	}
+	exec, err := builder.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputBuf := makeBuffer(t, shapes.Make(dtypes.Float32, 5), []float32{10, 20, 30, 40, 50})
+	outBufs, err := exec.Execute([]compute.Buffer{inputBuf}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]float32, 3)
+	if err := outBufs[0].ToFlatData(got); err != nil {
+		t.Fatal(err)
+	}
+	want := []float32{20, 30, 40}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPadNegativeAndPositive2D(t *testing.T) {
+	// Test Pad 2D with negative start and positive end on axis 0, positive start and negative end on axis 1.
+	builder := backend.Builder("test_pad_2d")
+	mainFn := builder.Main()
+	xParam, err := mainFn.Parameter("x", shapes.Make(dtypes.Int32, 3, 3), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fillVal, err := mainFn.Constant([]int32{99})
+	if err != nil {
+		t.Fatal(err)
+	}
+	padded, err := mainFn.Pad(xParam, fillVal,
+		compute.PadAxis{Start: -1, End: 1}, // dim 0: 3 -> -1 + 1 = 3 (rows 1, 2, fill)
+		compute.PadAxis{Start: 1, End: -1}, // dim 1: 3 -> +1 - 1 = 3 (fill, col 0, col 1)
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mainFn.Return([]compute.Value{padded}, nil); err != nil {
+		t.Fatal(err)
+	}
+	exec, err := builder.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputBuf := makeBuffer(t, shapes.Make(dtypes.Int32, 3, 3), []int32{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+	})
+	outBufs, err := exec.Execute([]compute.Buffer{inputBuf}, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]int32, 9)
+	if err := outBufs[0].ToFlatData(got); err != nil {
+		t.Fatal(err)
+	}
+	// Original rows:
+	// row 0: 1 2 3 (skipped due to Start: -1)
+	// row 1: 4 5 6 -> with axis 1 pad (Start: 1, End: -1): [99, 4, 5]
+	// row 2: 7 8 9 -> with axis 1 pad (Start: 1, End: -1): [99, 7, 8]
+	// row 3: fill -> [99, 99, 99]
+	want := []int32{
+		99, 4, 5,
+		99, 7, 8,
+		99, 99, 99,
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses three fixes across the pure Go backend and float16 data type implementations:

### 1. Simplified and Fixed `DotGeneral` for Dynamic Shapes
- **Eliminated unnecessary reshaping**: Removed `MergeAxes` calls in `reshapeToSupportedLayout` and `TransposeToLayout`. Contiguous row-major axis groups naturally match GEMM strides, eliminating unnecessary reshape overhead and cleanly supporting multi-batch or multi-contracting dynamic dimensions.
- **Dynamic shape support**: Updated `LayoutForDotGeneral` to accept multiple leading batch axes and sequential trailing contracting axes without merging.
- **Direct node construction**: Simplified `DotGeneral` to directly construct the node with the target `outputShape`, removing redundant intermediate 3D normalized shape allocations and reshapes.
- **Layout documentation**: Documented flat row-major layout invariants across `LayoutForDotGeneral`, `TransposeToLayout`, `reshapeToSupportedLayout`, `DotGeneral`, and `execDotGeneral`.
- **Tests**: Added unit test `TestDotGeneralDynamic` in `internal/gobackend/dot/dot_test.go` verifying multi-batch dynamic attention score dot products, along with multi-axis layout tests in `internal/gobackend/dot/layout_test.go`.

### 2. Fixed `Pad` Boundary and Clipping Handling
- **Negative padding bounds**: Fixed `padWithConcreteConfig` in `internal/gobackend/ops/pad.go` to compute the valid operand index range `[startI, endI)` when handling negative start/end padding (cropping) and interior padding step so that `0 <= outIdx < outputDim`.
- **Empty buffer safety**: Handled cases where `outputBytes` is empty (`len(outputBytes) == 0`).
- **Inner contiguous copy**: Accelerated the innermost contiguous dimension copy using `copy` when interior padding is 0.
- **Tests**: Added tests for negative 1D padding and mixed negative/positive 2D padding in `internal/gobackend/ops/pad_test.go`.

### 3. Fixed `Float32` -> `Float16` Conversion for Overflowing Values
- **Overflow & NaN handling**: Corrected the overflow check threshold in `FromFloat32` (`dtypes/float16/float16.go`) and SIMD conversion (`dtypes/float16/simd.go`) to `uAbs >= 0x47800000` (65536.0f) to properly map overflowing numbers to infinity while preserving NaN payload bits.
- **Denormal/subnormal rounding**: Replaced manual bit shifts with floating-point magic addition (`denormMagicBits = 126 << 23`), ensuring standard round-to-nearest-even behavior down to `SmallestNonzero`.
- **Tests**: Added scalar and SIMD subnormal roundtrip unit tests in `dtypes/float16/float16_test.go` and `dtypes/float16/simd_test.go`.